### PR TITLE
fix: payload branch and URL for `push` dispatch triggers

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -34,6 +34,6 @@ jobs:
               "actor": "${{ github.actor }}",
               "source": "${{ github.event.repository.name }}",
               "title": "${{ steps.sanitize.outputs.title }}",
-              "source_url": "${{ github.event.pull_request.html_url }}",
-              "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref }}\" }"
+              "source_url": "${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
+              "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref_name }}\" }"
             }


### PR DESCRIPTION
- fixes the branch name for `push` triggers, which was not correct and caused `git clone` failures in `clas12-validation` runs
- adds a URL to the relevant commit for `push` triggers, which is usually a PR merge