### PR TITLE
fix(ci): sanitize validation dispatch payload

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,6 +16,9 @@ jobs:
     name: clas12-validation dispatch
     runs-on: ubuntu-latest
     steps:
+      - name: santize message
+        id: sanitize
+        run: echo title=$(echo "${{ github.event.pull_request.title || github.event.head_commit.message }}" | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
       - name: dispatch
         uses: c-dilks/trigger-workflow-and-wait@summarize # convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -27,7 +30,7 @@ jobs:
           ref: main
           client_payload: '{
             "source": "${{ github.repository }}",
-            "title": "${{ github.event.pull_request.title || github.event.head_commit.message }}",
+            "title": "${{ steps.sanitize.outputs.title }}",
             "source_url": "${{ github.event.pull_request.html_url }}",
             "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"
           }'

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,7 +16,7 @@ jobs:
     name: clas12-validation dispatch
     runs-on: ubuntu-latest
     steps:
-      - name: santize message
+      - name: sanitize message
         id: sanitize
         run: echo title=$(echo "${{ github.event.pull_request.title || github.event.head_commit.message }}" | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
       - name: dispatch


### PR DESCRIPTION
Fixes #128

- take only the first line of a multi-line message
- remove all single and double quotes to help prevent payload modification