### PR TITLE
ci: remove validation caller concurrency class

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,10 +7,6 @@ on:
     tags: [ '*' ]
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
-
 jobs:
 
   get_gemc_tag:
@@ -49,5 +45,5 @@ jobs:
     with:
       git_upstream: >-
         {
-          "clas12Tags": { "fork": "gemc/clas12Tags", "branch": "${{ needs.get_gemc_tag.outputs.tag }}" }
+          "clas12Tags": { "fork": "gemc/clas12Tags", "ref": "${{ needs.get_gemc_tag.outputs.tag }}" }
         }


### PR DESCRIPTION
- respect https://github.com/JeffersonLab/clas12-validation/pull/64
  - callers can't override the reusable workflow class, so this PR removes it
- also respect https://github.com/JeffersonLab/clas12-validation/pull/54