### PR TITLE
feat: run Groovy Shell with `coatjava`

### DIFF
--- a/bin/run-groovysh
+++ b/bin/run-groovysh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+. `dirname $0`/env.sh groovy
+
+echo """
+***************************************
+*    Running COATJAVA Groovy Shell    *
+***************************************
+"""
+
+groovysh -cp "$JYPATH" "$@"


### PR DESCRIPTION
Add `run-groovysh`, which is similar to `run-groovy` but runs `groovysh`, the interactive Groovy Shell.

Depends on https://github.com/JeffersonLab/coatjava/pull/98.