### PR TITLE
 code to convert evio2hipo with decoder after evio2hipo2evio

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -764,6 +764,7 @@ public class CLASDecoder4 {
                 hr.nextEvent(hevent);
                 
                 Node evn = hevent.read(1, 11);
+                Node trg = hevent.read(5,  5);
                 
                 byte[] buffer = evn.getByte();
                 // this next few lines may seem wierd for untrained observer,
@@ -834,6 +835,7 @@ public class CLASDecoder4 {
                     writer.addEvent(scalerEvent, 1);
                 }
                 
+                decodedEvent.write(trg);
                 writer.addEvent(decodedEvent,0);
                 
                 counter++;


### PR DESCRIPTION
A new decoder option was added to decode files created by the online decoder. Due to missing features in HIPO4, not all the composite nodes can be transferred to the newly created HIPO file from the decoded file (which contains Level-3 trigger results), the h5utils with -join option has to be used to merge the events.