### PR TITLE
ci: update actions to `v3`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,11 +18,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up JDK
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
         java-version: 11
+        distribution: zulu
     - name: build
       run: ./build-coatjava.sh --spotbugs --unittests --quiet
     - name: kpp-test


### PR DESCRIPTION
This clears CI warnings such as:
```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-java@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```

Starting from `actions/setup-java` v2, the `distribution` is required. The default for v1 was `zulu`.