### PR TITLE
feat: `CODEOWNERS` file

### DIFF
--- a/.github/codeowners/README.md
+++ b/.github/codeowners/README.md
@@ -1,0 +1,5 @@
+This directory contains automation that helped us generate the [`CODEOWNERS`](/CODEOWNERS) file.
+
+- `main_dirs.txt` is a list of the "main" directories for which we want a list of code owners; this was generated with `find -d`, and manually choosing the "main" directories
+- `generate-codeowners.rb` reads `main_dirs.txt` and uses `git` logs to find the unique set of authors for all of the files within each directory; it then writes a new `CODEOWNERS` file
+- finally, we go through the `CODEOWNERS` file manually to decide which contributors to keep; those contributors will be notified in PR reviews, so for example we may not want to include contributors who are not involved in the project any more

--- a/.github/codeowners/generate-codeowners.rb
+++ b/.github/codeowners/generate-codeowners.rb
@@ -1,0 +1,107 @@
+#!/usr/bin/env ruby
+# run this script from the TOP level directory
+
+GithubHandles = {
+  '<Adam Hobart>'            => 'ajhobart',
+  '<Alessandra Filippi>'     => 'afilippi67',
+  '<Andrey Kim>'             => 'drewkenjo',
+  '<Blake Huck>'             => 'huckb',
+  '<Bruno Benkel>'           => 'bleaktwig',
+  '<Christopher Dilks>'      => 'c-dilks',
+  '<Cole Smith>'             => 'forcar',
+  '<Connor Pecar>'           => 'cpecar',
+  '<David Heddle>'           => 'heddle',
+  '<David Payette>'          => 'dpayette',
+  '<Efrain Patrick Segarra>' => '',
+  '<Efrain Segarra>'         => '',
+  '<Florian Hauenstein>'     => 'hauenst',
+  '<Francesco Bossu>'        => 'fbossu',
+  '<Francois-Xavier Girod>'  => 'fxgirod',
+  '<Gagik Gavalian>'         => 'gavalian',
+  '<Giovanni Angelini>'      => 'gangel85',
+  '<Guillaume Christiaens>'  => 'Guillaum-C',
+  '<Joseph Newton>'          => 'josnewton',
+  '<Justin Goodwill>'        => '',
+  '<L Smith>'                => 'forcar',
+  '<Latif Kabir>'            => 'latifkabir',
+  '<Marco Contalbrigo>'      => 'mcontalb',
+  '<Mathieu Ouillon>'        => 'mathieuouillon',
+  '<Maurik Holtrop>'         => 'mholtrop',
+  '<Maxime Defurne>'         => 'mdefurne',
+  '<Michael Hoffer>'         => 'miho',
+  '<Nathan Baltzell>'        => 'baltzell',
+  '<Nathan Harrison>'        => 'naharrison',
+  '<Nick Markov>'            => 'markovnick',
+  '<Noemie Pilleux-LOCAL>'   => 'N-Plx',
+  '<Peter EJ Davies>'        => '',
+  '<Pierre Chatagnon>'       => 'PChatagnon',
+  '<Rafayel Paremuzyan>'     => 'rafopar',
+  '<Raffaella De Vita>'      => 'raffaelladevita',
+  '<Reynier Cruz Torres>'    => '',
+  '<Rong Wang>'              => '',
+  '<Silvia Nicolai>'         => '',
+  '<Sylvester Joosten>'      => 'sly2j',
+  '<Tongtong Cao>'           => 'tongtongcao',
+  '<Vardan Gyurjyan>'        => 'gurjyan',
+  '<Veronique Ziegler>'      => 'zieglerv',
+  '<ajhobart>'               => 'ajhobart',
+  '<colesmith>'              => 'forcar',
+  '<cqplatt>'                => 'cqplatt',
+  '<dcpayette>'              => 'dcpayette',
+  '<dependabot[bot]>'        => '',
+  '<efuchey>'                => 'efuchey',
+  '<hattawy>'                => 'Hattawy',
+  '<huckb>'                  => 'huckb',
+  '<jwgibbs>'                => 'jwgibbs',
+  '<mariangela-bondi>'       => 'mariangela-bondi',
+  '<marmstr4>'               => 'marmstr4',
+  '<mcontalb>'               => 'mcontalb',
+  '<mpaolone>'               => 'mpaolone',
+  '<rtysonCLAS12>'           => 'rtysonCLAS12',
+  '<tongtongcao>'            => 'tongtongcao',
+  '<veronique>'              => 'zieglerv',
+}
+
+codeowners      = File.open('CODEOWNERS.GENERATED', 'w')
+unknown_authors = []
+
+File.readlines('.github/codeowners/main_dirs.txt').map(&:chomp).each do |line|
+  if line.match? /^#/ or line.empty?
+    codeowners.puts line
+    next
+  end
+
+  if line == '*'
+    codeowners.puts [line, '@baltzell', '@raffaelladevita', '@c-dilks'].join(' ')
+    next
+  end
+
+  puts line
+  these_authors = []
+  file_list = `git ls-files #{line.sub /\/\*$/, ''}`.split "\n"
+  file_list.each do |file|
+    puts " - #{file}"
+    authors = `git shortlog -s -n -- '#{file}'`.split("\n").map do |line|
+      "<" + line.split(' ')[1..-1].join(' ') + ">"
+    end
+    handles = authors.map do |author|
+      handle = GithubHandles[author]
+      if handle != ''
+        "@#{handle}"
+      else
+        unknown_authors << author
+        author
+      end
+    end.reject{|h|h.match?(/dependabot/)}
+    these_authors += handles
+  end
+  codeowners.puts "#{line.gsub(' ','\ ')} #{these_authors.uniq.join(' ')}"
+
+end
+
+unless unknown_authors.empty?
+  $stderr.puts "WARNING: the following authors have unknown GitHub handles:"
+  $stderr.puts unknown_authors.uniq.sort
+end
+
+codeowners.close

--- a/.github/codeowners/main_dirs.txt
+++ b/.github/codeowners/main_dirs.txt
@@ -1,0 +1,97 @@
+# primary maintainers
+*
+
+# infrastructure
+.github/*
+bin/*
+docs/*
+external-dependencies/*
+libexec/*
+parent/*
+
+# common-tools
+common-tools/clara-io/*
+common-tools/clas-analysis/*
+common-tools/clas-io/*
+common-tools/clas-jcsg/*
+common-tools/clas-logging/*
+common-tools/clas-math/*
+common-tools/clas-physics/*
+common-tools/clas-reco/*
+common-tools/clas-tracking/*
+common-tools/clas-utils/*
+common-tools/cnuphys/*
+common-tools/coat-lib/*
+common-tools/parent/*
+common-tools/swim-tools/*
+
+# common-tools / clas-detector
+common-tools/clas-detector/src/main/java/org/jlab/detector/banks/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/base/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/calib/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/decode/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/epics/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/examples/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/swaps/*
+common-tools/clas-detector/src/main/java/org/jlab/detector/view/*
+common-tools/clas-detector/src/test/*
+
+# common-tools / clas-geometry
+common-tools/clas-geometry/src/main/java/org/jlab/detector/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/abs/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/base/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/component/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/bst/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/cnd/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/dc/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/ec/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/fmt/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/ft/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/ftof/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/fx/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/geant/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/gemc/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/gui/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/prim/*
+common-tools/clas-geometry/src/main/java/org/jlab/geom/view/*
+
+# etc
+etc/bankdefs/*
+etc/benchmarks/*
+etc/data/*
+etc/ejml/*
+etc/logging/*
+etc/nnet/*
+etc/services/*
+
+# reconstruction
+reconstruction/alert/*
+reconstruction/band/*
+reconstruction/bg/*
+reconstruction/cnd/*
+reconstruction/cvt/*
+reconstruction/dc/*
+reconstruction/eb/*
+reconstruction/ec/*
+reconstruction/ec/src/*
+reconstruction/fmt/*
+reconstruction/ft/*
+reconstruction/htcc/*
+reconstruction/ltcc/*
+reconstruction/mc/*
+reconstruction/mltn/*
+reconstruction/postproc/*
+reconstruction/raster/*
+reconstruction/rich/*
+reconstruction/rtpc/*
+reconstruction/swaps/*
+reconstruction/tof/*
+reconstruction/urwell/*
+reconstruction/vtx/*
+
+# validation
+validation/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,6 +62,7 @@
 # infrastructure
 .github/* @baltzell @raffaelladevita @c-dilks
 .gitlab-ci.yml @baltzell @raffaelladevita @c-dilks
+.gitlab-rgl.yml @whit2333
 bin/* @baltzell @raffaelladevita @c-dilks
 docs/* @baltzell @raffaelladevita @c-dilks
 external-dependencies/* @baltzell @raffaelladevita @c-dilks

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,130 @@
+##################################################################################
+# | Name                  | GitHub Handle    |
+# | ----                  | -------------    |
+# | Adam Hobart           | ajhobart         |
+# | Alessandra Filippi    | afilippi67       |
+# | Andrey Kim            | drewkenjo        |
+# | Blake Huck            | huckb            |
+# | Bruno Benkel          | bleaktwig        |
+# | Christopher Dilks     | c-dilks          |
+# | Cole Smith            | forcar           |
+# | Connor Pecar          | cpecar           |
+# | David Heddle          | heddle           |
+# | Silvia Niccolai       | silvianic        |
+# | David Payette         | dpayette         |
+# | Felix Touchte Codjo   | ftouchte         |
+# | Florian Hauenstein    | hauenst          |
+# | Francesco Bossu       | fbossu           |
+# | Francois-Xavier Girod | fxgirod          |
+# | Gagik Gavalian        | gavalian         |
+# | Giovanni Angelini     | gangel85         |
+# | Guillaume Christiaens | Guillaum-C       |
+# | Joseph Newton         | josnewton        |
+# | L Smith               | forcar           |
+# | Latif Kabir           | latifkabir       |
+# | Marco Contalbrigo     | mcontalb         |
+# | Mathieu Ouillon       | mathieuouillon   |
+# | Maurik Holtrop        | mholtrop         |
+# | Maxime Defurne        | mdefurne         |
+# | Michael Hoffer        | miho             |
+# | Nathan Baltzell       | baltzell         |
+# | Nathan Harrison       | naharrison       |
+# | Nick Markov           | markovnick       |
+# | Noemie Pilleux-LOCAL  | N-Plx            |
+# | Pierre Chatagnon      | PChatagnon       |
+# | Rafayel Paremuzyan    | rafopar          |
+# | Raffaella De Vita     | raffaelladevita  |
+# | Sylvester Joosten     | sly2j            |
+# | Tongtong Cao          | tongtongcao      |
+# | Vardan Gyurjyan       | gurjyan          |
+# | Veronique Ziegler     | zieglerv         |
+# | Whitney Armstrong     | whit2333         |
+# | ajhobart              | ajhobart         |
+# | colesmith             | forcar           |
+# | cqplatt               | cqplatt          |
+# | dcpayette             | dcpayette        |
+# | efuchey               | efuchey          |
+# | hattawy               | Hattawy          |
+# | huckb                 | huckb            |
+# | jwgibbs               | jwgibbs          |
+# | mariangela-bondi      | mariangela-bondi |
+# | marmstr4              | marmstr4         |
+# | mcontalb              | mcontalb         |
+# | mpaolone              | mpaolone         |
+# | rtysonCLAS12          | rtysonCLAS12     |
+# | tongtongcao           | tongtongcao      |
+# | veronique             | zieglerv         |
+##################################################################################
+
+# primary (default) maintainers
+* @baltzell @raffaelladevita @c-dilks
+
+# infrastructure
+.github/* @baltzell @raffaelladevita @c-dilks
+.gitlab-ci.yml @baltzell @raffaelladevita @c-dilks
+bin/* @baltzell @raffaelladevita @c-dilks
+docs/* @baltzell @raffaelladevita @c-dilks
+external-dependencies/* @baltzell @raffaelladevita @c-dilks
+libexec/* @baltzell @raffaelladevita @c-dilks
+
+# POMs
+/**/pom.xml @c-dilks @baltzell @raffaelladevita
+
+# common-tools
+common-tools/clara-io/* @baltzell @raffaelladevita
+common-tools/clas-analysis/* @raffaelladevita @baltzell @naharrison @zieglerv @marmstr4
+common-tools/clas-decay-tools/* @baltzell @raffaelladevita @zieglerv
+common-tools/clas-detector/* @baltzell @raffaelladevita @zieglerv
+common-tools/clas-geometry/* @baltzell @raffaelladevita @zieglerv @mathieuouillon
+common-tools/clas-io/* @raffaelladevita @baltzell @gavalian @naharrison @zieglerv @forcar @drewkenjo @huckb
+common-tools/clas-jcsg/* @drewkenjo @naharrison @raffaelladevita @baltzell @zieglerv @gangel85 @mcontalb @cqplatt @mariangela-bondi @gavalian @cpecar
+common-tools/clas-logging/* @baltzell @raffaelladevita
+common-tools/clas-math/* @raffaelladevita @baltzell @zieglerv @tongtongcao
+common-tools/clas-physics/* @raffaelladevita @baltzell @naharrison @zieglerv @drewkenjo @gavalian @fxgirod
+common-tools/clas-reco/* @raffaelladevita @baltzell @naharrison @zieglerv @josnewton @mcontalb @gavalian @afilippi67 @N-Plx @drewkenjo @rafopar @gurjyan @dcpayette @hauenst
+common-tools/clas-tracking/* @zieglerv @baltzell @raffaelladevita @tongtongcao
+common-tools/clas-utils/* @raffaelladevita @baltzell @naharrison @zieglerv @gavalian
+common-tools/swim-tools/* @raffaelladevita @baltzell @zieglerv @heddle @tongtongcao @gurjyan
+
+# coat-libs
+common-tools/coat-libs/* @raffaelladevita @baltzell @c-dilks
+
+# common-tools / cnuphys
+common-tools/cnuphys/* @heddle @naharrison @raffaelladevita @baltzell @zieglerv @tongtongcao
+
+# reconstruction
+reconstruction/alert/* @baltzell @raffaelladevita @mathieuouillon @mpaolone @efuchey @whit2333 @ftouchte
+reconstruction/band/* @raffaelladevita @baltzell @zieglerv @hauenst
+reconstruction/bg/* @baltzell @raffaelladevita
+reconstruction/cnd/* @raffaelladevita @baltzell @naharrison @zieglerv @PChatagnon @ajhobart @silvianic
+reconstruction/cvt/* @zieglerv @raffaelladevita @baltzell @naharrison @drewkenjo @fbossu @N-Plx @Guillaum-C
+reconstruction/dc/* @naharrison @raffaelladevita @baltzell @zieglerv @drewkenjo @tongtongcao @gurjyan @mcontalb @hauenst @latifkabir @gavalian @bleaktwig @N-Plx @marmstr4
+reconstruction/eb/* @baltzell @naharrison @raffaelladevita @sly2j @zieglerv @josnewton
+reconstruction/ec/* @naharrison @raffaelladevita @baltzell @zieglerv @forcar @gavalian @rafopar
+reconstruction/ec/src/* @forcar @naharrison @raffaelladevita @baltzell @gavalian @rafopar
+reconstruction/fmt/* @baltzell @raffaelladevita
+reconstruction/ft/* @naharrison @raffaelladevita @baltzell @zieglerv @afilippi67
+reconstruction/htcc/* @raffaelladevita @baltzell @naharrison @zieglerv @markovnick
+reconstruction/ltcc/* @naharrison @raffaelladevita @baltzell @zieglerv @sly2j
+reconstruction/mc/* @baltzell @raffaelladevita @rafopar @zieglerv
+reconstruction/mltn/* @baltzell @raffaelladevita @gavalian
+reconstruction/postproc/* @baltzell
+reconstruction/raster/* @baltzell @raffaelladevita @N-Plx
+reconstruction/rich/* @drewkenjo @raffaelladevita @baltzell @naharrison @zieglerv @mcontalb
+reconstruction/rtpc/* @dcpayette @raffaelladevita @baltzell @mathieuouillon @zieglerv @Hattawy @dpayette
+reconstruction/swaps/* @baltzell @raffaelladevita
+reconstruction/tof/* @naharrison @zieglerv @raffaelladevita @baltzell @drewkenjo @gavalian
+reconstruction/urwell/* @baltzell @raffaelladevita @tongtongcao
+reconstruction/vtx/* @baltzell @raffaelladevita @zieglerv
+
+# etc
+etc/bankdefs/* @baltzell @raffaelladevita @c-dilks
+etc/benchmarks/* @naharrison
+etc/data/* @drewkenjo @baltzell
+etc/ejml/* @raffaelladevita @gavalian
+etc/logging/* @baltzell
+etc/nnet/* @gavalian
+etc/services/* @baltzell @raffaelladevita @zieglerv
+
+# validation
+validation/* @baltzell @raffaelladevita @c-dilks


### PR DESCRIPTION
A `CODEOWNERS` file provides the following:
- connects contributors to files they worked on
- notifies contributors of proposed changes to their files, by automatically requesting them for PR review

### TODO

- [x] generate a `CODEOWNERS` file
- [x] replace real names with GitHub handles
- [ ] ~~consider automating its update, e.g, with `version-bump.sh`~~ let's not.. at least the "default" owners (of `*`) will be notified for new files