### PR TITLE
ci: `push` trigger only on trunk branch and tags

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,10 +3,10 @@
 name: Coatjava-CI
 
 on:
-  push:
-    branches: [ '**' ]
   pull_request:
-    branches: [ '**' ]
+  push:
+    branches: [ development ]
+    tags: [ '*' ]
   schedule:
     # NOTE: From what I read, the email notification for cron can only go
     #       to the last committer of this file!!!!!


### PR DESCRIPTION
If we are following trunk-based development with PRs, then only the trunk branch (`development`) should trigger on `push`.

Resolves https://github.com/JeffersonLab/coatjava/issues/104