### PR TITLE
The SLM is unreliable, so favor Faraday cup for the livetime.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -42,6 +42,7 @@ Nathan Baltzell <baltzell@jlab.org> <baltzell@lappi4.home>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@LappiAir2.home>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@gmx.com>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@llama.jlab.org>
+Nathan Baltzell <baltzell@jlab.org> <baltzell@baltzellmac.jlab.org>
 Nathan Harrison <nathanh@jlab.org> <nathan.andrew.harrison@gmail.com>
 Nathan Harrison <nathanh@jlab.org> <harrison@Nathans-MacBook-Air.local>
 Nick Markov <markovnick@gmail.com>

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -98,8 +98,8 @@ public class Dsc2Scaler extends DaqScaler{
      * @param seconds 
      */
     protected final void calibrate(IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-        if (this.slm>0) {
-            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedSlm)/this.slm);
+        if (this.fcup>0) {
+            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedFcup)/this.fcup);
         }
     }
 }


### PR DESCRIPTION
This is a stopgap before correctly using the clock (for run periods where it doesn't rollover).  The downside is that the offset of the Faraday cup is much larger than the SLM in previous years, so there's a systematic error hit there, but that's irrelevant when the SLM is misbehaving.  Ultimately, using the clock, which currently requires going back to EVIO, will bring everything to sanity.