### PR TITLE
Helicity improvements

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -43,6 +43,7 @@ Nathan Baltzell <baltzell@jlab.org> <baltzell@LappiAir2.home>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@gmx.com>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@llama.jlab.org>
 Nathan Baltzell <baltzell@jlab.org> <baltzell@baltzellmac.jlab.org>
+Nathan Baltzell <baltzell@jlab.org> <baltzell@macbook-pro.mynetworksettings.com>
 Nathan Harrison <nathanh@jlab.org> <nathan.andrew.harrison@gmail.com>
 Nathan Harrison <nathanh@jlab.org> <harrison@Nathans-MacBook-Air.local>
 Nick Markov <markovnick@gmail.com>

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/RebuildScalers.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import java.util.List;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.detector.calib.utils.RCDBConstants;
+import org.jlab.detector.helicity.HelicitySequence;
 import org.jlab.detector.scalers.DaqScalers;
 import org.jlab.detector.helicity.HelicitySequenceManager;
 import org.jlab.jnp.hipo4.data.Bank;
@@ -155,4 +156,34 @@ public class RebuildScalers {
         }
     }
 
+    /**
+     * Assign the delay-corrected helicity to the HEL::scaler bank's rows
+     * @param timestamp event TI timestamp, e.g., from RUN::config bank
+     * @param bank the HEL::scaler bank
+     * @param seq previously initialized helicity sequence
+     */
+    public static void assignScalerHelicity(Long timestamp, Bank bank, HelicitySequence seq) {
+
+        // Struck (helicity) scaler readout is always slightly after the helicity
+        // state change, i.e., as registered in the FADCs, so its true helicity
+        // is offset by one state from its event:
+        final int readoutStateOffset = -1;
+
+        // Rows in the HEL::scaler bank correspond to the most recent, consecutive,
+        // time-ordered, T-stable intervals.  The first row is the earliest in
+        // time, and the last row is the latest.  Here we loop over them:
+        for (int row=0; row<bank.getRows(); ++row) {
+
+            // This is the helicity state offset for this HEL::scaler row, where
+            // the last row has an offset of -1:
+            final int offset = bank.getRows() - row - 1 + readoutStateOffset;
+
+            // Assign delay-corrected helicity to this HEL::scaler row:
+            bank.putByte("helicity",row,seq.search(timestamp,offset).value());
+            if (seq.getHalfWavePlate())
+                bank.putByte("helicityRaw",0,(byte)(-1*seq.search(timestamp,offset).value()));
+            else
+                bank.putByte("helicityRaw",0,seq.search(timestamp,offset).value());
+        }
+    }
 }

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -70,7 +70,7 @@ public class Tag1ToEvent {
             // Setup event and bank stores:
             Event event = new Event();
             Event configEvent = new Event();
-            Bank runConfigBank = new Bank(writer.getSchemaFactory().getSchema("HEL::scaler"));
+            Bank runConfigBank = new Bank(writer.getSchemaFactory().getSchema("RUN::config"));
             Bank recEventBank = new Bank(writer.getSchemaFactory().getSchema("REC::Event"));
             Bank helScalerBank = new Bank(writer.getSchemaFactory().getSchema("HEL::scaler"));
             Bank helFlipBank = new Bank(writer.getSchemaFactory().getSchema("HEL::flip"));

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -1,7 +1,5 @@
 package org.jlab.analysis.postprocess;
 
-import java.util.ArrayList;
-import java.util.List;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.jnp.hipo4.data.Bank;

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -80,30 +80,31 @@ public class Tag1ToEvent {
             Bank[] configBanks = new Bank[]{new Bank(schema.getSchema(ReconstructionEngine.CONFIG_BANK_NAME))};
 
             // Prepare to read from CCDB:
+            LOGGER.info("\n>>> Initializing helicity configuration from CCDB ...\n");
             ConstantsManager conman = new ConstantsManager();
             conman.init("/runcontrol/hwp","/runcontrol/helicity");
             final int run = getRunNumber(parser.getInputList().get(0));
             IndexedTable helTable = conman.getConstants(run, "/runcontrol/helicity");
  
             // Initialize the scaler sequence from tag-1 events:
-            LOGGER.info(">>> Initializing scaler sequence from RUN/HEL::scaler ...");
+            LOGGER.info("\n>>> Initializing scaler sequence from RUN/HEL::scaler ...\n");
             DaqScalersSequence chargeSeq = DaqScalersSequence.readSequence(parser.getInputList());
 
             // Initialize the helicity sequence:
             HelicitySequenceDelayed helSeq = new HelicitySequenceDelayed(helTable);
             if (doRebuildFlips) {
                 // Read all events in all the files once, to rebuild helicity sequence:
-                LOGGER.info(">>> Rebuilding helicity sequence from HEL::adc ...");
+                LOGGER.info("\n>>> Rebuilding helicity sequence from HEL::adc ...\n");
                 helSeq.addStream(schema, conman, parser.getInputList());
             }
             else {
                 // Just read the helicity sequence from existing HEL::flip banks in tag-1 events:
-                LOGGER.info(">>> Initializing helicity sequence from HEL::flip ...");
+                LOGGER.info("\n>>> Initializing helicity sequence from HEL::flip ...\n");
                 helSeq.initialize(parser.getInputList());
             }
 
             // Loop over the input HIPO files:
-            LOGGER.info(">>> Starting post-processing ...");
+            LOGGER.info("\n>>> Starting post-processing ...\n");
             for (String filename : parser.getInputList()) {
 
                 HipoReader reader = new HipoReader();
@@ -161,7 +162,7 @@ public class Tag1ToEvent {
 
             // Write new HEL::flip banks:
             if (doRebuildFlips) {
-                LOGGER.info(">>> Writing rebuilt HEL::flip banks ...");
+                LOGGER.info("\n>>> Writing rebuilt HEL::flip banks ...\n");
                 helSeq.writeFlips(writer, 1);
             }
         }

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -33,7 +33,6 @@ public class Tag1ToEvent {
 
         DefaultLogger.debug();
 
-
         // Parse command-line options:
         OptionParser parser = new OptionParser("postprocess");
         parser.addOption("-q","0","do beam charge and livetime (0/1=false/true)");
@@ -55,10 +54,10 @@ public class Tag1ToEvent {
             System.exit(1);
         }
 
-        long badCharge;
-        long goodCharge;
-        long badHelicity;
-        long goodHelicity;
+        long badCharge = 0;
+        long goodCharge = 0;
+        long badHelicity = 0;
+        long goodHelicity = 0;
 
         try (HipoWriterSorted writer = new HipoWriterSorted()) {
 
@@ -89,12 +88,6 @@ public class Tag1ToEvent {
 
             // Initialize the scaler sequence:
             DaqScalersSequence chargeSeq = DaqScalersSequence.readSequence(parser.getInputList());
-
-            // Initizlie event counters:
-            badCharge = 0;
-            goodCharge = 0;
-            badHelicity = 0;
-            goodHelicity = 0;
 
             // Loop over the input HIPO files:
             for (String filename : parser.getInputList()) {

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -52,7 +52,6 @@ public class Tag1ToEvent {
         OptionParser parser = new OptionParser("postprocess");
         parser.addOption("-q","0","do beam charge and livetime (0/1=false/true)");
         parser.addOption("-d","0","do delayed helicity (0/1=false/true)");
-        parser.addOption("-f","0","do global offline helicity flip (0/1=false/true)");
         parser.addRequired("-o","output.hipo");
         parser.parse(args);
 
@@ -70,14 +69,13 @@ public class Tag1ToEvent {
         // helicity / beamcharge options:
         final boolean doHelicityDelay = parser.getOption("-d").intValue() != 0;
         final boolean doBeamCharge = parser.getOption("-q").intValue() != 0;
-        final boolean doHelicityFlip = parser.getOption("-f").intValue() != 0;
-        if (!doHelicityDelay && !doBeamCharge && !doHelicityFlip) {
+        if (!doHelicityDelay && !doBeamCharge) {
             parser.printUsage();
-            System.err.println("\n >>>>> error : at least one of -q/-d/-f must be specified\n");
+            System.err.println("\n >>>>> error : at least one of -q/-d must be specified\n");
             System.exit(1);
         }
 
-        HelicitySequenceManager helSeq = new HelicitySequenceManager(8,inputList,doHelicityFlip);
+        HelicitySequenceManager helSeq = new HelicitySequenceManager(8,inputList);
         DaqScalersSequence chargeSeq = DaqScalersSequence.readSequence(inputList);
 
         HipoWriterSorted writer = new HipoWriterSorted();
@@ -131,31 +129,11 @@ public class Tag1ToEvent {
                 if (Math.abs(hb.value())==1) goodHelicity++;
                 else badHelicity++;
 
-                if (doHelicityFlip) {
-
-                    // flip this event's helicity:
-                    hb = HelicityBit.getFlipped(hb);
-                    hbraw = HelicityBit.getFlipped(hbraw);
-                
-                    // flip the helicity in the HEL::flip bank:
-                    if (helFlipBank.getRows()>0) {
-                        event.remove(helFlipBank.getSchema());
-                        helFlipBank.putByte("helicity", 0, (byte)-helFlipBank.getByte("helicity",0));
-                        helFlipBank.putByte("helicityRaw", 0, (byte)-helFlipBank.getByte("helicityRaw",0));
-                        event.write(helFlipBank);
-                    }
-                }
-
                 // write delay-corrected helicty to REC::Event and HEL::scaler:
                 if (doHelicityDelay) {
                     recEventBank.putByte("helicity",0,hb.value());
                     recEventBank.putByte("helicityRaw",0,hbraw.value());
                     RebuildScalers.assignScalerHelicity(event, helScalerBank, helSeq);
-                }
-                // flip the non-delay-corrected helicity in place in REC::Event:
-                else if (doHelicityFlip) {
-                    recEventBank.putByte("helicity",0,(byte)-recEventBank.getByte("helicity",0));
-                    recEventBank.putByte("helicityRaw",0,(byte)-recEventBank.getByte("helicityRaw",0));
                 }
 
                 // write beam charge to REC::Event:

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -739,13 +739,13 @@ public class CLASDecoder4 {
             decoder.detectorDecoder.setTimestamp(parser.getOption("-x").stringValue());
         }
 
+        // Store all helicity readings, ordered by timestamp:
+        TreeSet<HelicityState> helicityReadings = new TreeSet<>();
+
         for(String inputFile : inputList){
             EvioSource reader = new EvioSource();
             reader.open(inputFile);
            
-            // Store all helicity readings, ordered by timestamp:
-            TreeSet<HelicityState> helicityReadings = new TreeSet<>();
-            
             while(reader.hasEvent()==true){
                 EvioDataEvent event = (EvioDataEvent) reader.getNextEvent();
                 
@@ -800,12 +800,11 @@ public class CLASDecoder4 {
                 }
             }
 
-            // add the helicity flips into new tag-1 events:
-            HelicitySequence sequence = new HelicitySequence();
-            sequence.addStream(helicityReadings);
-            sequence.writeFlips(writer, 1);
         }
+
+        // add the helicity flips into new tag-1 events:
+        HelicitySequence.writeFlips(writer, helicityReadings);
+
         writer.close();
-        
     }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardTest.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardTest.java
@@ -55,7 +55,7 @@ public class DecoderBoardTest {
     }
 
     public static void main(String args[]) {
-        DecoderBoardUtil.INVERT_BITS_CHECK = true;
+        DecoderBoardUtil.INVERT_BITS_CHECK = false;
         String filename = "/Users/baltzell/Software/coatjava/iss166+167-eventordering+maurik/clas_019400.evio.00040.hipo";
         HelicitySequenceManager hsm = new HelicitySequenceManager(8, filename);
         try (HipoWriterSorted writer = new HipoWriterSorted()) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardTest.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardTest.java
@@ -55,7 +55,6 @@ public class DecoderBoardTest {
     }
 
     public static void main(String args[]) {
-        DecoderBoardUtil.INVERT_BITS_CHECK = false;
         String filename = "/Users/baltzell/Software/coatjava/iss166+167-eventordering+maurik/clas_019400.evio.00040.hipo";
         HelicitySequenceManager hsm = new HelicitySequenceManager(8, filename);
         try (HipoWriterSorted writer = new HipoWriterSorted()) {
@@ -77,7 +76,7 @@ public class DecoderBoardTest {
                     event.read(config);
                     event.read(online);
                     decoder.copyTo(compare);
-                    compare.putByte("board", 0, (byte)DecoderBoardUtil.getQuartetWindowHelicity(decoder,8));
+                    //compare.putByte("board", 0, DecoderBoardUtil.QUARTET.getWindowHelicity(decoder,8));
                     compare.putByte("online", 0, online.getByte("helicityRaw",0));
                     compare.putByte("offline", 0, hsm.search(event).value());
                     compare.putLong("timestamp", 0, config.getLong("timestamp",0));
@@ -85,7 +84,7 @@ public class DecoderBoardTest {
                     e.write(compare);
                     writer.addEvent(e,event.getEventTag());
                     System.out.println(toString(decoder));
-                    if (!DecoderBoardUtil.checkQuartetAll(decoder)) break;
+                    if (!DecoderBoardUtil.QUARTET.check(decoder)) break;
                     //System.out.println(hsm.search(event));
                     //break;
                 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
@@ -1,176 +1,87 @@
 package org.jlab.detector.helicity;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.jlab.io.base.DataBank;
 import org.jlab.jnp.hipo4.data.Bank;
 
 /**
- * Low-level static methods for delay-correcting and internal error-checking
- * the JLab helicity decoder board. 
- #
- * Note, the sequence bit words from the decoder board are time-ordered, with
- * the latest time being the lowest bit.
- *
+ * Delay correction and integrity checking for the JLab helicity decoder
+ * board's HEL::decoder HIPO bank.
+ * 
  * @author baltzell
  */
-public class DecoderBoardUtil {
+public class DecoderBoardUtil extends SequenceUtil {
 
-    // Number of helicity windows (bits) provided by the decoder board:
-    static final int SEQUENCE_LENGTH = 32;
+    public static final DecoderBoardUtil PAIR = new DecoderBoardUtil((byte)2); 
+    public static final DecoderBoardUtil QUARTET = new DecoderBoardUtil((byte)4); 
+    public static final DecoderBoardUtil OCTET = new DecoderBoardUtil((byte)8); 
 
-    // Register size for the pseudorandom helicity generator:
-    static final int RNG_REGISTER_SIZE = 30;
+    private final byte patternLength;
 
-    // Whether to invert the bits during error-checking:
-    static boolean INVERT_BITS_CHECK = false;
-
-    /**
-     * Window delay correction, only for quartet patterns.
-     * @param b instance of HEL::decoder from the event of interest
-     * @param windowDelay number of windows
-     * @return delay-corrected helicity for the event of interest
-     */
-    public static byte getQuartetWindowHelicity(Bank b, int windowDelay) {
-        return getWindowHelicity(b, windowDelay, (byte)4);
-    }
-
-    /**
-     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
-     * @return whether they're consistent with a good quartet sequence
-     */
-    public static boolean checkQuartetPatterns(int patterns) {
-        return checkPatterns(patterns, (byte)4);
-    }
-
-    /**
-     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
-     * @param helicities the previous SEQUENCE_LENGTH windows of the helicity signal
-     * @return whether the helicities are consistent with a good quartet sequence
-     */
-    public static boolean checkQuartetHelicities(int patterns, int helicities) {
-        return checkHelicities(patterns, helicities, (byte)4);
-    }
-
-    /**
-     * Run all available internal integrity checking on a HEL::decoder bank
-     * @param b the HEL::decoder bank to check
-     * @return whether everything looks good for a quartet configuration
-     */
-    public static boolean checkQuartetAll(Bank b) {
-        return checkAll(b, (byte)4);
+    private DecoderBoardUtil(byte patternLength) {
+        this.patternLength = patternLength; 
     }
 
     /**
      * Window delay correction, for any pattern type.
-     * @param b instance of HEL::decoder from the event of interest
-     * @param windowDelay number of delay windows
-     * @param patternLength numner of windows in the pattern
+     * @param bank instance of HEL::decoder from the event of interest
+     * @param delayWindows number of delay windows
      * @return delay-corrected helicity for the event of interest
      */
-    public static byte getWindowHelicity(Bank b, int windowDelay, byte patternLength) {
-        final int phase = b.getInt("phase",0);
-        final int patternDelay = windowDelay/patternLength;
-        final int windowIndex = (windowDelay+phase)%patternLength;
-        return getWindowHelicity(
-            getPatternHelicity( b.getInt("helicityPArray",0), patternDelay),
-            windowIndex );
+    public int getWindowHelicity(Object bank, byte delayWindows) {
+        final byte phase = (byte)getInt(bank,"phase");
+        final byte patternDelay = (byte)(delayWindows/this.patternLength);
+        final byte windowIndex = (byte)((delayWindows+phase)%this.patternLength);
+        final byte patternHelicity = getPatternHelicity(getInt(bank,"helicityPArray"),patternDelay);
+        return getWindowHelicity(patternHelicity, windowIndex);
     }
 
     /**
-     * Get the expected helicity for one window in a pattern, based on the
-     * first window in that pattern, for any pattern type.
-     * @param firstWindow helicity of the first window in the pattern
-     * @param windowIndex index of the window of interest
-     * @return helicity for the given window
+     * @param bank the HEL::decoder bank to check
+     * @return whether its pattern sequence looks good
      */
-    public static byte getWindowHelicity(int firstWindow, int windowIndex) {
-        return (byte) ( ((windowIndex+1)/2)%2 ^ firstWindow );
+    public boolean checkPatterns(Object bank) {
+        return checkPatterns(
+                getInt(bank,"patternArray"), 
+                this.patternLength);
     }
 
     /**
-     * Pattern delay correction, for any pattern type.
-     * @param helicities the first helicity of the previous SEQUENCE_LENGTH patterns 
-     * @param patternDelay number of patterns
-     * @return delay-corrected helicity of the first window in the pattern 
+     * @param bank the HEL::decoder bank to check
+     * @return whether its helicity sequence looks good
      */
-    public static byte getPatternHelicity(int helicities, int patternDelay) {
-        int bit = 0;
-        int register = 0;
-        for (int i=RNG_REGISTER_SIZE-1; i>=0; --i)
-            register = ( ((helicities>>i)&1) | (register<<1) ) & 0x3FFFFFFF;
-        for (int i=0; i<patternDelay; ++i) {
-            int bit7  = (register>>6)  & 1;
-            int bit28 = (register>>27) & 1;
-            int bit29 = (register>>28) & 1;
-            int bit30 = (register>>29) & 1;
-            bit = (bit30^bit29^bit28^bit7) & 1;
-            register = ( bit | (register<<1) ) & 0x3FFFFFFF;
-        }
-        return (byte)bit;
+    public boolean checkHelicities(Object bank) {
+        return checkHelicities(
+                getInt(bank,"patternArray"), 
+                getInt(bank,"helicityArray"), 
+                this.patternLength);
     }
 
     /**
-     * @param pairs the previous SEQUENCE_LENGTH windows of the pair signal
-     * @return whether they're consistent with a good sequence
-     */
-    public static boolean checkPairs(int pairs) {
-        for (int i=0; i<SEQUENCE_LENGTH-1; ++i) {
-            if ( Integer.bitCount((pairs>>i) & 0x3) != 1) {
-                Logger.getLogger(DecoderBoardUtil.class.getName()).log(Level.WARNING,
-                    "Bad pairs: {0}", pairs);
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
-     * @param patternLength number of windows per pattern
-     * @return whether they're consistent with a good pattern sequence
-     */
-    public static boolean checkPatterns(int patterns, byte patternLength) {
-        final int mask = (1<<patternLength)-1;
-        for (int i=0; i<(SEQUENCE_LENGTH-patternLength+1); ++i) {
-            if (Integer.bitCount((patterns>>i) & mask) != (INVERT_BITS_CHECK?patternLength-1:1)) {
-                return false;
-            }
-        }
-        return true;
-    }
-   
-    /**
-     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
-     * @param helicities the previous SEQUENCE_LENGTH windows of the helicity signal
-     * @param patternLength number of windows per pattern
-     * @return whether the helicities are consistent with a good pattern sequence
-     */
-    public static boolean checkHelicities(int patterns, int helicities, byte patternLength) {
-        for (int i=SEQUENCE_LENGTH-1; i>0; --i) {
-            if ( ((patterns>>i)&1) == (INVERT_BITS_CHECK?0:1) ) {
-                for (int j=1; j<patternLength && i-j>=0; ++j) {
-                    if ( ((helicities>>(i-j))&1) != getWindowHelicity((helicities>>i)&1,j) ) {
-                        Logger.getLogger(DecoderBoardUtil.class.getName()).log(Level.WARNING,
-                            "Bad pattern/helicity: {0}/{1}", new Object[]{patterns, helicities});
-                        return false;
-                    }
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Run all available internal integrity checking on a HEL::decoder bank
-     * @param b the HEL::decoder bank to check
-     * @param patternLength number of windows per pattern
+     * Run all available integrity checking on a HEL::decoder bank
+     * @param bank the HEL::decoder bank to check
      * @return whether everything looks good 
      */
-    public static boolean checkAll(Bank b, byte patternLength) {
-        boolean x = checkPairs(b.getInt("pairArray",0));
-        boolean y = checkPatterns(b.getInt("patternArray",0), patternLength);
-        boolean z = checkHelicities(b.getInt("patternArray",0), b.getInt("helicityArray",0), patternLength);
-        return x && y && z;
+    public boolean check(Object bank) {
+        return check(
+            getInt(bank,"pairArray"),
+            getInt(bank,"patternArray"),
+            getInt(bank,"helicityArray"),
+            this.patternLength);
+    }
+
+    /**
+     * Wrap different types of HIPO banks.
+     * @param bank the HEL::decoder bank to access
+     * @param name name of its variable to get
+     * @return value of the bank variable
+     */
+    private static int getInt(Object bank, String name) {
+        if (bank instanceof DataBank)
+            return ((DataBank)bank).getInt(name,0);
+        else if (bank instanceof Bank)
+            return ((Bank)bank).getInt(name,0);
+        else
+            throw new IllegalArgumentException();
     }
 
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
@@ -68,9 +68,12 @@ public class DecoderBoardUtil {
      * @return delay-corrected helicity for the event of interest
      */
     public static byte getWindowHelicity(Bank b, int windowDelay, byte patternLength) {
+        final int phase = b.getInt("phase",0);
+        final int patternDelay = windowDelay/patternLength;
+        final int windowIndex = (windowDelay+phase)%patternLength;
         return getWindowHelicity(
-            getPatternHelicity( b.getInt("helicityPArray",0), windowDelay/patternLength),
-            windowDelay%patternLength );
+            getPatternHelicity( b.getInt("helicityPArray",0), patternDelay),
+            windowIndex );
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/DecoderBoardUtil.java
@@ -4,8 +4,11 @@ import org.jlab.io.base.DataBank;
 import org.jlab.jnp.hipo4.data.Bank;
 
 /**
- * Delay correction and integrity checking for the JLab helicity decoder
- * board's HEL::decoder HIPO bank.
+ * Delay correction and integrity checking for the JLab helicity decoder board's
+ * HEL::decoder HIPO bank.
+ * 
+ * NOTE:  To avoid repetition, generic objects are used to support different
+ * types of HIPO banks.
  * 
  * @author baltzell
  */
@@ -75,7 +78,7 @@ public class DecoderBoardUtil extends SequenceUtil {
      * @param name name of its variable to get
      * @return value of the bank variable
      */
-    private static int getInt(Object bank, String name) {
+    private int getInt(Object bank, String name) {
         if (bank instanceof DataBank)
             return ((DataBank)bank).getInt(name,0);
         else if (bank instanceof Bank)

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
@@ -283,9 +283,9 @@ public final class HelicityGenerator implements Comparable<HelicityGenerator>, C
                         this.timestamp += timestamps.get(kk);
                     }
                     this.timestamp /= timestamps.size();
-                    LOGGER.log(Level.INFO, "raw timestamps:  {0}", timestampsRaw);
-                    LOGGER.log(Level.INFO, "timestamps:      {0}", timestamps);
-                    LOGGER.log(Level.INFO, "modulo-corrected timestamp:  {0}", this.timestamp);
+                    LOGGER.log(Level.FINE, "raw timestamps:  {0}", timestampsRaw);
+                    LOGGER.log(Level.FINE, "timestamps:      {0}", timestamps);
+                    LOGGER.log(Level.FINE, "modulo-corrected timestamp:  {0}", this.timestamp);
                     break;
                 }
 
@@ -303,7 +303,7 @@ public final class HelicityGenerator implements Comparable<HelicityGenerator>, C
                     double corr=(jj-this.offset)/this.clock*HelicitySequence.TIMESTAMP_CLOCK;
                     timestamps.add(timeStamp-corr);
                     timestampsRaw.add((double)timeStamp);
-                    LOGGER.info(String.format("HelicityGenerator:  timestamp = %d/%.1f/%.2f",
+                    LOGGER.fine(String.format("HelicityGenerator:  timestamp = %d/%.1f/%.2f",
                                 timeStamp,corr,timeStamp-corr));
                 }
             }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPattern.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityPattern.java
@@ -17,7 +17,7 @@ public enum HelicityPattern {
 
     private final int value;
 
-    HelicityPattern(int value) {
+    private HelicityPattern(int value) {
         this.value=value;
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -552,4 +552,15 @@ public class HelicitySequence {
         }
     }
 
+    /**
+     * Write all state changes from a stream into new HEL::flip banks in new,
+     * tagged events
+     * @param writer
+     * @param stream 
+     */
+    public static void writeFlips(HipoWriterSorted writer, TreeSet<HelicityState> stream) {
+        HelicitySequence sequence = new HelicitySequence();
+        sequence.addStream(stream);
+        sequence.writeFlips(writer, 1);
+    }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.detector.calib.utils.ConstantsManager;
 
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.Event;
@@ -522,6 +523,25 @@ public class HelicitySequence {
         }
         LOGGER.log(Level.INFO, "found {0} helicity sequence states in stream.", this.size());
         this.integrityCheck();
+    }
+
+    public void addStream(SchemaFactory schema, ConstantsManager conman, List<String> filenames) {
+        Bank runConfigBank = new Bank(schema.getSchema("HEL::scaler"));
+        Bank helAdcBank = new Bank(schema.getSchema("HEL::adc"));
+        TreeSet<HelicityState> stream = new TreeSet<>();
+        Event e = new Event();
+        for (String filename : filenames) {
+            HipoReader r = new HipoReader();
+            r.open(filename);
+            while (r.hasNext()) {
+                r.nextEvent(e);
+                e.read(helAdcBank);
+                e.read(runConfigBank);
+                stream.add(HelicityState.createFromFadcBank(
+                        helAdcBank, runConfigBank,conman));
+            }
+        }
+        this.addStream(stream);
     }
 
     /**

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -526,7 +526,7 @@ public class HelicitySequence {
     }
 
     public void addStream(SchemaFactory schema, ConstantsManager conman, List<String> filenames) {
-        Bank runConfigBank = new Bank(schema.getSchema("HEL::scaler"));
+        Bank runConfigBank = new Bank(schema.getSchema("RUN::config"));
         Bank helAdcBank = new Bank(schema.getSchema("HEL::adc"));
         TreeSet<HelicityState> stream = new TreeSet<>();
         Event e = new Event();

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/SequenceUtil.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/SequenceUtil.java
@@ -4,11 +4,12 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
- * Low-level static methods for delay-correcting and integrity-checking
- * the sequences of the helicity signals, based on basic pattern properties
+ * Low-level, static methods for delay-correcting and integrity-checking the bit
+ * sequences of the JLab helicity signals, based only on basic pattern properties
  * and the pseudorandom generator.
  * 
- * Note, these methods require time-ordered bit sequence integers as inputs,
+ * NOTE:  These methods require time-ordered bit sequence integers as inputs and
+ * are independent of pattern type.
  * 
  * @author baltzell
  */
@@ -17,14 +18,14 @@ public class SequenceUtil {
     // Register size for the pseudorandom helicity generator:
     static final int RNG_REGISTER_SIZE = 30;
 
-    // Number of bits of input helicity windows (32 for the decoder board):
+    // Number of wondows/bits in input sequences:
     static int SEQUENCE_LENGTH = 32;
 
     // Whether to invert the bits during error-checking, for debugging:
     static boolean INVERT_BITS_CHECK = false;
 
     /**
-     * Pattern delay correction.
+     * Pattern delay correction, as specified by JLab's injector group.
      * @param helicities the first helicity of the previous SEQUENCE_LENGTH patterns 
      * @param patternDelay number of patterns
      * @return delay-corrected helicity of the first window in the pattern 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/SequenceUtil.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/SequenceUtil.java
@@ -1,0 +1,126 @@
+package org.jlab.detector.helicity;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Low-level static methods for delay-correcting and integrity-checking
+ * the sequences of the helicity signals, based on basic pattern properties
+ * and the pseudorandom generator.
+ * 
+ * Note, these methods require time-ordered bit sequence integers as inputs,
+ * 
+ * @author baltzell
+ */
+public class SequenceUtil {
+
+    // Register size for the pseudorandom helicity generator:
+    static final int RNG_REGISTER_SIZE = 30;
+
+    // Number of bits of input helicity windows (32 for the decoder board):
+    static int SEQUENCE_LENGTH = 32;
+
+    // Whether to invert the bits during error-checking, for debugging:
+    static boolean INVERT_BITS_CHECK = false;
+
+    /**
+     * Pattern delay correction.
+     * @param helicities the first helicity of the previous SEQUENCE_LENGTH patterns 
+     * @param patternDelay number of patterns
+     * @return delay-corrected helicity of the first window in the pattern 
+     */
+    public static byte getPatternHelicity(int helicities, byte patternDelay) {
+        int bit = 0;
+        int register = 0;
+        for (int i=RNG_REGISTER_SIZE-1; i>=0; --i)
+            register = ( ((helicities>>i)&1) | (register<<1) ) & 0x3FFFFFFF;
+        for (int i=0; i<patternDelay; ++i) {
+            int bit7  = (register>>6)  & 1;
+            int bit28 = (register>>27) & 1;
+            int bit29 = (register>>28) & 1;
+            int bit30 = (register>>29) & 1;
+            bit = (bit30^bit29^bit28^bit7) & 1;
+            register = ( bit | (register<<1) ) & 0x3FFFFFFF;
+        }
+        return (byte)bit;
+    }
+
+    /**
+     * Get the expected helicity for one window in a pattern, based on the
+     * first window in that pattern.
+     * @param firstWindow helicity of the first window in the pattern
+     * @param windowIndex index of the window of interest
+     * @return helicity for the given window
+     */
+    public static byte getWindowHelicity(byte firstWindow, byte windowIndex) {
+        return (byte) ( ((windowIndex+1)/2)%2 ^ firstWindow );
+    }
+
+    /**
+     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
+     * @param helicities the previous SEQUENCE_LENGTH windows of the helicity signal
+     * @param patternLength number of windows per pattern
+     * @return whether the helicities are consistent with a good pattern sequence
+     */
+    public static boolean checkHelicities(int patterns, int helicities, byte patternLength) {
+        for (int i=SequenceUtil.SEQUENCE_LENGTH-1; i>0; --i) {
+            if ( ((patterns>>i)&1) == (SequenceUtil.INVERT_BITS_CHECK?0:1) ) {
+                for (int j=1; j<patternLength && i-j>=0; ++j) {
+                    if ( ((helicities>>(i-j))&1) != 
+                            SequenceUtil.getWindowHelicity((byte)((helicities>>i)&1),(byte)j) ) {
+                        Logger.getLogger(SequenceUtil.class.getName()).log(Level.WARNING,
+                            "Bad pattern/helicity: {0}/{1}", new Object[]{patterns, helicities});
+                        return false;
+                    }
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param pairs the previous SEQUENCE_LENGTH windows of the pair signal
+     * @return whether they're consistent with a good sequence
+     */
+    public static boolean checkPairs(int pairs) {
+        for (int i=0; i<SEQUENCE_LENGTH-1; ++i) {
+            if ( Integer.bitCount((pairs>>i) & 0x3) != 1) {
+                Logger.getLogger(SequenceUtil.class.getName()).log(Level.WARNING,
+                    "Bad pairs: {0}", pairs);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
+     * @param patternLength number of windows per pattern
+     * @return whether they're consistent with a good pattern sequence
+     */
+    public static boolean checkPatterns(int patterns, byte patternLength) {
+        final int mask = (1<<patternLength)-1;
+        for (int i=0; i<(SEQUENCE_LENGTH-patternLength+1); ++i) {
+            if (Integer.bitCount((patterns>>i) & mask) != (INVERT_BITS_CHECK?patternLength-1:1)) {
+                Logger.getLogger(SequenceUtil.class.getName()).log(Level.WARNING,
+                    "Bad patterns: {0}", patterns);
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * @param pairs the previous SEQUENCE_LENGTH windows of the pair signal
+     * @param patterns the previous SEQUENCE_LENGTH windows of the pattern signal
+     * @param helicities the previous SEQUENCE_LENGTH windows of the helicity signal
+     * @param patternLength number of windows per pattern
+     * @return whether everything looks good 
+     */
+    public static boolean check(int pairs, int patterns, int helicities, byte patternLength) {
+        boolean x = checkPairs(pairs);
+        boolean y = checkPatterns(patterns, patternLength);
+        boolean z = checkHelicities(patterns, helicities, patternLength);
+        return x && y && z;
+    }
+}

--- a/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataBank.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataBank.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.jlab.io.hipo;
 
 import javax.swing.table.TableModel;
@@ -28,34 +23,14 @@ public class HipoDataBank implements DataBank  {
     
     public HipoDataBank(HipoDataDescriptor desc, int size){        
         hipoGroup = new Bank( desc.getSchema(),size);
-        //Map<Integer,HipoNode>  nodes = desc.getSchema();
         this.descriptor = desc;
-        //hipoGroup = new HipoGroup(nodes,this.descriptor.getSchema());
     }
-    /*
-    public HipoDataBank(Map<Integer,HipoNode> nodes, Schema desc){
-        descriptor = new HipoDataDescriptor();
-        descriptor.init(desc);
-        hipoGroup = new HipoGroup(nodes,this.descriptor.getSchema());
-    }
-    
-    public HipoDataBank(HipoGroup group){
-        this.hipoGroup = group;
-        descriptor = new HipoDataDescriptor();
-        descriptor.init(this.hipoGroup.getSchema());
-    }
-    */
     
     public Bank getBank(){
         return hipoGroup;
     }
     
-    /*public HipoGroup getGroup(){
-        return this.hipoGroup;
-    }*/
-    
     public String[] getColumnList() {
-
         String[] columns = new String[descriptor.getSchema().getElements()];
         for(int i = 0; i < columns.length; i++) columns[i] = descriptor.getSchema().getElementName(i);
         return columns;
@@ -71,28 +46,23 @@ public class HipoDataBank implements DataBank  {
         double[] result = new double[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getDouble(path, i);
         return result;
-        //return this.hipoGroup.getNode(path).getDouble();
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     @Override
     public double getDouble(String path, int index) {
         return this.hipoGroup.getDouble(path, index);
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public void setDouble(String path, double[] arr) {
-        //this.getNode(path).setDouble(index, value);
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setDouble(String path, int row, double value) {
         hipoGroup.putDouble(path,row,value);
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public void appendDouble(String path, double[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public float[] getFloat(String path) {
@@ -100,8 +70,6 @@ public class HipoDataBank implements DataBank  {
         float[] result = new float[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getFloat(path, i);
         return result;
-        //return this.hipoGroup.getNode(path).getFloat();
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public float getFloat(String path, int index) {
@@ -109,7 +77,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void setFloat(String path, float[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setFloat(String path, int row, float value) {
@@ -117,7 +85,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void appendFloat(String path, float[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public int[] getInt(String path) {
@@ -125,8 +93,6 @@ public class HipoDataBank implements DataBank  {
         int[] result = new int[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getInt(path, i);
         return result;
-        //return this.getGroup().getNode(path).getInt();
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public int getInt(String path, int index) {
@@ -134,7 +100,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void setInt(String path, int[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setInt(String path, int row, int value) {
@@ -142,7 +108,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void appendInt(String path, int[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public short[] getShort(String path) {
@@ -150,8 +116,6 @@ public class HipoDataBank implements DataBank  {
         short[] result = new short[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getShort(path, i);
         return result;
-        //return this.hipoGroup.getNode(path).getShort();
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public short getShort(String path, int index) {
@@ -159,7 +123,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void setShort(String path, short[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setShort(String path, int row, short value) {
@@ -167,7 +131,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void appendShort(String path, short[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public long[] getLong(String path) {
@@ -175,7 +139,6 @@ public class HipoDataBank implements DataBank  {
         long[] result = new long[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getLong(path, i);
         return result;
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public long getLong(String path, int index) {
@@ -183,7 +146,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void setLong(String path, long[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setLong(String path, int row, long value) {
@@ -191,7 +154,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void appendLong(String path, long[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
     
     public byte[] getByte(String path) {
@@ -199,8 +162,6 @@ public class HipoDataBank implements DataBank  {
         byte[] result = new byte[nrows];
         for(int i = 0; i < nrows; i++) result[i] = hipoGroup.getByte(path, i);
         return result;
-        //return this.hipoGroup.getNode(path).getByte();
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
     }
 
     public byte getByte(String path, int index) {
@@ -208,7 +169,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void setByte(String path, byte[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public void setByte(String path, int row, byte value) {
@@ -216,7 +177,7 @@ public class HipoDataBank implements DataBank  {
     }
 
     public void appendByte(String path, byte[] arr) {
-        throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     public int columns() {

--- a/etc/bankdefs/hipo4/data.json
+++ b/etc/bankdefs/hipo4/data.json
@@ -444,6 +444,38 @@
       ]
   },
   {
+      "name": "ahel",
+      "group": 22000,
+      "item":  15,
+      "info": "Helicity decoder board data",
+      "entries":[
+          {"name":"offline",        "type":"B", "info":"HELICITY"},
+          {"name":"online",        "type":"B", "info":"HELICITY"},
+          {"name":"board",        "type":"B", "info":"HELICITY"},
+          {"name":"helicity",        "type":"B", "info":"HELICITY"},
+          {"name":"pair",            "type":"B", "info":"PAIR_SYNC"},
+          {"name":"pattern",         "type":"B", "info":"PATTERN_SYNC"},
+          {"name":"tSettle",         "type":"B", "info":"T_SETTLE"},
+          {"name":"helicityPattern", "type":"B", "info":"HELICITY at pattern start"},
+          {"name":"polarity",        "type":"B", "info":"event polarity (XOR of 3,4)"},
+          {"name":"phase",           "type":"B", "info":"pattern phase count"},
+          {"name":"timestamp",       "type":"L", "info":"timestamp (4ns)"},
+          {"name":"helicitySeed",    "type":"I", "info":"helicity seed"},
+          {"name":"nTStableRE",      "type":"I", "info":"count of T_STABLE rising edge"},
+          {"name":"nTStableFE",      "type":"I", "info":"count of T_STABLE falling edge"},
+          {"name":"nPattern",        "type":"I", "info":"count of PATTERN_SYNC"},
+          {"name":"nPair",           "type":"I", "info":"count of PAIR_SYNC"},
+          {"name":"tStableStart",    "type":"I", "info":"time of trigger since start of T_STABLE (8 ns"},
+          {"name":"tStableEnd",      "type":"I", "info":"time of trigger since end of T_STABLE (8 ns"},
+          {"name":"tStableTime",     "type":"I", "info":"time duration of last complete T_STABLE period (8 ns"},
+          {"name":"tSettleTime",     "type":"I", "info":"time duration of last complete T_SETTLE period (8 ns"},
+          {"name":"patternArray",    "type":"I", "info":"last 32 windows of PATTERN_SYNC"},
+          {"name":"pairArray",       "type":"I", "info":"last 32 windows of PAIR_SYNC"},
+          {"name":"helicityArray",   "type":"I", "info":"last 32 windows of HELICITY_STATE"},
+          {"name":"helicityPArray",  "type":"I", "info":"last 32 windows of HELICITY_STATE at start of pattern"}
+      ]
+  },
+  {
     "name" : "BAND::adc",
     "group": 22100,
     "item" : 11,

--- a/etc/bankdefs/hipo4/data.json
+++ b/etc/bankdefs/hipo4/data.json
@@ -444,38 +444,6 @@
       ]
   },
   {
-      "name": "ahel",
-      "group": 22000,
-      "item":  15,
-      "info": "Helicity decoder board data",
-      "entries":[
-          {"name":"offline",        "type":"B", "info":"HELICITY"},
-          {"name":"online",        "type":"B", "info":"HELICITY"},
-          {"name":"board",        "type":"B", "info":"HELICITY"},
-          {"name":"helicity",        "type":"B", "info":"HELICITY"},
-          {"name":"pair",            "type":"B", "info":"PAIR_SYNC"},
-          {"name":"pattern",         "type":"B", "info":"PATTERN_SYNC"},
-          {"name":"tSettle",         "type":"B", "info":"T_SETTLE"},
-          {"name":"helicityPattern", "type":"B", "info":"HELICITY at pattern start"},
-          {"name":"polarity",        "type":"B", "info":"event polarity (XOR of 3,4)"},
-          {"name":"phase",           "type":"B", "info":"pattern phase count"},
-          {"name":"timestamp",       "type":"L", "info":"timestamp (4ns)"},
-          {"name":"helicitySeed",    "type":"I", "info":"helicity seed"},
-          {"name":"nTStableRE",      "type":"I", "info":"count of T_STABLE rising edge"},
-          {"name":"nTStableFE",      "type":"I", "info":"count of T_STABLE falling edge"},
-          {"name":"nPattern",        "type":"I", "info":"count of PATTERN_SYNC"},
-          {"name":"nPair",           "type":"I", "info":"count of PAIR_SYNC"},
-          {"name":"tStableStart",    "type":"I", "info":"time of trigger since start of T_STABLE (8 ns"},
-          {"name":"tStableEnd",      "type":"I", "info":"time of trigger since end of T_STABLE (8 ns"},
-          {"name":"tStableTime",     "type":"I", "info":"time duration of last complete T_STABLE period (8 ns"},
-          {"name":"tSettleTime",     "type":"I", "info":"time duration of last complete T_SETTLE period (8 ns"},
-          {"name":"patternArray",    "type":"I", "info":"last 32 windows of PATTERN_SYNC"},
-          {"name":"pairArray",       "type":"I", "info":"last 32 windows of PAIR_SYNC"},
-          {"name":"helicityArray",   "type":"I", "info":"last 32 windows of HELICITY_STATE"},
-          {"name":"helicityPArray",  "type":"I", "info":"last 32 windows of HELICITY_STATE at start of pattern"}
-      ]
-  },
-  {
     "name" : "BAND::adc",
     "group": 22100,
     "item" : 11,


### PR DESCRIPTION
* bugfix on new decoder board delay correction
* treat all input files as one for helicity state change detection during decoding
* post-processing
  * enable helicity state change detection during post-processing, rebuilding all HEL::flip banks
  * remove the option to flip the helicity during post-processing, never used
  * initialize all helicity parameters from CCDB (removing hardcoded delay=8)
* various cleanup and convenience methods