### PR TITLE
ci: dispatch `clas12-validation` workflow runs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,33 @@
+name: Dispatch Validation
+
+on:
+  pull_request:
+  push:
+    branches: [ development ]
+    tags: [ '*' ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  clas12-validation:
+    name: clas12-validation dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: dispatch
+        uses: c-dilks/trigger-workflow-and-wait@summarize # convictional/trigger-workflow-and-wait@v1.6.5
+        with:
+          owner: JeffersonLab
+          repo: clas12-validation
+          summarize: true
+          github_token: ${{ secrets.CLAS12VALIDATION }}
+          workflow_file_name: ci.yml
+          ref: main
+          client_payload: '{
+            "source": "${{ github.repository }}",
+            "title": "${{ github.event.pull_request.title || github.event.head_commit.message }}",
+            "source_url": "${{ github.event.pull_request.html_url }}",
+            "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"
+          }'


### PR DESCRIPTION
Adds a workflow to dispatch [`clas12-validation`](https://github.com/JeffersonLab/clas12-validation) workflow runs.

Since this is a PR from a fork, the PAT is not accessible and the [dispatch job will fail](https://github.com/JeffersonLab/coatjava/actions/runs/6437368988/job/17482371130?pr=126#step:3:12) until this PR is merged.

To see an example working dispatch, see [this equivalent PR](https://github.com/c-dilks/coatjava/pull/1) against my fork, along with [a successful workflow dispatch run](https://github.com/c-dilks/coatjava/actions/runs/6437368965); follow the "Workflow URL" link in the run's summary table to see the dispatched `clas12-validation` run.

---

Unfortunately, a PR from a fork will never* have a successful validation dispatch, because of the inaccessible PAT; one possible workaround is having a contributor from a fork open a test PR on `clas12-validation`, manually [changing the default `coatjava` fork and branch here](https://github.com/JeffersonLab/clas12-validation/blob/2ec6a69d59962437c9e13a13fd17b61ec2275c7b/.github/workflows/ci.yml#L41-L44), but that's not ideal.

*well.. unless we use the [dangerous `pull_request_target` trigger](https://stackoverflow.com/questions/76975408/how-to-pass-a-secret-from-a-forked-github-repo-to-source-repo), which might be okay as long as we require approvals for running workflows for PRs from forks. IIRC the only secret we have is the PAT for `clas12-validation` dispatches, but if we enable `pull_request_target`, we need to be _very_ careful if we forget about this and add another secret, especially if such a secret grants write access somewhere.