### PR TITLE
fix: Nonsensical self computation of `n` with itself in `HelixFitJava`

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/HelixFit/HelixFitJava.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/HelixFit/HelixFitJava.java
@@ -56,7 +56,7 @@ public class HelixFitJava {
 
 
 	    // --------- Loop begins ----------
-	    nrank = n - ni;
+	    nrank = 0;
 	    
 	    for (i=1; i<=ni; i++)
 	    {

--- a/reconstruction/rtpc/src/main/java/org/jlab/rec/rtpc/hit/HelixFitJava.java
+++ b/reconstruction/rtpc/src/main/java/org/jlab/rec/rtpc/hit/HelixFitJava.java
@@ -58,7 +58,7 @@ public class HelixFitJava {
 
 
 	    // --------- Loop begins ----------
-	    nrank = n - ni;
+	    nrank = 0;
 	    
 	    for (i=1; i<=ni; i++)
 	    {


### PR DESCRIPTION
Fixes a "bug" spotted by the new `spotbugs-maven-plugin` version in https://github.com/JeffersonLab/coatjava/pull/209