### PR TITLE
fix(ci): latest v4 `groovy` 4.0.19 has been silently failing; regress to 4.0.3, the `ifarm` version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -16,6 +16,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  java_version: 11
+  java_distribution: zulu
+  groovy_version: 4.x
+
 jobs:
 
   # build
@@ -36,8 +41,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: zulu
+          java-version: ${{ env.java_version }}
+          distribution: ${{ env.java_distribution }}
       - name: build
         run: ./build-coatjava.sh --spotbugs --unittests --quiet -T4
       - name: tar # tarball to preserve permissions
@@ -90,8 +95,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: zulu
+          java-version: ${{ env.java_version }}
+          distribution: ${{ env.java_distribution }}
       - uses: actions/download-artifact@v4
         with:
           name: build_${{ matrix.runner }}
@@ -111,12 +116,12 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
-          distribution: zulu
+          java-version: ${{ env.java_version }}
+          distribution: ${{ env.java_distribution }}
       - name: setup groovy
         uses: wtfjoke/setup-groovy@v2
         with:
-          groovy-version: 4.x
+          groovy-version: ${{ env.groovy_version }}
       - uses: actions/download-artifact@v4
         with:
           name: build_${{ needs.build.outputs.default_runner }}

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -19,7 +19,7 @@ concurrency:
 env:
   java_version: 11
   java_distribution: zulu
-  groovy_version: 4.x
+  groovy_version: 4.0.3
 
 jobs:
 


### PR DESCRIPTION
running even just `groovy --version` returns the following, and exits 0
```
java.lang.NoClassDefFoundError: picocli/CommandLine$ParameterException
	at java.base/java.lang.Class.getDeclaredMethods0(Native Method)
	at java.base/java.lang.Class.privateGetDeclaredMethods(Class.java:3166)
	at java.base/java.lang.Class.getMethodsRecursive(Class.java:3307)
	at java.base/java.lang.Class.getMethod0(Class.java:3293)
	at java.base/java.lang.Class.getMethod(Class.java:2106)
	at org.codehaus.groovy.tools.GroovyStarter.rootLoader(GroovyStarter.java:110)
	at org.codehaus.groovy.tools.GroovyStarter.main(GroovyStarter.java:37)
Caused by: java.lang.ClassNotFoundException: picocli.CommandLine$ParameterException
	at org.codehaus.groovy.tools.RootLoader.findClass(RootLoader.java:180)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
	at org.codehaus.groovy.tools.RootLoader.loadClass(RootLoader.java:148)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
	... 7 more
```
This PR sets the `groovy` version to 4.0.3 in the `maven.yml` workflow, to match the version on `ifarm`.