### PR TITLE
alert s/l/c/o indexing

### DIFF
--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -54,7 +54,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 
 	@Override
 	public AlertDCSector createSector(ConstantProvider cp, int sectorId) {
-		AlertDCSector sector = new AlertDCSector(sectorId);
+		AlertDCSector sector = new AlertDCSector(sectorId+1);
 		for (int superlayerId = 0; superlayerId < nsuperl; superlayerId++)
 		     sector.addSuperlayer(createSuperlayer(cp, sectorId, superlayerId));
 		return sector;
@@ -63,7 +63,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 
 	@Override
 	public AlertDCSuperlayer createSuperlayer(ConstantProvider cp, int sectorId, int superlayerId) {
-		AlertDCSuperlayer superlayer = new AlertDCSuperlayer(sectorId, superlayerId);
+		AlertDCSuperlayer superlayer = new AlertDCSuperlayer(sectorId+1, superlayerId+1);
 
 		for (int layerId = 0; layerId < nlayers; layerId++)
 		     superlayer.addLayer(createLayer(cp, sectorId, superlayerId, layerId));
@@ -77,7 +77,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 		if (!(0 <= superlayerId && superlayerId < nsuperl)) throw new IllegalArgumentException("Error: invalid superlayer=" + superlayerId);
 		if (!(0 <= layerId && layerId < nlayers)) throw new IllegalArgumentException("Error: invalid layer=" + layerId);
 
-		AlertDCLayer layer = new AlertDCLayer(sectorId, superlayerId, layerId);
+		AlertDCLayer layer = new AlertDCLayer(sectorId+1, superlayerId+1, layerId+1);
 
 		// Load constants AHDC
 		// Length in Z mm!
@@ -213,7 +213,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			// not possible to add directly PrismaticComponent class because it is an ABSTRACT
 			// a new class should be created: public class NewClassWire extends PrismaticComponent {...}
 			// 5 top points & 5 bottom points with convexe shape. Concave shape is not supported.
-			AlertDCWire wire = new AlertDCWire(wireId, wireLine, firstF, secondF);
+			AlertDCWire wire = new AlertDCWire(wireId+1, wireLine, firstF, secondF);
 			// Add wire object to the list
 			layer.addComponent(wire);
 		}

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -54,7 +54,6 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 
 	@Override
 	public AlertDCSector createSector(ConstantProvider cp, int sectorId) {
-		if (!(0 <= sectorId && sectorId < nsectors)) throw new IllegalArgumentException("Error: invalid sector=" + sectorId);
 		AlertDCSector sector = new AlertDCSector(sectorId);
 		for (int superlayerId = 0; superlayerId < nsuperl; superlayerId++)
 		     sector.addSuperlayer(createSuperlayer(cp, sectorId, superlayerId));
@@ -64,8 +63,6 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 
 	@Override
 	public AlertDCSuperlayer createSuperlayer(ConstantProvider cp, int sectorId, int superlayerId) {
-		if (!(0 <= sectorId && sectorId < nsectors)) throw new IllegalArgumentException("Error: invalid sector=" + sectorId);
-		if (!(0 <= superlayerId && superlayerId < nsuperl)) throw new IllegalArgumentException("Error: invalid superlayer=" + superlayerId);
 		AlertDCSuperlayer superlayer = new AlertDCSuperlayer(sectorId, superlayerId);
 
 		for (int layerId = 0; layerId < nlayers; layerId++)

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.jlab.geom.detector.alert.AHDC;
 
 import org.jlab.geom.base.ConstantProvider;

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
@@ -107,8 +107,6 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 		AlertTOFLayer layer = new AlertTOFLayer(sectorId, superlayerId, layerId);
 
-		List<Plane3D> planes = new ArrayList<>();
-
 		double len_b   = layerId * pad_z + layerId * gap_pad_z; // back paddle plan
 		double len_f   = len_b + pad_z; // front paddle plan
 		double Rl      = R0;
@@ -152,7 +150,6 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 		Plane3D plane = new Plane3D(0, Rl, 0, 0, 1, 0);
 		plane.rotateZ(sectorId * openAng_sector_rad - Math.toRadians(90));
-		planes.add(plane);
 
 		return layer;
 	}

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
@@ -1,11 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
-
-//package clas12vis;
-
 package org.jlab.geom.detector.alert.ATOF;
 
 import org.jlab.geom.base.ConstantProvider;
@@ -15,9 +7,6 @@ import org.jlab.geom.component.ScintillatorPaddle;
 import org.jlab.geom.prim.Plane3D;
 import org.jlab.geom.prim.Point3D;
 import org.jlab.geom.prim.Transformation3D;
-
-import java.util.ArrayList;
-import java.util.List;
 
 /**
  * @author viktoriya

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
@@ -49,7 +49,7 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 	@Override
 	public AlertTOFSector createSector(ConstantProvider cp, int sectorId) {
-		AlertTOFSector sector = new AlertTOFSector(sectorId);
+		AlertTOFSector sector = new AlertTOFSector(sectorId+1);
 		for (int superlayerId = 0; superlayerId < nsuperl; superlayerId++)
 		     sector.addSuperlayer(createSuperlayer(cp, sectorId, superlayerId));
 		return sector;
@@ -57,7 +57,7 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 	@Override
 	public AlertTOFSuperlayer createSuperlayer(ConstantProvider cp, int sectorId, int superlayerId) {
-		AlertTOFSuperlayer superlayer = new AlertTOFSuperlayer(sectorId, superlayerId);
+		AlertTOFSuperlayer superlayer = new AlertTOFSuperlayer(sectorId+1, superlayerId+1);
 
 		if (superlayerId == 0) {
 			int nlayers0 = 1;
@@ -94,7 +94,7 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 		double gap_pad_z = 0.3d; // mm, gap between paddles in z
 
-		AlertTOFLayer layer = new AlertTOFLayer(sectorId, superlayerId, layerId);
+		AlertTOFLayer layer = new AlertTOFLayer(sectorId+1, superlayerId+1, layerId+1);
 
 		double len_b   = layerId * pad_z + layerId * gap_pad_z; // back paddle plan
 		double len_f   = len_b + pad_z; // front paddle plan

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/ATOF/AlertTOFFactory.java
@@ -60,7 +60,6 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 	@Override
 	public AlertTOFSector createSector(ConstantProvider cp, int sectorId) {
-		if (!(0 <= sectorId && sectorId < nsectors)) throw new IllegalArgumentException("Error: invalid sector=" + sectorId);
 		AlertTOFSector sector = new AlertTOFSector(sectorId);
 		for (int superlayerId = 0; superlayerId < nsuperl; superlayerId++)
 		     sector.addSuperlayer(createSuperlayer(cp, sectorId, superlayerId));
@@ -69,8 +68,6 @@ public class AlertTOFFactory implements Factory<AlertTOFDetector, AlertTOFSector
 
 	@Override
 	public AlertTOFSuperlayer createSuperlayer(ConstantProvider cp, int sectorId, int superlayerId) {
-		if (!(0 <= sectorId && sectorId < nsectors)) throw new IllegalArgumentException("Error: invalid sector=" + sectorId);
-		if (!(0 <= superlayerId && superlayerId < nsuperl)) throw new IllegalArgumentException("Error: invalid superlayer=" + superlayerId);
 		AlertTOFSuperlayer superlayer = new AlertTOFSuperlayer(sectorId, superlayerId);
 
 		if (superlayerId == 0) {

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Cluster/Cluster.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Cluster/Cluster.java
@@ -27,7 +27,9 @@ public class Cluster {
 		_PreClusters_list.add(precluster);
 		_PreClusters_list.add(other_precluster);
 		this._Radius = (precluster.get_Radius() + other_precluster.get_Radius()) / 2;
-		this._Z      = ((other_precluster.get_Phi() - precluster.get_Phi()) / (Math.toRadians(20) * Math.pow(-1, precluster.get_Super_layer()) - Math.toRadians(20) * Math.pow(-1, other_precluster.get_Super_layer()))) * 300 - 150;
+
+		this._Z      = ((other_precluster.get_Phi() - precluster.get_Phi()) / (Math.toRadians(20) * Math.pow(-1, precluster.get_Super_layer()-1) - Math.toRadians(20) * Math.pow(-1, other_precluster.get_Super_layer()-1))) * 300 - 150;
+
 		double x1     = -precluster.get_Radius() * Math.sin(precluster.get_Phi());
 		double y1     = -precluster.get_Radius() * Math.cos(precluster.get_Phi());
 		double x2     = -other_precluster.get_Radius() * Math.sin(other_precluster.get_Phi());

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Cluster/ClusterFinder.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Cluster/ClusterFinder.java
@@ -16,7 +16,7 @@ public class ClusterFinder {
 		if (precluster.get_Super_layer() == super_layer && precluster.get_Layer() == layer && !precluster.is_Used()) {
 			ArrayList<PreCluster> possible_precluster_list = new ArrayList<>();
 
-			double phi_mean = precluster.get_Phi() + 0.1 * Math.pow(-1, precluster.get_Super_layer());
+			double phi_mean = precluster.get_Phi() + 0.1 * Math.pow(-1, precluster.get_Super_layer()-1);
 			double x        = -precluster.get_Radius() * Math.sin(phi_mean);
 			double y        = -precluster.get_Radius() * Math.cos(phi_mean);
 			for (PreCluster other_precluster : AHDC_precluster_list) {
@@ -67,10 +67,10 @@ public class ClusterFinder {
 		// Collections.sort(AHDC_precluster_list);
 
 		for (PreCluster precluster : AHDC_precluster_list) {
-			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 0, 0, 1);
 			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 1, 1, 2);
-			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 2, 1, 3);
-			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 3, 1, 4);
+			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 2, 2, 3);
+			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 3, 2, 4);
+			find_associate_cluster(precluster, AHDC_precluster_list, window, minimal_distance, 4, 2, 5);
 		}
 
 		for (Cluster cluster : _list_with_maybe_same_cluster) {

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
@@ -23,7 +23,7 @@ public class Hit implements Comparable<Hit> {
 	public Hit(int superLayer, int layer, int wire, int numWire, double r, double doca) {
 		this.superLayer = superLayer;
 		this.layer      = layer;
-		this.wire       = wire - 1;
+		this.wire       = wire;
 		this.r          = r;
 		this.doca       = doca;
 		this.numWires = numWire;
@@ -51,35 +51,35 @@ public class Hit implements Comparable<Hit> {
 		Plane3D rPlane = new Plane3D(p2, n2);
 
 		switch (this.superLayer) {
-			case 0:
+			case 1:
 				numWires = 47.0;
 				R_layer = 32.0;
 				break;
-			case 1:
+			case 2:
 				numWires = 56.0;
 				R_layer = 38.0;
 				break;
-			case 2:
+			case 3:
 				numWires = 72.0;
 				R_layer = 48.0;
 				break;
-			case 3:
+			case 4:
 				numWires = 87.0;
 				R_layer = 58.0;
 				break;
-			case 4:
+			case 5:
 				numWires = 99.0;
 				R_layer = 68.0;
 				break;
 		}
 
-		R_layer = R_layer + DR_layer * this.layer;
+		R_layer = R_layer + DR_layer * (this.layer-1);
 		double alphaW_layer = Math.toRadians(round / (numWires));
-		double wx           = -R_layer * Math.sin(alphaW_layer * this.wire);
-		double wy           = -R_layer * Math.cos(alphaW_layer * this.wire);
+		double wx           = -R_layer * Math.sin(alphaW_layer * (this.wire-1));
+		double wy           = -R_layer * Math.cos(alphaW_layer * (this.wire-1));
 
-		double wx_end = -R_layer * Math.sin(alphaW_layer * this.wire + thster * (Math.pow(-1, this.superLayer)));
-		double wy_end = -R_layer * Math.cos(alphaW_layer * this.wire + thster * (Math.pow(-1, this.superLayer)));
+		double wx_end = -R_layer * Math.sin(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));
+		double wy_end = -R_layer * Math.cos(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));
 
 		Line3D line = new Line3D(wx, wy, -150, wx_end, wy_end, zl/2);
 

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/PreCluster/PreClusterFinder.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/PreCluster/PreClusterFinder.java
@@ -23,21 +23,21 @@ public class PreClusterFinder {
 
 	public void findPreCluster(List<Hit> AHDC_hits) {
 		ArrayList<Hit> s0l0 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s0l0, 0, 0);
+		fill_list(AHDC_hits, s0l0, 1, 1);
 		ArrayList<Hit> s1l0 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s1l0, 1, 0);
+		fill_list(AHDC_hits, s1l0, 2, 1);
 		ArrayList<Hit> s1l1 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s1l1, 1, 1);
+		fill_list(AHDC_hits, s1l1, 3, 2);
 		ArrayList<Hit> s2l0 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s2l0, 2, 0);
+		fill_list(AHDC_hits, s2l0, 4, 1);
 		ArrayList<Hit> s2l1 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s2l1, 2, 1);
+		fill_list(AHDC_hits, s2l1, 5, 2);
 		ArrayList<Hit> s3l0 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s3l0, 3, 0);
+		fill_list(AHDC_hits, s3l0, 6, 1);
 		ArrayList<Hit> s3l1 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s3l1, 3, 1);
+		fill_list(AHDC_hits, s3l1, 7, 2);
 		ArrayList<Hit> s4l0 = new ArrayList<Hit>();
-		fill_list(AHDC_hits, s4l0, 4, 0);
+		fill_list(AHDC_hits, s4l0, 8, 1);
 
 		ArrayList<ArrayList<Hit>> all_super_layer = new ArrayList<>();
 		all_super_layer.add(s0l0);

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/PreCluster/PreClusterFinder.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/PreCluster/PreClusterFinder.java
@@ -57,10 +57,10 @@ public class PreClusterFinder {
 					hit.setUse(true);
 					int expected_wire_plus  = hit.getWireId() + 1;
 					int expected_wire_minus = hit.getWireId() - 1;
-					if (hit.getWireId() - 1 == 0) {
+					if (hit.getWireId() == 1) {
 						expected_wire_minus = hit.getNbOfWires();
 					}
-					if (hit.getWireId() + 1 == hit.getNbOfWires() + 1) {
+					if (hit.getWireId() == hit.getNbOfWires() ) {
 						expected_wire_plus = 1;
 					}
 


### PR DESCRIPTION
This should be one way to index consistently within ALERT itself (every exposed index starting from the same "zero"), and with the other detectors (that "zero" being 1 for used indices).

Note, this requires a change to GEMC to remove a manual +1 (only for wire number) in the perl script that converts from COATJAVA geometry to GEMC text files.