### PR TITLE
ci: change `trigger-workflow-and-wait` fork branch to `master`

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -21,7 +21,7 @@ jobs:
         id: sanitize
         run: echo title=$(echo '${{ github.event.pull_request.title || github.event.head_commit.message }}' | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
       - name: dispatch
-        uses: c-dilks/trigger-workflow-and-wait@summarize # convictional/trigger-workflow-and-wait@v1.6.5
+        uses: c-dilks/trigger-workflow-and-wait@master # convictional/trigger-workflow-and-wait@v1.6.5
         with:
           owner: JeffersonLab
           repo: clas12-validation


### PR DESCRIPTION
Since I intend to add another feature to `trigger-workflow-and-wait`, and the upstream repository doesn't seem to be actively worked on at the moment, this PR switches the action to use to my fork's `master` branch, where I can merge in features as desired, without waiting for upstream decisions.