### PR TITLE
refactor: combine environment for `run-groovy` and `run-jshell`

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -13,3 +13,22 @@ if [ -z "$COAT_MAGFIELD_SOLENOIDMAP" ]; then
     export COAT_MAGFIELD_SOLENOIDMAP=Symm_solenoid_r601_phi1_z1201_13June2018.dat
 fi
 
+# additional environment variables for groovy or interactive use
+# - call as `source $0 groovy` or `source $0 jshell`
+if [ $# -ge 1 ]; then
+
+  # add jar files to class path
+  for lib in clas services utils; do
+    for jars in $(ls -a $CLAS12DIR/lib/$lib/*.jar); do
+      JYPATH="${JYPATH:+${JYPATH}:}${jars}"
+    done
+  done
+
+  # additional variables and settings for groovy
+  if [ "$1" == "groovy" ]; then
+    JYPATH="${JYPATH:+${JYPATH}:}${CLAS12DIR}/lib/packages"
+    export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
+  fi
+
+  export JYPATH
+fi

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -16,19 +16,22 @@ fi
 # additional environment variables for groovy or interactive use
 # - call as `source $0 groovy` or `source $0 jshell`
 if [ $# -ge 1 ]; then
+  if [ "$1" == "groovy" -o "$1" == "jshell" ]; then
 
-  # add jar files to class path
-  for lib in clas services utils; do
-    for jars in $(ls -a $CLAS12DIR/lib/$lib/*.jar); do
-      JYPATH="${JYPATH:+${JYPATH}:}${jars}"
+    # add jar files to class path
+    for lib in clas services utils; do
+      for jars in $(ls -a $CLAS12DIR/lib/$lib/*.jar); do
+        JYPATH="${JYPATH:+${JYPATH}:}${jars}"
+      done
     done
-  done
 
-  # additional variables and settings for groovy
-  if [ "$1" == "groovy" ]; then
-    JYPATH="${JYPATH:+${JYPATH}:}${CLAS12DIR}/lib/packages"
-    export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
+    # additional variables and settings for groovy
+    if [ "$1" == "groovy" ]; then
+      JYPATH="${JYPATH:+${JYPATH}:}${CLAS12DIR}/lib/packages"
+      export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
+    fi
+
+    export JYPATH
+
   fi
-
-  export JYPATH
 fi

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,53 +1,11 @@
 #!/bin/sh
 
-. `dirname $0`/env.sh 
+. `dirname $0`/env.sh groovy
 
-export CLAS12DIR=`dirname $0`/..
- 
-#--------------------------------------------------------------
-# Adding supporting COAT jar files
-for i in `ls -a $CLAS12DIR/lib/clas/*.jar`
-do  
-#echo "$i"
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done 
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-for i in `ls -a $CLAS12DIR/lib/services/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-#--------------------------------------------------------------
-# Done loading plugins
-#--------------------------------------------------------------
-# Adding supporting plugins directory 
-for i in `ls -a $CLAS12DIR/lib/utils/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done
-#-------------------------------------------------------------
-JYPATH=${JYPATH}:${CLAS12DIR}/lib/packages
-echo " "
-echo " "
-echo "*****************************************"
-echo "*    Running COAT-JAVA Groovy Scripts   *"
-echo "*    Version : 3a  Release : 2016       *" 
-echo "*****************************************"
-echo " "
-echo " "
-export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
+echo """
+****************************************
+*    Running COATJAVA Groovy Script    *
+****************************************
+"""
+
 groovy -cp "$JYPATH" "$@"

--- a/bin/run-jshell
+++ b/bin/run-jshell
@@ -1,50 +1,11 @@
 #!/bin/sh
 
-. `dirname $0`/env.sh 
+. `dirname $0`/env.sh jshell
 
-export CLAS12DIR=`dirname $0`/..
- 
-#--------------------------------------------------------------
-# Adding supporting COAT jar files
-for i in `ls -a $CLAS12DIR/lib/clas/*.jar`
-do  
-#echo "$i"
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done 
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-for i in `ls -a $CLAS12DIR/lib/services/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done
-#--------------------------------------------------------------
-# Adding supporting plugins directory
-#--------------------------------------------------------------
-# Done loading plugins
-#--------------------------------------------------------------
-# Adding supporting plugins directory 
-for i in `ls -a $CLAS12DIR/lib/utils/*.jar`
-do
-if [ -z "${JYPATH}" ] ; then
-JYPATH="$i"
-else
-JYPATH=${JYPATH}:"$i"
-fi
-done
-#-------------------------------------------------------------
-echo " "
-echo " "
-echo "*****************************************"
-echo "*    Running COAT-JAVA JShell Scripts   *" 
-echo "*****************************************"
-echo " "
-echo " "
+echo """
+*********************************
+*    Running COATJAVA JShell    *
+*********************************
+"""
+
 jshell --class-path "$JYPATH" "$@"


### PR DESCRIPTION
Most of the environment setup (viz. class path) in `run-groovy` and `run-jshell` is identical. This PR moves this environment setup to `bin/env.sh`, and the extra variables (`$JYPATH`) is only set when an argument (`groovy` or `jshell`) is supplied to the `source bin/env.sh` command.