### PR TITLE
ci: replace `clas12-validation` dispatch with reusable workflow

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,8 +11,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   clas12-validation:
     name: clas12-validation workflow
-    uses: JeffersonLab/clas12-validation/.github/workflows/validation.yml@reusable-workflow  # FIXME: use `@main`
-    secrets: inherit  # FIXME: may not be needed if we can avoid `trigger-workflow-and-wait`
+    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
+    with:
+      # num_events: 0 # FIXME test this
+      config_file_versions: >-
+        {
+          "coatjava": "latest",
+          "gemc":     "latest"
+        }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,4 +14,5 @@ jobs:
 
   clas12-validation:
     name: clas12-validation workflow
-    uses: JeffersonLab/clas12-validation/.github/workflows/validation.yml@reusable-workflow
+    uses: JeffersonLab/clas12-validation/.github/workflows/validation.yml@reusable-workflow  # FIXME: use `@main`
+    secrets: inherit  # FIXME: may not be needed if we can avoid `trigger-workflow-and-wait`

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,7 +5,7 @@ on:
   push:
     # branches: [ development ]
     # tags: [ '*' ]
-  workflow_dipatch:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,11 +1,11 @@
 name: Validation
 
 on:
-  pull_request:
+  # pull_request:
   push:
-    branches: [ development ]
-    tags: [ '*' ]
-  workflow_dispatch:
+    # branches: [ development ]
+    # tags: [ '*' ]
+  # workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,12 +16,11 @@ jobs:
     name: clas12-validation workflow
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
     with:
-      num_events: 7 # FIXME test this
       # FIXME: drop this after testing
       config_file_versions: >-
         {
-          "coatjava": "latest",
-          "gemc":     "latest"
+          "coatjava": "2",
+          "gemc":     "3"
         }
       # FIXME: drop this after testing
       git_upstream: >-

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,10 +1,10 @@
 name: Validation
 
 on:
-  # pull_request: #FIXME: revert
+  pull_request:
   push:
-    # branches: [ development ]
-    # tags: [ '*' ]
+    branches: [ development ]
+    tags: [ '*' ]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,8 +16,14 @@ jobs:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
     with:
       # num_events: 0 # FIXME test this
+      # FIXME: drop this after testing
       config_file_versions: >-
         {
           "coatjava": "latest",
           "gemc":     "latest"
+        }
+      # FIXME: drop this after testing
+      git_upstream: >-
+        {
+          "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "branch": "reusable-workflow" }
         }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,8 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clas12-validation:
-    name: clas12-validation workflow
+  validation:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
     with:
       # FIXME: drop this after testing

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -16,7 +16,7 @@ jobs:
     name: clas12-validation workflow
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
     with:
-      # num_events: 0 # FIXME test this
+      num_events: 7 # FIXME test this
       # FIXME: drop this after testing
       config_file_versions: >-
         {

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,12 +17,6 @@ jobs:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
     with:
       # FIXME: drop this after testing
-      config_file_versions: >-
-        {
-          "coatjava": "2",
-          "gemc":     "3"
-        }
-      # FIXME: drop this after testing
       git_upstream: >-
         {
           "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "branch": "reusable-workflow" }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,4 +1,4 @@
-name: Dispatch Validation
+name: Validation
 
 on:
   pull_request:

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -5,6 +5,7 @@ on:
   push:
     # branches: [ development ]
     # tags: [ '*' ]
+  workflow_dipatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,10 +1,10 @@
 name: Validation
 
 on:
-  pull_request:
+  # pull_request: #FIXME: revert
   push:
-    branches: [ development ]
-    tags: [ '*' ]
+    # branches: [ development ]
+    # tags: [ '*' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,11 +1,11 @@
 name: Validation
 
 on:
-  # pull_request:
+  pull_request:
   push:
-    # branches: [ development ]
-    # tags: [ '*' ]
-  # workflow_dispatch:
+    branches: [ development ]
+    tags: [ '*' ]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -10,42 +10,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-env:
-  # number of events; use 0 for the default in `clas12-validation`
-  num_events_low_stats: 0
-  num_events_high_stats: 1000
-
 jobs:
 
   clas12-validation:
-    name: clas12-validation dispatch
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }} # not a PR from a fork || is a push
-    steps:
-      - name: sanitize message
-        id: sanitize
-        run: echo title=$(echo '${{ github.event.pull_request.title || github.event.head_commit.message }}' | head -n1 | sed 's;";;g' | sed "s;';;g") >> $GITHUB_OUTPUT
-      - name: set number of events
-        id: num_events
-        run: |
-          # use low stats for PR commits, or high stats for pushes (which should only be PR merges)
-          [ "${{ github.event_name }}" = "push" ] && num_events=${{ env.num_events_high_stats }} || num_events=${{ env.num_events_low_stats }}
-          echo num_events=$num_events >> $GITHUB_OUTPUT
-      - name: dispatch
-        uses: c-dilks/trigger-workflow-and-wait@master # convictional/trigger-workflow-and-wait@v1.6.5
-        with:
-          owner: JeffersonLab
-          repo: clas12-validation
-          summarize: true
-          github_token: ${{ secrets.CLAS12VALIDATION }}
-          workflow_file_name: ci.yml
-          ref: main
-          client_payload: >-
-            {
-              "num_events": "${{ steps.num_events.outputs.num_events }}",
-              "actor": "${{ github.actor }}",
-              "source": "${{ github.event.repository.name }}",
-              "title": "${{ steps.sanitize.outputs.title }}",
-              "source_url": "${{ github.event.pull_request.html_url || github.event.head_commit.url }}",
-              "git_${{ github.event.repository.name }}": "{\"fork\": \"${{ github.repository }}\", \"branch\": \"${{ github.head_ref || github.ref_name }}\" }"
-            }
+    name: clas12-validation workflow
+    uses: JeffersonLab/clas12-validation/.github/workflows/validation.yml@reusable-workflow

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,10 +13,4 @@ concurrency:
 
 jobs:
   validation:
-    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@reusable-workflow  # FIXME: use `@main`
-    with:
-      # FIXME: drop this after testing
-      git_upstream: >-
-        {
-          "clas12-validation": { "fork": "JeffersonLab/clas12-validation", "branch": "reusable-workflow" }
-        }
+    uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # coatjava
 [![Build Status](https://github.com/jeffersonlab/coatjava/workflows/Coatjava-CI/badge.svg)](https://github.com/jeffersonlab/coatjava/actions)
-[![Validation Status](https://github.com/JeffersonLab/clas12-validation/actions/workflows/ci.yml/badge.svg)](https://github.com/JeffersonLab/clas12-validation/actions/workflows/ci.yml)
+[![Validation Status](https://github.com/JeffersonLab/coatjava/actions/workflows/validation.yml/badge.svg)](https://github.com/JeffersonLab/coatjava/actions/workflows/validation.yml)
 [![codecov](https://codecov.io/gh/JeffersonLab/coatjava/branch/development/graph/badge.svg?precision=2)](https://codecov.io/gh/JeffersonLab/coatjava/branch/development)
 
 The original repository for COATJAVA was named "clas12-offline-software" and is [now archived and read-only](https://github.com/JeffersonLab/clas12-offline-software).  On May 17, 2023, this new repository was created by running BFG Repo Cleaner to get rid of old, large data files and things that should never have been in the repository, giving 10x reduction in repository size, clone time, etc, and renamed "coatjava".  The most critical, github-specific aspects have been transferred to this new repository:


### PR DESCRIPTION
Since other repositories (`clas12Tags`, `clas12-config`) would benefit from dispatching `clas12-validation` runs, this PR changes the dispatch workflow to a reusable workflow caller.

Depends on https://github.com/JeffersonLab/clas12-validation/pull/33

This PR resolves _several_ issues:
- PRs from forks of `coatjava` now successfully trigger `clas12-validation` workflow runs
- no more [annoying queuing issues](https://github.com/JeffersonLab/clas12-validation/issues/10): rapid commits on a PR branch will successfully cancel running `clas12-validation` workflow runs
- no need for an access token secret
- it is easier to find the running `clas12-validation` workflow run, since we are no longer dispatching; the reusable workflow means the workflow run happens _here_ and is fully controllable _here_
- the status badge in `README.md` is now accurate: it reflects the status of `coatjava` calls of `clas12-validation` workflow, instead of the _overall_ status of `clas12-validation` workflow runs (which may likely be independent of `coatjava`'s status)
- significantly simpler caller workflow `validation.yml`: very unlikely the important part of this file will need to change, so this file may simply be added to other repos (`clas12Tags` and `clas12-config`) so they may also run `clas12-validation`