### PR TITLE
doc: add status badge for `clas12-validation` runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # coatjava
 [![Build Status](https://github.com/jeffersonlab/coatjava/workflows/Coatjava-CI/badge.svg)](https://github.com/jeffersonlab/coatjava/actions)
+[![Validation Status](https://github.com/JeffersonLab/clas12-validation/actions/workflows/ci.yml/badge.svg)](https://github.com/JeffersonLab/clas12-validation/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/JeffersonLab/coatjava/branch/development/graph/badge.svg?precision=2)](https://codecov.io/gh/JeffersonLab/coatjava/branch/development)
 
 The original repository for COATJAVA was named "clas12-offline-software" and is [now archived and read-only](https://github.com/JeffersonLab/clas12-offline-software).  On May 17, 2023, this new repository was created by running BFG Repo Cleaner to get rid of old, large data files and things that should never have been in the repository, giving 10x reduction in repository size, clone time, etc, and renamed "coatjava".  The most critical, github-specific aspects have been transferred to this new repository:


### PR DESCRIPTION
Add a status badge for `clas12-validation`. This watches `clas12-validation` workflow runs, which are not _only_ triggered by `coatjava` actions, so its status depends on more than just the state of `coatjava`.