### PR TITLE
fix: run validation pipelines using latest `clas12Tags` semver tag

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,10 +12,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
+  get_gemc_tag:
+    runs-on: ubuntu-latest
+    name: Get highest GEMC tag
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - name: checkout clas12-validation
+        uses: actions/checkout@v4
+        with:
+          repository: JeffersonLab/clas12-validation
+          ref: main
+          path: clas12-validation
+      - name: checkout clas12Tags
+        uses: actions/checkout@v4
+        with:
+          repository: gemc/clas12Tags
+          ref: main
+          clean: false
+          fetch-tags: true
+          fetch-depth: 0
+          path: clas12Tags
+      - name: get highest tag
+        id: tag
+        working-directory: clas12Tags
+        run: |
+          tag=$(../clas12-validation/bin/get_highest_tag.rb)
+          echo "Highest \`clas12Tags` (GEMC) tag: \`$tag\`" >> $GITHUB_STEP_SUMMARY
+          echo '- using this version for `clas12-validation` workflow run' >> $GITHUB_STEP_SUMMARY
+          echo tag=$tag >> $GITHUB_OUTPUT
+
   validation:
+    needs: [ get_gemc_tag ]
     uses: JeffersonLab/clas12-validation/.github/workflows/ci.yml@main
     with:
       git_upstream: >-
         {
-          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "8f9956678b44386d3df85d8d8df9d5002333a82b" }
+          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "${{ needs.get_gemc_tag.outputs.tag }}" }
         }

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: clas12Tags
         run: |
           tag=$(../clas12-validation/bin/get_highest_tag.rb)
-          echo "Highest \`clas12Tags` (GEMC) tag: \`$tag\`" >> $GITHUB_STEP_SUMMARY
+          echo "Highest \`clas12Tags\` (GEMC) tag: \`$tag\`" >> $GITHUB_STEP_SUMMARY
           echo '- using this version for `clas12-validation` workflow run' >> $GITHUB_STEP_SUMMARY
           echo tag=$tag >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Better fix for #168 (supersedes #169)

Triggers `clas12-validation` workflow run using the highest semantically-versioned tag from `clas12Tags`.
- highest semantic version is preferred over latest tag, since there may be backports to older tags which occur in the git DAG _later_ than semantically later tags
- assumes that tag is working
- ignores the `dev` tag, which appears to be moving; it's ignored because it is not a semantic version number
- this automation is a better approach than choosing a fixed tag, since we may eventually forget to increment it