### PR TITLE
fix: `groovy.util.CliBuilder` deprecation

### DIFF
--- a/validation/advanced-tests/src/eb/scripts/gen.groovy
+++ b/validation/advanced-tests/src/eb/scripts/gen.groovy
@@ -12,7 +12,7 @@ import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.base.GeometryFactory;
 import org.jlab.physics.io.LundReader;
 
-import groovy.util.CliBuilder
+import groovy.cli.commons.CliBuilder
 import org.apache.commons.cli.HelpFormatter
 
 double torusScale = -1.0;


### PR DESCRIPTION
`validation/advanced-tests/src/eb/scripts/gen.groovy` uses deprecated package; it seems that `groovy.cli.commons.CliBuilder` is [the backward-compatible replacement](https://picocli.info/groovy-2.5-clibuilder-renewal.html).