### PR TITLE
feat: dispatch validation with low stats for PRs or high stats for PR merges

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # number of events; use 0 for the default in `clas12-validation`
+  num_events_low_stats: 0
+  num_events_high_stats: 10000
+
 jobs:
 
   clas12-validation:
@@ -20,6 +25,12 @@ jobs:
       - name: sanitize message
         id: sanitize
         run: echo title=$(echo '${{ github.event.pull_request.title || github.event.head_commit.message }}' | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
+      - name: set number of events
+        id: num_events
+        run: |
+          # use low stats for PR commits, or high stats for pushes (which should only be PR merges)
+          [ "${{ github.event_name }}" = "push" ] && num_events=${{ env.num_events_high_stats }} || num_events=${{ env.num_events_low_stats }}
+          echo num_events=$num_events >> $GITHUB_OUTPUT
       - name: dispatch
         uses: c-dilks/trigger-workflow-and-wait@master # convictional/trigger-workflow-and-wait@v1.6.5
         with:
@@ -31,6 +42,7 @@ jobs:
           ref: main
           client_payload: >-
             {
+              "num_events": "${{ steps.num_events.outputs.num_events }}",
               "actor": "${{ github.actor }}",
               "source": "${{ github.event.repository.name }}",
               "title": "${{ steps.sanitize.outputs.title }}",


### PR DESCRIPTION
- for PR commits (expected to be frequent), run `clas12-validation` with its default number of events (assumed to be relatively low statistics)
- for PR merges (_i.e._, commits on `development` and expected to not be frequent), run with high statistics, set here to 10k (see https://github.com/JeffersonLab/clas12-validation/pull/28)