### PR TITLE
Adding the run-jshell script to the bin/

### DIFF
--- a/bin/run-jshell
+++ b/bin/run-jshell
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+. `dirname $0`/env.sh 
+
+export CLAS12DIR=`dirname $0`/..
+ 
+#--------------------------------------------------------------
+# Adding supporting COAT jar files
+for i in `ls -a $CLAS12DIR/lib/clas/*.jar`
+do  
+#echo "$i"
+if [ -z "${JYPATH}" ] ; then
+JYPATH="$i"
+else
+JYPATH=${JYPATH}:"$i"
+fi
+done 
+#--------------------------------------------------------------
+# Adding supporting plugins directory
+for i in `ls -a $CLAS12DIR/lib/services/*.jar`
+do
+if [ -z "${JYPATH}" ] ; then
+JYPATH="$i"
+else
+JYPATH=${JYPATH}:"$i"
+fi
+done
+#--------------------------------------------------------------
+# Adding supporting plugins directory
+#--------------------------------------------------------------
+# Done loading plugins
+#--------------------------------------------------------------
+# Adding supporting plugins directory 
+for i in `ls -a $CLAS12DIR/lib/utils/*.jar`
+do
+if [ -z "${JYPATH}" ] ; then
+JYPATH="$i"
+else
+JYPATH=${JYPATH}:"$i"
+fi
+done
+#-------------------------------------------------------------
+echo " "
+echo " "
+echo "*****************************************"
+echo "*    Running COAT-JAVA JShell Scripts   *" 
+echo "*****************************************"
+echo " "
+echo " "
+jshell --class-path "$JYPATH" $*

--- a/bin/run-jshell
+++ b/bin/run-jshell
@@ -47,4 +47,4 @@ echo "*    Running COAT-JAVA JShell Scripts   *"
 echo "*****************************************"
 echo " "
 echo " "
-jshell --class-path "$JYPATH" $*
+jshell --class-path "$JYPATH" "$@"


### PR DESCRIPTION
Added a bash script called run-shell that will open the jshell interactive session and load the jar files in coatjava/lib to the class-path.  The user does not need to add the jar files as options on the command line or set them as environment variables.