### PR TITLE
fix: allow `run-groovy` to run inline commands

### DIFF
--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -50,4 +50,4 @@ echo "*****************************************"
 echo " "
 echo " "
 export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
-groovy -cp "$JYPATH" $*
+groovy -cp "$JYPATH" "$@"


### PR DESCRIPTION
This allows one to call inline `groovy` commands with `-e`. I've done a few tests to make sure things work as expected, but more thorough testing is recommended.

### test 1:
Before this PR:
```bash
run-groovy -e "println 'hello inline command'"
```
returns
```
*****************************************
*    Running COAT-JAVA Groovy Scripts   *
*    Version : 3a  Release : 2016       *
*****************************************

Caught: groovy.lang.MissingPropertyException: No such property: println for class: script_from_command_line
groovy.lang.MissingPropertyException: No such property: println for class: script_from_command_line
        at script_from_command_line.run(script_from_command_line:1)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
```

After this PR, it returns:
```
*****************************************
*    Running COAT-JAVA Groovy Scripts   *
*    Version : 3a  Release : 2016       *
*****************************************
 
hello inline command
```

### test 2
I've confirmed the following behavior is the same for both before and after this PR:
```groovy
// file: check.groovy
args.eachWithIndex { it, idx ->
  println "args[$idx] = $it"
}
```
```bash
run-groovy check.groovy abc def hij

args[0] = abc
args[1] = def
args[2] = hij
```

### test 3
When quoting the arguments, we now get:
```bash
run-groovy check.groovy "abc def hij"

args[0] = abc def hij
```
whereas the behavior from before this PR returns the same output as test 2.