### PR TITLE
fix: run 10x less events in `clas12-validation` high-stats tests

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   # number of events; use 0 for the default in `clas12-validation`
   num_events_low_stats: 0
-  num_events_high_stats: 10000
+  num_events_high_stats: 1000
 
 jobs:
 


### PR DESCRIPTION
Now that we have the full matrix of  ( event generation types, configurations ) validation tests, it turns out that 10k events is too time consuming.

The validation dispatch from the most recent PR merge to `development` was auto-cancelled since the job time exceeded GitHub's limits:
https://github.com/JeffersonLab/clas12-validation/actions/runs/6561980932

So for now, let's run 1k events in the high-stats test.