### PR TITLE
dependabot: ignore `groot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "org.jlab:groot" # since version numbers are not in order
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
We recently discovered that `groot` version numbers are out of order. https://github.com/JeffersonLab/coatjava/pull/218 was actually a regression by several versions; therefore we revert by https://github.com/JeffersonLab/coatjava/pull/261.

This PR tells dependebot to ignore `groot` to prevent this from happening again; updates to `groot` will henceforth be manual.