### PR TITLE
Use CCDB to determine whether the clock is good, and, if so, use it instead of RCDB's run start time

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -42,6 +42,7 @@ Nathan Baltzell <baltzell@jlab.org> <baltzell@lappi4.home>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@LappiAir2.home>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@gmx.com>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@llama.jlab.org>
+Nathan Baltzell <baltzell@jlab.org> <baltzell@baltzellmac.jlab.org>
 Nathan Harrison <nathanh@jlab.org> <nathan.andrew.harrison@gmail.com>
 Nathan Harrison <nathanh@jlab.org> <harrison@Nathans-MacBook-Air.local>
 Nick Markov <markovnick@gmail.com>

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -13,7 +13,3 @@ if [ -z "$COAT_MAGFIELD_SOLENOIDMAP" ]; then
     export COAT_MAGFIELD_SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 fi
 
-echo +-------------------------------------------------------------------------
-echo "| COATJAVA LIBRARY DIRECTORY = " $CLAS12DIR/lib/clas/
-echo +-------------------------------------------------------------------------
-

--- a/bin/hipo-diff
+++ b/bin/hipo-diff
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+. `dirname $0`/env.sh 
+
+export MALLOC_ARENA_MAX=1
+
+java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+    -cp "$CLAS12DIR/lib/clas/*:$CLAS12DIR/lib/services/*:$CLAS12DIR/lib/utils/*" \
+    org.jlab.utils.HipoDiff \
+    $*

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -620,7 +620,7 @@ public class CLASDecoder4 {
                 getConstants(this.detectorDecoder.getRunNumber(),"/daq/config/scalers/dsc1");
 
         // if the scaler clock is slow enough, use it for the offset correction:
-        if (dscTable.getIntValue("frequency", 0,0,0) <= 1.2e5) {
+        if (dscTable.getIntValue("frequency", 0,0,0) < 2e5) {
             ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,dscTable));
         }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -621,7 +621,7 @@ public class CLASDecoder4 {
 
         // if the scaler clock is slow enough, use it for the offset correction:
         if (dscTable.getIntValue("frequency", 0,0,0) <= 1.2e5) {
-            ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable));
+            ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,dscTable));
         }
 
         // otherwise use RCDB's run start time: 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -4,8 +4,6 @@ import org.jlab.detector.scalers.DaqScalers;
 import java.util.ArrayList;
 import java.util.List;
 
-import java.sql.Time;
-import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.jlab.detector.base.DetectorDescriptor;
@@ -577,73 +575,20 @@ public class CLASDecoder4 {
     }
 
     /**
-     * create the RUN::scaler bank
-     *
+     * Create the RUN::scaler and HEL::scaler banks
      * Requires:
-     *   RAW::scaler
-     *   event unix time from RUN::config
-     *   fcup calibrations from CCDB
-     *   run start time from RCDB
-     * Otherwise returns null
-     *
-     * FIXME:  refactor this out more cleanly
+     *   - RAW::scaler
+     *   - fcup/slm/hel/dsc calibrations from CCDB
+     *   - event unix time from RUN::config and run start time from RCDB,
+     *     or a good clock frequency from CCDB
      * @param event
      * @return 
      */
     public List<Bank> createReconScalerBanks(Event event){
-
-        List<Bank> ret = new ArrayList<>();
-
-        // abort if run number corresponds to simulation:
-        if (this.detectorDecoder.getRunNumber() < 1000) return ret;
-
-        // abort if we don't know about the required banks:
-        if(schemaFactory.hasSchema("RUN::config")==false) return ret;
-        if(schemaFactory.hasSchema("RAW::scaler")==false) return ret;
-        if(schemaFactory.hasSchema("RUN::scaler")==false) return ret;
-
-        // retrieve necessary input banks, else abort:
-        Bank configBank = new Bank(schemaFactory.getSchema("RUN::config"),1);
-        Bank rawScalerBank = new Bank(schemaFactory.getSchema("RAW::scaler"),1);
-        event.read(configBank);
-        event.read(rawScalerBank);
-        if (configBank.getRows()<1 || rawScalerBank.getRows()<1) return ret;
-
-        // retrieve fcup/slm calibrations from slm:
-        IndexedTable fcupTable = this.detectorDecoder.scalerManager.
-                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/fcup");
-        IndexedTable slmTable = this.detectorDecoder.scalerManager.
-                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/slm");
-        IndexedTable helTable = this.detectorDecoder.scalerManager.
-                getConstants(this.detectorDecoder.getRunNumber(),"/runcontrol/helicity");
-        IndexedTable dscTable = this.detectorDecoder.scalerManager.
-                getConstants(this.detectorDecoder.getRunNumber(),"/daq/config/scalers/dsc1");
-
-        // if the scaler clock is slow enough, use it for the offset correction:
-        if (dscTable.getIntValue("frequency", 0,0,0) < 2e5) {
-            ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,dscTable));
-        }
-
-        // otherwise use RCDB's run start time: 
-        else {
-            // get unix event time (in seconds), and convert to Java's date (via milliseconds):
-            Date uet=new Date(configBank.getInt("unixtime",0)*1000L);
-
-            // retrieve RCDB run start time:
-            Time rst;
-            try {
-                rst = (Time)this.detectorDecoder.scalerManager.
-                    getRcdbConstant(this.detectorDecoder.getRunNumber(),"run_start_time").getValue();
-            }
-            catch (Exception e) {
-                // abort if no RCDB access (e.g. offsite)
-                return ret;
-            }
-            ret.addAll(DaqScalers.createBanks(schemaFactory,rawScalerBank,fcupTable,slmTable,helTable,rst,uet));
-        }
-        return ret;
+        return DaqScalers.createBanks(detectorDecoder.getRunNumber(),
+                schemaFactory, event, detectorDecoder.scalerManager);
     }
-    
+
     public Bank createBonusBank(){
         if(schemaFactory.hasSchema("RTPC::adc")==false) return null;
         List<DetectorDataDgtz> bonusData = this.getEntriesADC(DetectorType.RTPC);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -1095,6 +1095,7 @@ public class CodaEventDecoder {
                     int[] intData =  ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
                     for(int loop = 2; loop < intData.length; loop++){
                         int  dataEntry = intData[loop];
+                        // Struck Scaler:
                         if(node.getTag()==57637) {
                             int helicity = DataUtils.getInteger(dataEntry, 31, 31);
                             int quartet  = DataUtils.getInteger(dataEntry, 30, 30);
@@ -1111,15 +1112,48 @@ public class CodaEventDecoder {
                                 scalerEntries.add(entry);
                             }
                         }
+                        // DSC2 Scaler:
+                        // FIXME:  There's serious channel number mangling here
+                        // and inherited in org.jlab.detector.scalers.Dsc2Scaler,
+                        // all scaler words should be decoded but aren't, and the
+                        // preserved slot number is an arbitrary number from Sergey
+                        // and the same for all DSC2s in the crate, instead of being
+                        // parsed from the header or assigned manually based on
+                        // the data length.
                         else if(node.getTag()==57621 && loop>=5) {
-                            int id   = (loop-5)%16;
-                            int slot = (loop-5)/16;
-                            if(id<3 && slot<4) {
-                                DetectorDataDgtz entry = new DetectorDataDgtz(crate,num,loop-5);
-                                SCALERData scaler = new SCALERData();
-                                scaler.setValue(DataUtils.getLongFromInt(dataEntry));
-                                entry.addSCALER(scaler);
-                                scalerEntries.add(entry);
+
+                            final int dataWordIndex = loop-5;
+                            final int nChannels = 16;
+                            final int type = dataWordIndex / nChannels;
+
+                            // "type" is TRG-/TDC-gated/TRG-/TDC-ungated = 0/1/2/3 
+                            if (type < 4) {
+                                final int channel = dataWordIndex % nChannels;
+                                // The first two channels are the Faraday Cup and SLM:
+                                // (the third channel is a 1 MHz input clock, which we
+                                // now ignore in favor of the scaler's internal clock below)
+                                if (channel<2) {
+                                    DetectorDataDgtz entry = new DetectorDataDgtz(crate,num,dataWordIndex);
+                                    SCALERData scaler = new SCALERData();
+                                    scaler.setValue(DataUtils.getLongFromInt(dataEntry));
+                                    entry.addSCALER(scaler);
+                                    scalerEntries.add(entry);
+                                }
+                            }
+
+                            // the trailing words contain the scaler's internal
+                            // reference clock:
+                            else {
+                                if (dataWordIndex == 64 || dataWordIndex == 65) {
+                                    // Define the mangled/magic channels numbers that were
+                                    // previously assigned above to the gated/ungated clock:
+                                    final int channel = dataWordIndex == 64 ? 18 : 50;
+                                    DetectorDataDgtz entry = new DetectorDataDgtz(crate,num,channel);
+                                    SCALERData scaler = new SCALERData();
+                                    scaler.setValue(DataUtils.getLongFromInt(dataEntry));
+                                    entry.addSCALER(scaler);
+                                    scalerEntries.add(entry);
+                                }
                             }
                         }
                     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -1129,9 +1129,9 @@ public class CodaEventDecoder {
                             // "type" is TRG-/TDC-gated/TRG-/TDC-ungated = 0/1/2/3 
                             if (type < 4) {
                                 final int channel = dataWordIndex % nChannels;
-                                // The first two channels are the Faraday Cup and SLM:
-                                // (the third channel is a 1 MHz input clock, which we
-                                // now ignore in favor of the scaler's internal clock below)
+                                // The first two channels are the Faraday Cup and SLM.
+                                // The third channel is a 1 MHz input clock, which we
+                                // now ignore in favor of the scaler's internal clock below.
                                 if (channel<2) {
                                     DetectorDataDgtz entry = new DetectorDataDgtz(crate,num,dataWordIndex);
                                     SCALERData scaler = new SCALERData();
@@ -1145,7 +1145,7 @@ public class CodaEventDecoder {
                             // reference clock:
                             else {
                                 if (dataWordIndex == 64 || dataWordIndex == 65) {
-                                    // Define the mangled/magic channels numbers that were
+                                    // Define the mangled, magic channels numbers that were
                                     // previously assigned above to the gated/ungated clock:
                                     final int channel = dataWordIndex == 64 ? 18 : 50;
                                     DetectorDataDgtz entry = new DetectorDataDgtz(crate,num,channel);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -76,7 +76,7 @@ public class DetectorEventDecoder {
         tablesFitter = Arrays.asList(new String[]{"/daq/fadc/clasdev/htcc"});
         translationManager.init(keysTrans,tablesTrans);
         fitterManager.init(keysFitter, tablesFitter);
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity"}));
+        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1"}));
     }
 
     public final void initDecoder(){
@@ -100,7 +100,7 @@ public class DetectorEventDecoder {
         });
         fitterManager.init(keysFitter, tablesFitter);
 
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity"}));
+        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1"}));
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -127,8 +127,8 @@ public class DaqScalers {
      * @param helTable /runcontrol/helicity from CCDB
      * @return  
      */
-    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable) {
-        Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable);
+    public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,IndexedTable dscTable) {
+        Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable,dscTable);
         return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,dsc2.getGatedClockSeconds());
     }
 
@@ -170,8 +170,8 @@ public class DaqScalers {
      * @param helTable /runcontrol/helicity CCDB table
      * @return [RUN::scaler,HEL::scaler] banks
      */
-    public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable) {
-        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable);
+    public static List<Bank> createBanks(SchemaFactory schema,Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,IndexedTable dscTable) {
+        DaqScalers ds = DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,dscTable);
         List<Bank> ret = new ArrayList<>();
         // only add the RUN::scaler bank if we actually got a DSC2 readout:
         if (ds.dsc2.getClock()>0 || ds.dsc2.getGatedClock()>0) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -1,15 +1,19 @@
 package org.jlab.detector.scalers;
 
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.jlab.utils.groups.IndexedTable;
 
 /**
  *
- * Read the occasional scaler bank, extract beam charge, livetime, etc.
+ * Helper methods to read the RAW::scaler bank, and create RUN::scaler and 
+ * HEL::scaler from Dsc2Scaler and StruckScaler objects.
  *
  * We have at least two relevant scaler hardware boards, STRUCK and DSC2, both
  * readout on helicity flips and with DAQ-busy gating, both decoded into RAW::scaler.
@@ -30,13 +34,13 @@ import org.jlab.utils.groups.IndexedTable;
  * offset/slope/attenuation are read from CCDB
  *
  * Accounting for the offset in accumulated beam charge requires knowledge of
- * time duration.  Currently, the (32 bit) DSC2 clock is zeroed at run start
+ * time duration.  In some run periods the DSC2 clock is zeroed at run start
  * but at 1 Mhz rolls over every 35 seconds, and the (48 bit) 250 MHz TI timestamp
  * can also rollover within a run since only zeroed upon reboot.  Instead we allow
  * run duration to be passed in, e.g. using run start time from RCDB and event
  * unix time from RUN::config.
  *
- * FIXME:  Use CCDB for GATEINVERTED, CLOCK_FREQ, CRATE/SLOT/CHAN
+ * FIXME:  Use CCDB for GATEINVERTED and CRATE/SLOT/CHAN
  *
  * @author baltzell
  */
@@ -125,6 +129,7 @@ public class DaqScalers {
      * @param fcupTable /runcontrol/fcup from CCDB
      * @param slmTable /runcontrol/slm from CCDB
      * @param helTable /runcontrol/helicity from CCDB
+     * @param dscTable
      * @return  
      */
     public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,IndexedTable dscTable) {
@@ -140,7 +145,7 @@ public class DaqScalers {
         Bank bank = new Bank(schema.getSchema("RUN::scaler"),1);
         bank.putFloat("fcup",0,(float)this.dsc2.getBeamCharge());
         bank.putFloat("fcupgated",0,(float)this.dsc2.getBeamChargeGated());
-        if (this.struck.size() > 0)
+        if (!this.struck.isEmpty())
           bank.putFloat("livetime",0,(float)this.struck.get(this.struck.size()-1).getLivetimeClock());
         return bank;
     }
@@ -163,6 +168,7 @@ public class DaqScalers {
     }
 
     /**
+     * Use scaler clock for run duration for Faraday cup offset correction.
      * @param rawScalerBank RAW::scaler bank
      * @param schema bank schema
      * @param fcupTable /runcontrol/fcup CCDB table
@@ -185,6 +191,7 @@ public class DaqScalers {
     }
 
     /**
+     * Use user-defined seconds for run duration Faraday cup offset correction.
      * @param rawScalerBank RAW::scaler bank
      * @param schema bank schema
      * @param fcupTable /runcontrol/fcup CCDB table
@@ -208,6 +215,7 @@ public class DaqScalers {
     }
 
     /**
+     * Use run start time and end times for run duration Faraday cup offset correction.
      * @param rawScalerBank RAW::scaler bank
      * @param schema bank schema
      * @param fcupTable /runcontrol/fcup CCDB table
@@ -221,5 +229,50 @@ public class DaqScalers {
         return DaqScalers.createBanks(schema,rawScalerBank,fcupTable,slmTable,helTable,DaqScalers.getSeconds(rst,uet));
     }
 
+    /**
+     * @param runnumber
+     * @param schema
+     * @param event
+     * @param conman
+     * @return [RUN::scaler,HEL::scaler] banks
+     */
+    public static List<Bank> createBanks(int runnumber, SchemaFactory schema, Event event, ConstantsManager conman) {
+
+        List<Bank> ret = new ArrayList<>();
+
+        Bank rawScaler = new Bank(schema.getSchema("RAW::scaler"));
+        Bank runConfig = new Bank(schema.getSchema("RUN::config"));
+
+        event.read(runConfig);
+        event.read(rawScaler);
+
+        if (runConfig.getRows()<1 || rawScaler.getRows()<1) return ret;
+
+        IndexedTable fcup = conman.getConstants(runnumber, "/runcontrol/fcup");
+        IndexedTable slm = conman.getConstants(runnumber, "/runcontrol/slm");
+        IndexedTable hel = conman.getConstants(runnumber, "/runcontrol/helicity");
+        IndexedTable dsc = conman.getConstants(runnumber, "/daq/config/scalers/dsc1");
+
+        if (dsc.getIntValue("frequency", 0,0,0) < 2e5) {
+            ret.addAll(createBanks(schema,rawScaler,fcup, slm, hel, dsc));
+        }
+        else {
+            // get unix event time (in seconds), and convert to Java's date (via milliseconds):
+            Date uet=new Date(runConfig.getInt("unixtime",0)*1000L);
+
+            // retrieve RCDB run start time:
+            Time rst;
+            try {
+                rst = (Time)conman.getRcdbConstant(runnumber,"run_start_time").getValue();
+            }
+            catch (Exception e) {
+                // abort if no RCDB access (e.g. offsite)
+                return ret;
+            }
+            ret.addAll(DaqScalers.createBanks(schema,rawScaler,fcup,slm,hel,rst,uet));
+        }
+
+        return ret;
+    }
 }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -36,11 +36,42 @@ public class Dsc2Scaler extends DaqScaler{
      * @param seconds dwell time, provided in case the clock rolls over
      */
     public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-
-        // the DSC2's clock is (currently) 1 MHz
-        // FIXME:  use CCDB
         this.clockFreq=1e6;
+        this.read(bank);
+        this.calibrate(fcupTable,slmTable,seconds);
+    }
 
+    /**
+     * @param bank RAW::scaler bank
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable  /runcontrol/slm CCDB table
+     * @param dscTable /daq/config/scalers/dsc1 CCDB table
+     */
+    public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, IndexedTable dscTable) {
+        this.clockFreq = dscTable.getIntValue("frequency", 0,0,0);
+        this.read(bank);
+        this.calibrate(fcupTable,slmTable);
+    }
+
+    /**
+     * During some run periods, the run-integrating DSC2 scaler's clock frequency
+     * was too large and rolls over during the run.  So here we can pass in seconds
+     * (e.g. based on RCDB run start time) instead.
+     * @param fcupTable /runcontrol/fcup CCDB table
+     * @param slmTable /runcontrol/slm CCDB table
+     * @param seconds 
+     */
+    protected final void calibrate(IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
+        if (this.fcup>0) {
+            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedFcup)/this.fcup);
+        }
+    }
+
+    /**
+     * 
+     * @param bank 
+     */
+    public final void read(Bank bank) {
         // this will get the last entries (most recent) in the bank
         for (int k=0; k<bank.getRows(); k++){
 
@@ -75,31 +106,6 @@ public class Dsc2Scaler extends DaqScaler{
             gatedFcup = fcup - gatedFcup;
             gatedClock = clock - gatedClock;
         }
-    
-        this.calibrate(fcupTable,slmTable,seconds);
     }
 
-    /**
-     * @param bank RAW::scaler bank
-     * @param fcupTable /runcontrol/fcup CCDB table
-     * @param slmTable  /runcontrol/slm CCDB table
-     */
-    public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable) {
-        this(bank,fcupTable,slmTable,1);
-        this.calibrate(fcupTable,slmTable);
-    }
-
-    /**
-     * During some run periods, the run-integrating DSC2 scaler's clock frequency
-     * was too large and rolls over during the run.  So here we can pass in seconds
-     * (e.g. based on RCDB run start time) instead.
-     * @param fcupTable /runcontrol/fcup CCDB table
-     * @param slmTable /runcontrol/slm CCDB table
-     * @param seconds 
-     */
-    protected final void calibrate(IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-        if (this.fcup>0) {
-            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedFcup)/this.fcup);
-        }
-    }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -98,8 +98,8 @@ public class Dsc2Scaler extends DaqScaler{
      * @param seconds 
      */
     protected final void calibrate(IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-        if (this.slm>0) {
-            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedSlm)/this.slm);
+        if (this.fcup>0) {
+            super.calibrate(fcupTable,slmTable,seconds,seconds*((double)this.gatedFcup)/this.fcup);
         }
     }
 }

--- a/common-tools/clas-io/src/main/java/org/jlab/utils/HipoDiff.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/utils/HipoDiff.java
@@ -1,0 +1,134 @@
+package org.jlab.utils;
+
+import org.jlab.jnp.hipo4.io.HipoReader;
+import org.jlab.jnp.hipo4.data.Bank;
+import org.jlab.jnp.hipo4.data.Event;
+import org.jlab.jnp.hipo4.data.Schema;
+import java.util.HashMap;
+import org.jlab.utils.options.OptionParser;
+
+public class HipoDiff {
+
+    public static void main(String args[]) {
+
+        OptionParser op = new OptionParser();
+        op.addOption("-r", "0.00001", "resolution");
+        op.addOption("-n", "-1", "number of events");
+        op.addRequired("-b", "name of bank to diff");
+        op.setRequiresInputList(true);
+        op.parse(args);
+        if (op.getInputList().size() != 2) {
+            op.show();
+            System.err.println("ERROR:  Exactly 2 input files are required.");
+            System.exit(1);
+        }
+
+        final String bankName = op.getOption("-b").stringValue();
+        final double resolution = op.getOption("-r").doubleValue();
+        final int nmax = op.getOption("-n").intValue();
+
+        HipoReader readerA = new HipoReader();
+        HipoReader readerB = new HipoReader();
+        readerA.open(op.getInputList().get(0));
+        readerB.open(op.getInputList().get(1));
+
+        Schema schema = readerA.getSchemaFactory().getSchema(bankName);
+        Bank bankA = new Bank(schema);
+        Bank bankB = new Bank(schema);
+
+        Bank runConfigBank = new Bank(readerA.getSchemaFactory().getSchema("RUN::config"));
+        Event event = new Event();
+
+        int nevent = -1;
+        int nrow = 0;
+        int nentry = 0;
+        int nbadevent = 0;
+        int nbadrow = 0;
+        int nbadentry = 0;
+        HashMap<String, Integer> badEntries = new HashMap<>();
+
+        while (readerA.hasNext() && readerB.hasNext() && (nmax<1 || nevent<nmax)) {
+
+            if (++nevent % 10000 == 0) {
+                System.out.println("Analyzed " + nevent + " events");
+            }
+
+            readerA.nextEvent(event);
+            event.read(bankA);
+            readerB.nextEvent(event);
+            event.read(bankB);
+
+            event.read(runConfigBank);
+
+            if (bankA.getRows() != bankB.getRows()) {
+                System.out.println("========================= Different number of rows:");
+                runConfigBank.show();
+                bankA.show();
+                bankB.show();
+                nbadevent++;
+                System.out.println("=========================");
+            }
+
+            else {
+                for (int i = 0; i < bankA.getRows(); i++) {
+                    boolean mismatch = false;
+                    nrow++;
+                    for (int j = 0; j < schema.getElements(); j++) {
+                        final int type = schema.getType(j);
+                        final String name = schema.getElementName(j);
+                        int element = -1;
+                        nentry++;
+                        switch (type) {
+                            case 1:
+                                if (bankA.getByte(name, i) != bankB.getByte(name, i)) {
+                                    element = j;
+                                }
+                                break;
+                            case 2:
+                                if (bankA.getShort(name, i) != bankB.getShort(name, i)) {
+                                    element = j;
+                                }
+                                break;
+                            case 3:
+                                if (bankA.getInt(name, i) != bankB.getInt(name, i)) {
+                                    element = j;
+                                }
+                                break;
+                            case 4:
+                                if ((!Double.isNaN(bankA.getFloat(name, i)) || !Double.isNaN(bankB.getFloat(name, i)))
+                                        && (!Double.isInfinite(bankA.getFloat(name, i)) || !Double.isInfinite(bankB.getFloat(name, i)))
+                                        && Math.abs(bankA.getFloat(name, i) - bankB.getFloat(name, i)) > resolution) {
+                                    element = j;
+                                }
+                                break;
+                        }
+                        if (element >= 0) {
+                            System.out.println("mismatch at event " + runConfigBank.getInt("event", 0)
+                                    + ", in row " + i + ", s/l/c " + bankA.getByte("sector", i) + "/"
+                                    + bankA.getByte("layer", i) + "/" + bankA.getShort("component", i)
+                                    + " for variable " + name + " with values " + bankA.getByte(name, i) + "/"
+                                    + bankB.getByte(name, i));
+                            mismatch = true;
+                            nbadentry++;
+                            if (badEntries.containsKey(schema.getElementName(element))) {
+                                int nbad = badEntries.get(schema.getElementName(element)) + 1;
+                                badEntries.replace(schema.getElementName(element), nbad);
+                            } else {
+                                badEntries.put(schema.getElementName(element), 1);
+                            }
+                        }
+                    }
+                    if (mismatch) {
+                        nbadrow++;
+                    }
+                }
+            }
+        }
+        System.out.println("Analyzed " + nevent + " with " + nbadevent + " bad banks");
+        System.out.println(nbadrow + "/" + nrow + " mismatched rows");
+        System.out.println(nbadentry + "/" + nentry + " mismatched entry");
+        for (String name : badEntries.keySet()) {
+            System.out.println(name + " " + badEntries.get(name));
+        }
+    }
+}

--- a/common-tools/clas-io/src/main/java/org/jlab/utils/HipoDiff.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/utils/HipoDiff.java
@@ -11,20 +11,20 @@ public class HipoDiff {
 
     public static void main(String args[]) {
 
-        OptionParser op = new OptionParser();
-        op.addOption("-r", "0.00001", "resolution");
+        OptionParser op = new OptionParser("hipo-diff");
+        op.addOption("-t", "0.00001", "absolute tolerance for comparisons");
         op.addOption("-n", "-1", "number of events");
         op.addRequired("-b", "name of bank to diff");
         op.setRequiresInputList(true);
         op.parse(args);
         if (op.getInputList().size() != 2) {
-            op.show();
-            System.err.println("ERROR:  Exactly 2 input files are required.");
+            System.out.println(op.getUsageString());
+            System.out.println("ERROR:  Exactly 2 input files are required.");
             System.exit(1);
         }
 
         final String bankName = op.getOption("-b").stringValue();
-        final double resolution = op.getOption("-r").doubleValue();
+        final double tolerance = op.getOption("-t").doubleValue();
         final int nmax = op.getOption("-n").intValue();
 
         HipoReader readerA = new HipoReader();
@@ -97,7 +97,7 @@ public class HipoDiff {
                             case 4:
                                 if ((!Double.isNaN(bankA.getFloat(name, i)) || !Double.isNaN(bankB.getFloat(name, i)))
                                         && (!Double.isInfinite(bankA.getFloat(name, i)) || !Double.isInfinite(bankB.getFloat(name, i)))
-                                        && Math.abs(bankA.getFloat(name, i) - bankB.getFloat(name, i)) > resolution) {
+                                        && Math.abs(bankA.getFloat(name, i) - bankB.getFloat(name, i)) > tolerance) {
                                     element = j;
                                 }
                                 break;


### PR DESCRIPTION
This is how things need to be done going forward, decoding the correct clock and using it for the Faraday offset calculation.  The gotchas are:

1.  Data that was recorded when the clock's frequency was too large and rolled over within a run.
2.  Data that was decoded without preserving the correct clock.

Currently those are controlled by using the clock frequency from CCDB, currently set for RG-M and later to be usable, and for all previous runs to be unusable, with a threshold of 200 kHz.
