### PR TITLE
feat: generalize validation dispatch workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -35,5 +35,5 @@ jobs:
               "source": "${{ github.event.repository.name }}",
               "title": "${{ steps.sanitize.outputs.title }}",
               "source_url": "${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
-              "git_coatjava": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref_name }}\" }"
+              "git_${{ github.event.repository.name }}": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref_name }}\" }"
             }


### PR DESCRIPTION
This is the first step to migrating this workflow to `clas12-validation`, allowing it to be called from anywhere.

All that needs to change is the `git_${repo_name}` key in the payload.