### PR TITLE
fix: `run-groovy` class path

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export CLAS12DIR=`dirname $0`/..
+export CLAS12DIR=`dirname $0`/../coatjava
 
 # Set default field maps (but do not override user's env):
 if [ -z "$COAT_MAGFIELD_TORUSMAP" ]; then

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -2,8 +2,6 @@
 
 . `dirname $0`/env.sh 
 
-export CLAS12DIR=`dirname $0`/..
- 
 #--------------------------------------------------------------
 # Adding supporting COAT jar files
 for i in `ls -a $CLAS12DIR/lib/clas/*.jar`


### PR DESCRIPTION
Fixes `run-groovy` class paths (`$JYPATH`) for `.jar` file location.