### PR TITLE
fix!: use `bash` for `env.sh` to provide access to its true location

### DIFF
--- a/bin/bg-merger
+++ b/bin/bg-merger
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/bos2hipo
+++ b/bin/bos2hipo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/cvt-compare
+++ b/bin/cvt-compare
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/daqEventViewer
+++ b/bin/daqEventViewer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/dclayereffs-ana
+++ b/bin/dclayereffs-ana
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/decoder
+++ b/bin/decoder
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/dict-generator
+++ b/bin/dict-generator
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/dict-maker
+++ b/bin/dict-maker
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/dict-merger
+++ b/bin/dict-merger
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/dict-validator
+++ b/bin/dict-validator
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -2,13 +2,6 @@
 
 thisEnv=${BASH_SOURCE[0]:-$0}
 export CLAS12DIR=$(realpath $(dirname $thisEnv)/..)
-echo """
-BASH_SOURCE[0] = ${BASH_SOURCE[0]}
-0              = $0
-1              = $1
-thisEnv        = $thisEnv
-CLAS12DIR      = $CLAS12DIR
-"""
 
 # Set default field maps (but do not override user's env):
 if [ -z "$COAT_MAGFIELD_TORUSMAP" ]; then

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -1,6 +1,14 @@
-#!/bin/sh
+#!/bin/bash
 
-export CLAS12DIR=`dirname $0`/..
+thisEnv=${BASH_SOURCE[0]:-$0}
+export CLAS12DIR=$(realpath $(dirname $thisEnv)/..)
+echo """
+BASH_SOURCE[0] = ${BASH_SOURCE[0]}
+0              = $0
+1              = $1
+thisEnv        = $thisEnv
+CLAS12DIR      = $CLAS12DIR
+"""
 
 # Set default field maps (but do not override user's env):
 if [ -z "$COAT_MAGFIELD_TORUSMAP" ]; then

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -16,7 +16,7 @@ fi
 # additional environment variables for groovy or interactive use
 # - call as `source $0 groovy` or `source $0 jshell`
 if [ $# -ge 1 ]; then
-  if [ "$1" == "groovy" -o "$1" == "jshell" ]; then
+  if [ "$1" = "groovy" -o "$1" = "jshell" ]; then
 
     # add jar files to class path
     for lib in clas services utils; do
@@ -26,7 +26,7 @@ if [ $# -ge 1 ]; then
     done
 
     # additional variables and settings for groovy
-    if [ "$1" == "groovy" ]; then
+    if [ "$1" = "groovy" ]; then
       JYPATH="${JYPATH:+${JYPATH}:}${CLAS12DIR}/lib/packages"
       export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
     fi

--- a/bin/evio-viewer
+++ b/bin/evio-viewer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/evio2hipo
+++ b/bin/evio2hipo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/eviocure
+++ b/bin/eviocure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/eviodump
+++ b/bin/eviodump
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/hipo-add
+++ b/bin/hipo-add
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/hipo-browser
+++ b/bin/hipo-browser
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/hipo-diff
+++ b/bin/hipo-diff
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/hipo-json
+++ b/bin/hipo-json
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/hipo-utils
+++ b/bin/hipo-utils
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/postprocess
+++ b/bin/postprocess
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/recon-util
+++ b/bin/recon-util
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 . `dirname $0`/env.sh groovy
 

--- a/bin/run-groovy
+++ b/bin/run-groovy
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh groovy
 

--- a/bin/run-groovysh
+++ b/bin/run-groovysh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh groovy
 

--- a/bin/run-jshell
+++ b/bin/run-jshell
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh jshell
 

--- a/bin/trigger-filter
+++ b/bin/trigger-filter
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 

--- a/bin/trigger-splitter
+++ b/bin/trigger-splitter
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . `dirname $0`/env.sh 
 


### PR DESCRIPTION
Using `$0` and `$1` in `env.sh` when called as
```bash
. bin/env.sh    # or source bin/env.sh
```
depends on the shell. Ideally, we want:
```
$0 = bin/env.sh
$1 = whatever additional argument was supplied to the '. bin/env.sh' call (see 'run-groovy')
```
However, these may not be the case depending on the shell (especially for `dash`, which may be used in place of `sh`).

Since [there is no POSIX-compliant way to get the true script name](https://stackoverflow.com/questions/29832037/how-to-get-script-directory-in-posix-sh), this PR proposes switching `env.sh` to be in `bash`, so that we may prioritize using `$BASH_SOURCE[0]` in place of `$0` to get the true `bin/env.sh` path.

All `sh` scripts which source `bin/env.sh` are also converted to `bash`.