### PR TITLE
Revert "build(deps): bump org.jlab:groot from 4.0.5 to 4.1.0"

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.jlab</groupId>
       <artifactId>groot</artifactId>
-      <version>4.1.0</version>
+      <version>4.0.5</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->


### PR DESCRIPTION
Reverts JeffersonLab/coatjava#218

This should fix https://github.com/JeffersonLab/clas12-timeline/issues/202

Apparently the buffer size was _already_ increased in version 4.0.5, which is a _later_ version than 4.1.0 (an error in the semantic versioning). Here are the versions, ordered from most recent to oldest:

![image](https://github.com/JeffersonLab/coatjava/assets/7843751/c4222dbb-363a-4a33-a7ea-03a40253d440)
