### PR TITLE
feat: pass user args to `mvn` in `build-coatjava.sh`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,7 +39,7 @@ jobs:
           java-version: 11
           distribution: zulu
       - name: build
-        run: ./build-coatjava.sh --spotbugs --unittests --quiet
+        run: ./build-coatjava.sh --spotbugs --unittests --quiet -T4
       - name: tar # tarball to preserve permissions
         run: tar czvf coatjava.tar.gz coatjava
       - uses: actions/upload-artifact@v3

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -4,33 +4,28 @@ set -e
 set -u
 set -o pipefail
 
-usage='build-coatjava.sh [-h] [--quiet] [--spotbugs] [--nomaps] [--unittests]'
+usage='''build-coatjava.sh [-h] [--help] [--quiet] [--spotbugs] [--nomaps] [--unittests]
+ - all other arguments will be passed to `mvn`, e.g., -T4 will build with 4 parallel threads'''
 
 quiet="no"
 runSpotBugs="no"
 downloadMaps="yes"
 runUnitTests="no"
+mvnArgs=()
 for xx in $@
 do
-    if [ "$xx" == "--spotbugs" ]
-    then
-        runSpotBugs="yes"
-    elif [ "$xx" == "-n" ]
-    then
-        runSpotBugs="no"
-    elif [ "$xx" == "--nomaps" ]
-    then
-        downloadMaps="no"
-    elif [ "$xx" == "--unittests" ]
-    then
-        runUnitTests="yes"
-    elif [ "$xx" == "--quiet" ]
-    then
-        quiet="yes"
-    else
-        echo "$usage"
-        exit 2
-    fi
+  case $xx in
+    --spotbugs)  runSpotBugs="yes"  ;;
+    -n)          runSpotBugs="no"   ;;
+    --nomaps)    downloadMaps="no"  ;;
+    --unittests) runUnitTests="yes" ;;
+    --quiet)     quiet="yes"        ;;
+    -h|--help)
+      echo "$usage"
+      exit 2
+      ;;
+    *) mvnArgs+=($xx) ;;
+  esac
 done
 
 top="$(cd "$(dirname "${BASH_SOURCE[0]}")" &> /dev/null && pwd)"
@@ -42,6 +37,7 @@ then
     wget='wget --progress=dot:mega'
     mvn="mvn -q -B --settings $top/maven-settings.xml"
 fi
+mvn+=" ${mvnArgs[*]}"
 
 command_exists () {
     type "$1" &> /dev/null


### PR DESCRIPTION
This allows user arguments to be passed to the `mvn` command used in `build-coatjava.sh`.

I originally did this so one can run `mvn` multi-threaded, e.g., 
```bash
build-coatjava.sh -T 4  # runs with 4 threads
```
however, `coatjava` builds so quickly that this does not make any improvement whatsoever.

Maybe this PR will be useful someday though...

```bash
time build-coatjava.sh       # 70.39s user 3.69s system 335% cpu 22.071 total
time build-coatjava.sh       # 68.33s user 3.32s system 386% cpu 18.538 total

time build-coatjava.sh -T 1  # 64.44s user 3.39s system 339% cpu 19.979 total
time build-coatjava.sh -T 1  # 73.75s user 3.68s system 356% cpu 21.702 total

time build-coatjava.sh -T 2  # 76.67s user 3.77s system 501% cpu 16.045 total
time build-coatjava.sh -T 2  # 75.24s user 3.69s system 431% cpu 18.291 total

time build-coatjava.sh -T 4  # 74.28s user 4.00s system 486% cpu 16.075 total
time build-coatjava.sh -T 4  # 73.92s user 4.01s system 546% cpu 14.262 total

time build-coatjava.sh -T 8  # 68.79s user 3.97s system 517% cpu 14.059 total
time build-coatjava.sh -T 8  # 75.55s user 4.11s system 461% cpu 17.256 total
```