### PR TITLE
fix(ci): don't deploy webpages from forks

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -169,7 +169,7 @@ jobs:
   #############################################################################
 
   collect_webpages:
-    if: ${{ github.head_ref == 'development' || github.ref_name == 'development' }}
+    if: ${{ github.ref == 'refs/heads/development' }}
     needs: [ build, generate_documentation ]
     runs-on: ubuntu-latest
     steps:
@@ -190,7 +190,7 @@ jobs:
           path: pages/
 
   deploy_web_pages:
-    if: ${{ github.head_ref == 'development' || github.ref_name == 'development' }}
+    if: ${{ github.ref == 'refs/heads/development' }}
     needs: collect_webpages
     permissions:
       pages: write


### PR DESCRIPTION
Deployment attempts have been happening (and failing) from PRs from forks, when the head branch is `development`, e.g., #264. This PR prevents this.