### PR TITLE
Fix data bank name in AHDCengine

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
@@ -69,7 +69,8 @@ public class AHDCEngine extends ReconstructionEngine {
 
 		magfield = 50 * magfieldfactor;
 
-		if (event.hasBank("AHDC::tdc")) {
+		//if (event.hasBank("AHDC::tdc")) {
+		if (event.hasBank("AHDC::adc")) {
 
 			// I) Read raw hit
 			HitReader hitRead = new HitReader(event, simulation);


### PR DESCRIPTION
Fixed the data bank name in AHDCengine from AHDC::tdc to AHDC::adc (which is used by the corresponding hit reader)