### PR TITLE
ci: dispatch author name to `clas12-validation` runs

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,7 +29,8 @@ jobs:
           workflow_file_name: ci.yml
           ref: main
           client_payload: '{
-            "source": "${{ github.repository }}",
+            "actor": "${{ github.actor }}",
+            "source": "${{ github.event.repository.name }}",
             "title": "${{ steps.sanitize.outputs.title }}",
             "source_url": "${{ github.event.pull_request.html_url }}",
             "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"


### PR DESCRIPTION
Uses https://github.com/JeffersonLab/clas12-validation/pull/24 so the author name shows up in `clas12-validation` actions.