### PR TITLE
hotfix: trigger validation pipelines with the most recently working `clas12Tags`

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -14,3 +14,8 @@ concurrency:
 jobs:
   validation:
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main
+    with:
+      git_upstream: >-
+        {
+          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "8f99566" }
+        }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -17,5 +17,5 @@ jobs:
     with:
       git_upstream: >-
         {
-          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "8f99566" }
+          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "8f9956678b44386d3df85d8d8df9d5002333a82b" }
         }


### PR DESCRIPTION
Temporarily resolves #168 

The latest commit on `clas12Tags` does not pass validation checks; I'll open an issue on `clas12Tags` and link it here in a comment.