### PR TITLE
fix rotation of pixel map to follow sector

### DIFF
--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHGeoCalibration.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHGeoCalibration.java
@@ -89,7 +89,7 @@ public class RICHGeoCalibration {
 
                 if((debugMode>=1 || geopar.DEBUG_GEO_CONSTS>=1) && ncalls<Math.max(1,geopar.DEBUG_GEO_CONSTS)) {
                         System.out.format("------------------------------------------------------------- \n");
-                        System.out.format("RICH: Load ALI Calibration from local TxT file for RICH 4d  sector %4d  run %6d \n", irich, isec, run);
+                        System.out.format("RICH: Load ALI Calibration from local TxT file for RICH %4d  sector %4d  run %6d \n", irich, isec, run);
                         System.out.format("------------------------------------------------------------- \n");
 
                         dump_AliCalibration(isec, "TXT  ");
@@ -102,7 +102,7 @@ public class RICHGeoCalibration {
 
                 if((debugMode>=1 || geopar.DEBUG_GEO_CONSTS>=1) && ncalls<=Math.max(1,geopar.DEBUG_GEO_CONSTS)) {
                         System.out.format("------------------------------------------------------------- \n");
-                        System.out.format("RICH: Load AER Calibration from local TxT file for RICH 4d  sector %4d  run %6d \n", irich, isec, run);
+                        System.out.format("RICH: Load AER Calibration from local TxT file for RICH %4d  sector %4d  run %6d \n", irich, isec, run);
                         System.out.format("------------------------------------------------------------- \n");
 
                         dump_AerCalibration(isec, "TXT  ");

--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHGeoFactory.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHGeoFactory.java
@@ -38,7 +38,6 @@ public class RICHGeoFactory{
 
     private RICHGeant4Factory richfactory = new RICHGeant4Factory();
     private RICHPixelMap pixelmap = new RICHPixelMap();
-    private RICHPixel pmtpixels  = null; 
     private RICHGeoParameters    geopar  = new RICHGeoParameters();
     private RICHGeoCalibration   geocal  = new RICHGeoCalibration();
 
@@ -87,7 +86,7 @@ public class RICHGeoFactory{
         geocal.load_CCDB(manager, run, Ncalls, geopar);
 
         if(FactoryMode>0){
-            // global pixel coordinate indexes
+            // global pixel coordinate indexes (obsolete)
             pixelmap.init_GlobalPixelGeo();
 
             // RICH survey (obsolete)
@@ -577,15 +576,16 @@ public class RICHGeoFactory{
 
 
     //------------------------------
-    public Vector3d GetPixelCenter(int ipmt, int anode){
+    /*public Vector3d GetPixelCenter(int ipmt, int anode){
     //------------------------------
 
+        // obsolete as refers to un-aligned richfactory
         Vector3d Vertex = richfactory.GetPhotocatode(ipmt).getVertex(2);
         Vector3d VPixel = Vertex.plus(pmtpixels.GetPixelCenter(anode));
         //System.out.format("Std  vtx %8.3f %8.3f %8.3f \n",Vertex.x, Vertex.y, Vertex.z);
         return new Vector3d (VPixel.x, -VPixel.y, VPixel.z);
 
-    }
+    }*/
 
 
     //------------------------------
@@ -598,7 +598,7 @@ public class RICHGeoFactory{
             Face3D compo_face = get_Layer(isec, ilay).get_CompoFace(ipmt-1, 0);
             Vector3d Vertex = toVector3d( compo_face.point(1) );
         
-            Vector3d VPixel = Vertex.plus(pmtpixels.GetPixelCenter(anode));
+            Vector3d VPixel = Vertex.plus(get_Layer(isec, ilay).get_PMTPixels().GetPixelCenter(anode));
             return new Point3D (VPixel.x, -VPixel.y, VPixel.z);
         }
 
@@ -1347,7 +1347,8 @@ public class RICHGeoFactory{
             }
 
             if(downversor!=null && rightversor!= null) {
-                pmtpixels = new RICHPixel(new Vector3d(0.,0.,0.), downversor, rightversor);
+                RICHPixel pmtpixels = new RICHPixel(new Vector3d(0.,0.,0.), downversor, rightversor);
+                layer.set_PMTPixels(pmtpixels);
                 if(debugMode>=1){
                     pmtpixels.show_Pixels( vertex );
                     vertex = toVector3d( layer.get_CompoFace(5,0).point(1) );

--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHLayer.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geom/RICH/RICHLayer.java
@@ -42,6 +42,7 @@ public class RICHLayer extends ArrayList<RICHComponent> {
     private ArrayList<Integer> compo_list          = new ArrayList<Integer>();
     
     private RICHFrame local_frame = new RICHFrame();
+    private RICHPixel pmtpixels   = null;
 
 
     // ----------------
@@ -99,6 +100,14 @@ public class RICHLayer extends ArrayList<RICHComponent> {
     public int get_size() { return this.size(); }
     // ----------------
 
+    // ----------------
+    public void set_PMTPixels(RICHPixel pmtpixels){ this.pmtpixels = pmtpixels;}
+    // ----------------
+  
+    // ----------------
+    public RICHPixel get_PMTPixels(){ return this.pmtpixels;}
+    // ----------------
+  
     // ----------------
     public Shape3D get_TrackingSurf() { 
     // ----------------


### PR DESCRIPTION
The pmtpixels description of pixel geometry is stored in RICHLayer to be part of the sector and rotate with it. Before was unique and inconsistent for different sectors. 