### PR TITLE
style: use block scalar for validation dispatch payload

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,10 +29,11 @@ jobs:
           github_token: ${{ secrets.CLAS12VALIDATION }}
           workflow_file_name: ci.yml
           ref: main
-          client_payload: '{
-            "actor": "${{ github.actor }}",
-            "source": "${{ github.event.repository.name }}",
-            "title": "${{ steps.sanitize.outputs.title }}",
-            "source_url": "${{ github.event.pull_request.html_url }}",
-            "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"
-          }'
+          client_payload: >-
+            {
+              "actor": "${{ github.actor }}",
+              "source": "${{ github.event.repository.name }}",
+              "title": "${{ steps.sanitize.outputs.title }}",
+              "source_url": "${{ github.event.pull_request.html_url }}",
+              "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"
+            }


### PR DESCRIPTION
Fold and chomp the `json` payload with block scalar syntax `>-`, instead of confusing some editors or parsers with a multi-line single quote.