### PR TITLE
ci: test `run-groovy`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -37,7 +37,7 @@ jobs:
         retention-days: 1
         path: coatjava.tar.gz
 
-  test:
+  test_coatjava:
     needs: [ build ]
     runs-on: ubuntu-latest
     strategy:
@@ -73,3 +73,25 @@ jobs:
       run: |
         cd validation/advanced-tests
         ${{matrix.cmd}}
+
+  test_run-groovy:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK
+      uses: actions/setup-java@v3
+      with:
+        java-version: 11
+        distribution: zulu
+    - name: setup groovy
+      uses: wtfjoke/setup-groovy@v1
+      with:
+        groovy-version: 4.x
+    - uses: actions/download-artifact@v3
+      with:
+        name: build
+    - name: untar build
+      run: tar xzvf coatjava.tar.gz
+    - name: test run-groovy
+      run: coatjava/bin/run-groovy validation/advanced-tests/test-run-groovy.groovy

--- a/validation/advanced-tests/test-run-groovy.groovy
+++ b/validation/advanced-tests/test-run-groovy.groovy
@@ -10,7 +10,7 @@
     System.err.println "ERROR: environment variable $name is set, but empty"
     System.exit(100)
   }
-  System.out.println("$name = $val")
+  System.out.println "$name = $val"
 }
 
 // try to import a local package

--- a/validation/advanced-tests/test-run-groovy.groovy
+++ b/validation/advanced-tests/test-run-groovy.groovy
@@ -1,0 +1,17 @@
+// simple test to make sure that `run-groovy` is working
+
+// check environment variables
+[ 'JYPATH', 'JAVA_OPTS' ].collectEntries{ [it, System.getenv(it)] }.each{ name, val ->
+  if(val==null) {
+    System.err.println "ERROR: environment variable $name not set"
+    System.exit(100)
+  }
+  if(val=="") {
+    System.err.println "ERROR: environment variable $name is set, but empty"
+    System.exit(100)
+  }
+  System.out.println("$name = $val")
+}
+
+// try to import a local package
+import org.jlab.clas.physics.*


### PR DESCRIPTION
Add a simple test to make sure `run-groovy` works.

This is part of a debugging effort for running `run-groovy` on CI runners in https://github.com/JeffersonLab/clas12-validation/pull/4 and helps stabilize `run-groovy` for the future.