### PR TITLE
Do not include clas6 banks in clas12 schema

### DIFF
--- a/etc/bankdefs/util/bankSplit.py
+++ b/etc/bankdefs/util/bankSplit.py
@@ -30,8 +30,7 @@ def create(dirname, banklist):
 
 # for each json file in hipo schema folder
 for filename in os.listdir("./"):
-    if filename.endswith(".json"):
-
+    if filename.endswith(".json") and not filename.startswith("clas6"):
         #Read JSON data into the datastore variable
         f = open(filename)
         try:


### PR DESCRIPTION
Shouldn't be in clas12 schema anyway, and breaks on case-insensitive filesystem due to MC::[Pp]article banks.