### PR TITLE
fix: sanitize backquotes in `clas12-validation` dispatch payload

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: sanitize message
         id: sanitize
-        run: echo title=$(echo "${{ github.event.pull_request.title || github.event.head_commit.message }}" | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
+        run: echo title=$(echo '${{ github.event.pull_request.title || github.event.head_commit.message }}' | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
       - name: dispatch
         uses: c-dilks/trigger-workflow-and-wait@summarize # convictional/trigger-workflow-and-wait@v1.6.5
         with:


### PR DESCRIPTION
```
echo "`code`"   # executes `code`
echo '`code`'   # does not
```