### PR TITLE
ci: bump action versions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -32,9 +32,9 @@ jobs:
       default_runner: ubuntu-latest
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: zulu
@@ -42,7 +42,7 @@ jobs:
         run: ./build-coatjava.sh --spotbugs --unittests --quiet -T4
       - name: tar # tarball to preserve permissions
         run: tar czvf coatjava.tar.gz coatjava
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: build_${{ matrix.runner }}
           retention-days: 1
@@ -52,7 +52,7 @@ jobs:
         run: validation/jacoco-aggregate.sh
       - name: publish jacoco report
         if: ${{ matrix.runner == 'ubuntu-latest' }}
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: publish/
           retention-days: 1
@@ -86,13 +86,13 @@ jobs:
           - { runner: macos-latest, id: eb-ep, cmd: ./run-eb-tests.sh -100 electronproton }
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: zulu
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build_${{ matrix.runner }}
       - name: untar build
@@ -107,17 +107,17 @@ jobs:
     needs: [ build ]
     runs-on: ${{ needs.build.outputs.default_runner }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 11
           distribution: zulu
       - name: setup groovy
-        uses: wtfjoke/setup-groovy@v1
+        uses: wtfjoke/setup-groovy@v2
         with:
           groovy-version: 4.x
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: build_${{ needs.build.outputs.default_runner }}
       - name: untar build
@@ -151,4 +151,4 @@ jobs:
     steps:
       - name: deployment
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Fixes Node.js deprecation warnings (which are starting to appear in other repos).