### PR TITLE
ci: add final job, to be required as a trunk branch protection rule

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -95,3 +95,18 @@ jobs:
       run: tar xzvf coatjava.tar.gz
     - name: test run-groovy
       run: coatjava/bin/run-groovy validation/advanced-tests/test-run-groovy.groovy
+
+  final:
+    needs:
+      - test_coatjava
+      - test_run-groovy
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: fail
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "### Some tests failed." >> $GITHUB_STEP_SUMMARY
+          exit 1
+      - name: pass
+        run: echo "### All tests passed." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Github branch protection rules for a job matrix status check require _every_ matrix element to be set to "required". This PR adds a simple downstream job, named `final`, which will only run _successfully_ if all tests pass.

@baltzell: with this PR, the `development` branch protection rule may be set to require just the `final` status check to pass