### PR TITLE
ci: do not `always()` run `final`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -116,12 +116,6 @@ jobs:
       - test_coatjava
       - test_run-groovy
     runs-on: ${{ needs.build.outputs.default_runner }}
-    if: always()
     steps:
-      - name: fail
-        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-        run: |
-          echo "### Some tests failed." >> $GITHUB_STEP_SUMMARY
-          exit 1
       - name: pass
-        run: echo "### All tests passed." >> $GITHUB_STEP_SUMMARY
+        run: exit 0


### PR DESCRIPTION
https://github.com/JeffersonLab/coatjava/pull/127 is a nice idea, but having the `final` job run `always()` means that it, along with the full workflow run, can neither be cancelled manually nor by `cancel-in-progress` from runs in the same concurrency class (leading to long startup times).

This PR changes `final` to only run if its upstream jobs succeed; if upstream jobs fail, `final` will be cancelled, which unfortunately does not block PR merging.