### PR TITLE
update for DC stereo angle

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
@@ -54,9 +54,10 @@ public class Constants {
     public static final double SIN25 = Math.sin(Math.toRadians(25.));
     public static final double COS25 = Math.cos(Math.toRadians(25.));
     public static final double COS30 = Math.cos(Math.toRadians(30.)); 
-    public static final double SIN6 = Math.sin(Math.toRadians(6.));
-    public static final double COS6 = Math.cos(Math.toRadians(6.));
-    public static final double TAN6 = Math.tan(Math.toRadians(6.));
+    public static final double STEREOANGLE = 6.;
+    public static final double SIN6 = Math.sin(Math.toRadians(STEREOANGLE));
+    public static final double COS6 = Math.cos(Math.toRadians(STEREOANGLE));
+    public static final double TAN6 = Math.tan(Math.toRadians(STEREOANGLE));
     public static final double CTAN6 = 1/TAN6;
     public static final double[] SINSECTOR60 = {0, Math.sin(Math.toRadians(60.)), Math.sin(Math.toRadians(120.)), 0, 
         Math.sin(Math.toRadians(240.)), Math.sin(Math.toRadians(300.))};

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
@@ -244,7 +244,7 @@ public class Segment extends ArrayList<FittedHit> implements Comparable<Segment>
         boolean value = false;
 
         if (this.get_fitPlane() != null && otherseg.get_fitPlane() != null) { 
-            if (Math.abs(Math.toDegrees(Math.acos(this.get_fitPlane().normal().dot(otherseg.get_fitPlane().normal()))) - 12.) < Constants.SEGMENTPLANESANGLE) // the angle between the plane normals is 12 degrees with some tolerance
+            if (Math.abs(Math.toDegrees(Math.acos(this.get_fitPlane().normal().dot(otherseg.get_fitPlane().normal()))) - 2*Constants.STEREOANGLE) < Constants.SEGMENTPLANESANGLE) // the angle between the plane normals is 2*Constants.STEREOANGLE degrees with some tolerance
             {
                 value = true;
             }


### PR DESCRIPTION
DC stereo angle = 6 might not be accurate. For convenience of investigation, we need to set a constant value, and apply it in DC reconstruction where stereo angle is needed.