### PR TITLE
fix issue for path length in FD tracking

### DIFF
--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
@@ -708,7 +708,9 @@ public class KFitter extends AKFitter {
             return false;
         }
     }
-
+    
+    // Since no vertex inforamtion, the starting point for path length is the final point at the last layer.
+    // After vertex information is obtained, transition for the starting point from the final point to vertex will be taken.
     private boolean filter(int k, boolean forward) {
         StateVec sVec = sv.transported(forward).get(k);
         org.jlab.clas.tracking.kalmanfilter.AMeasVecs.MeasVec mVec = mv.measurements.get(k);
@@ -857,7 +859,9 @@ public class KFitter extends AKFitter {
     private void calcFinalChisq(int sector) {
         calcFinalChisq(sector, false);
     }
-    
+        
+    // Since no vertex inforamtion, the starting point for path length is the final point at the last layer.
+    // After vertex information is obtained, transition for the starting point from the final point to vertex will be taken.
     private void calcFinalChisq(int sector, boolean nofilter) {
         int k = svzLength - 1;
         this.chi2 = 0;

--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
@@ -880,9 +880,9 @@ public class KFitter extends AKFitter {
             sv.transport(sector, k, 0, sVec, mv, this.getSwimmer(), forward);
 
             StateVec svc = sv.transported(forward).get(0);
-            path += svc.deltaPath;
+            path += (forward ? 1 : -1) * svc.deltaPath;
             svc.setPathLength(path);
-
+            
             double V0 = mv.measurements.get(0).surface.unc[0];
 
             Point3D point = new Point3D(svc.x, svc.y, mv.measurements.get(0).surface.measPoint.z());
@@ -922,7 +922,7 @@ public class KFitter extends AKFitter {
 
                 double h = mv.hDoca(point, mv.measurements.get(k1 + 1).surface.wireLine[0]);
                 svc = sv.transported(forward).get(k1 + 1);
-                path += svc.deltaPath;
+                path += (forward ? 1 : -1) * svc.deltaPath;
                 svc.setPathLength(path);
                 svc.setProjector(mv.measurements.get(k1 + 1).surface.wireLine[0].origin().x());
                 svc.setProjectorDoca(h);
@@ -975,7 +975,7 @@ public class KFitter extends AKFitter {
             sv.transport(sector, k, 0, sVec, mv, this.getSwimmer(), forward);
 
             StateVec svc = sv.transported(forward).get(0);
-            path += svc.deltaPath;
+            path += (forward ? 1 : -1) * svc.deltaPath;
             svc.setPathLength(path);
             
             Point3D point = new Point3D(svc.x, svc.y, mv.measurements.get(0).surface.measPoint.z());
@@ -1047,7 +1047,7 @@ public class KFitter extends AKFitter {
                 }
                 
                 svc = sv.transported(forward).get(k1 + 1);
-                path += svc.deltaPath;
+                path += (forward ? 1 : -1) * svc.deltaPath;
                 svc.setPathLength(path);
                 
                 point = new Point3D(sv.transported(forward).get(k1 + 1).x, sv.transported(forward).get(k1 + 1).y, mv.measurements.get(k1 + 1).surface.measPoint.z());
@@ -1115,6 +1115,10 @@ public class KFitter extends AKFitter {
 
     public Matrix propagateToVtx(int sector, double Zf) {
         return sv.transport(sector, finalStateVec.k, Zf, finalStateVec, mv, this.getSwimmer());
+    }
+    
+    public double getDeltaPathToVtx(int sector, double Zf) {
+        return sv.getDeltaPath(sector, finalStateVec.k, Zf, finalStateVec, mv, this.getSwimmer());
     }
 
     //Todo: apply the common funciton to replace current function above

--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitterStraight.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitterStraight.java
@@ -406,6 +406,8 @@ public class KFitterStraight extends AKFitter {
 		calcFinalChisq(sector, false);
 	}
     
+        // Since no vertex inforamtion, the starting point for path length is the final point at the last layer.
+        // After vertex information is obtained, transition for the starting point from the final point to vertex will be taken.
 	private void calcFinalChisq(int sector, boolean nofilter) {
         int k = svzLength - 1;
         this.chi2 = 0;

--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitterStraight.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitterStraight.java
@@ -426,11 +426,11 @@ public class KFitterStraight extends AKFitter {
         kfStateVecsAlongTrajectory = new ArrayList<>();
         if (sVec != null && sVec.CM != null) {
         	
-        	boolean forward = false;
+           boolean forward = false;
             sv.transport(sector, k, 0, sVec, mv, this.getSwimmer(), forward);            
             
             StateVec svc = sv.transported(forward).get(0);             
-            path += svc.deltaPath;            
+            path += (forward ? 1 : -1) * svc.deltaPath;           
             svc.setPathLength(path);            
             
             double V0 = mv.measurements.get(0).surface.unc[0];
@@ -473,7 +473,7 @@ public class KFitterStraight extends AKFitter {
                 
                 double h = mv.hDoca(point, mv.measurements.get(k1 + 1).surface.wireLine[0]);
                 svc = sv.transported(forward).get(k1+1);
-                path += svc.deltaPath;
+                path += (forward ? 1 : -1) * svc.deltaPath;
                 svc.setPathLength(path);
                 svc.setProjector(mv.measurements.get(k1 + 1).surface.wireLine[0].origin().x());
                 svc.setProjectorDoca(h);
@@ -502,6 +502,10 @@ public class KFitterStraight extends AKFitter {
 	
     public Matrix propagateToVtx(int sector, double Zf) {
         return sv.transport(sector, finalStateVec.k, Zf, finalStateVec, mv, this.getSwimmer());
+    }
+    
+    public double getDeltaPathToVtx(int sector, double Zf) {
+        return sv.getDeltaPath(sector, finalStateVec.k, Zf, finalStateVec, mv, this.getSwimmer());
     }
     
     @Override

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -907,8 +907,6 @@ public class TrackCandListFinder {
                         continue;
                     }
 
-                    List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef);
-
                     StateVec fn = new StateVec();
                     if (!kFZRef.setFitFailed && kFZRef.finalStateVec != null) {
                         fn.set(kFZRef.finalStateVec.x, kFZRef.finalStateVec.y, kFZRef.finalStateVec.tx, kFZRef.finalStateVec.ty);
@@ -927,6 +925,11 @@ public class TrackCandListFinder {
                             cand.set_FitConvergenceStatus(kFZRef.ConvStatus);
                             cand.set_Id(cands.size() + 1);
                             cand.set_CovMat(kFZRef.finalStateVec.CM);
+                            
+                            Point3D VTCS = cand.get(cand.size()-1).getCoordsInTiltedSector(cand.get_Vtx0().x(), cand.get_Vtx0().y(), cand.get_Vtx0().z());
+                            double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(cand.get(cand.size()-1).get_Sector(), VTCS.z());
+                            
+                            List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);
                             cand.setStateVecs(kfStateVecsAlongTrajectory);
 
                             // add candidate to list of tracks	
@@ -1071,7 +1074,6 @@ public class TrackCandListFinder {
                         kFZRef.init(measSurfaces, initSV);						
 						
                         kFZRef.runFitter();
-                        List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef);
                         
                         if (kFZRef.finalStateVec == null) {
                             continue;
@@ -1093,15 +1095,21 @@ public class TrackCandListFinder {
                                 cand.set_FitNDF(kFZRef.NDF);
                                 cand.set_FitConvergenceStatus(kFZRef.ConvStatus);
 
-                                cand.set_CovMat(kFZRef.finalStateVec.CM);
-                                cand.setStateVecs(kfStateVecsAlongTrajectory);                                    							
-
+                                cand.set_CovMat(kFZRef.finalStateVec.CM);                                 
+                                
                                 cand.setFinalStateVec(fitStateVec);
                                 cand.set_Id(cands.size() + 1);
                                 this.setTrackPars(cand, traj,
                                         trjFind, fitStateVec,
                                         fitStateVec.getZ(),
                                         DcDetector, dcSwim);
+                                
+                                Point3D VTCS = cand.get(cand.size()-1).getCoordsInTiltedSector(cand.get_Vtx0().x(), cand.get_Vtx0().y(), cand.get_Vtx0().z());
+                                double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(cand.get(cand.size()-1).get_Sector(), VTCS.z());
+                                
+                                List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);
+                                cand.setStateVecs(kfStateVecsAlongTrajectory);                                  
+                                
                                 // add candidate to list of tracks
                                 if (cand.fit_Successful = true) {
                                     cands.add(cand);                                    
@@ -1117,7 +1125,7 @@ public class TrackCandListFinder {
         return cands;
     }
     
-    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitter kFZRef) {
+    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitter kFZRef, double deltaPathToVtx) {
     	List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = new ArrayList<>();
     	
     	for(int i = 0; i < kFZRef.kfStateVecsAlongTrajectory.size(); i++) {
@@ -1125,7 +1133,7 @@ public class TrackCandListFinder {
             org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength());  
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx);  
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);
@@ -1134,7 +1142,7 @@ public class TrackCandListFinder {
     	return kfStateVecsAlongTrajectory;
     }
     
-        public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitterStraight kFZRef) {
+        public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitterStraight kFZRef, double deltaPathToVtx) {
     	List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = new ArrayList<>();
     	
     	for(int i = 0; i < kFZRef.kfStateVecsAlongTrajectory.size(); i++) {
@@ -1142,7 +1150,7 @@ public class TrackCandListFinder {
             org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength());  
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx);  
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -1133,7 +1133,7 @@ public class TrackCandListFinder {
             org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength() + deltaPathToVtx);  
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx);  // Transition for the starting point from the final point at the last layer to vertex
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);
@@ -1150,7 +1150,7 @@ public class TrackCandListFinder {
             org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength() + deltaPathToVtx);  
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); // Transition for the starting point from the final point at the last layer to vertex 
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -372,7 +372,7 @@ public class DCTBEngine extends DCEngine {
     	    org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); 
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); // Transition for the starting point from the final point at the last layer to vertex
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             sv.setDAFWeight(svc.getFinalDAFWeight());
@@ -391,7 +391,7 @@ public class DCTBEngine extends DCEngine {
     	    org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); 
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); // Transition for the starting point from the final point at the last layer to vertex
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -258,7 +258,7 @@ public class DCTBEngine extends DCEngine {
                     }
                                         
                     // get CovMat at vertex
-                    Point3D VTCS = crosses.get(0).getCoordsInSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
+                    Point3D VTCS = crosses.get(0).getCoordsInTiltedSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
                     TrackArray1.set_CovMat(kFZRef.propagateToVtx(crosses.get(0).get_Sector(), VTCS.z()));
                     
                     double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(TrackArray1.get(TrackArray1.size()-1).get_Sector(), VTCS.z());                                
@@ -302,7 +302,7 @@ public class DCTBEngine extends DCEngine {
                     }
 
                     // get CovMat at vertex
-                    Point3D VTCS = crosses.get(0).getCoordsInSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
+                    Point3D VTCS = crosses.get(0).getCoordsInTiltedSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
                     TrackArray1.set_CovMat(kFZRef.propagateToVtx(crosses.get(0).get_Sector(), VTCS.z()));
                     
                     double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(TrackArray1.get(TrackArray1.size()-1).get_Sector(), VTCS.z());                                

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -235,7 +235,6 @@ public class DCTBEngine extends DCEngine {
                 getInitState(TrackArray1, measSurfaces.get(0).measPoint.z(), initSV, kFZRef, dcSwim, new float[3]);
                 kFZRef.initFromHB(measSurfaces, initSV, TrackArray1.get(0).get(0).get(0).get_Beta());
                 kFZRef.runFitter();
-                List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef);
 
                 StateVec fn = new StateVec();
                 if (kFZRef.setFitFailed==false && kFZRef.finalStateVec!=null) { 
@@ -253,15 +252,18 @@ public class DCTBEngine extends DCEngine {
 
                     TrackArray1.set_FitChi2(kFZRef.chi2);
                     TrackArray1.set_FitNDF(kFZRef.NDF);
-                    TrackArray1.setStateVecs(kfStateVecsAlongTrajectory);
                     TrackArray1.set_FitConvergenceStatus(kFZRef.ConvStatus);
                     if (TrackArray1.get_Vtx0().toVector3D().mag() > 500) {
                         continue;
                     }
-
+                                        
                     // get CovMat at vertex
                     Point3D VTCS = crosses.get(0).getCoordsInSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
                     TrackArray1.set_CovMat(kFZRef.propagateToVtx(crosses.get(0).get_Sector(), VTCS.z()));
+                    
+                    double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(TrackArray1.get(TrackArray1.size()-1).get_Sector(), VTCS.z());                                
+                    List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);
+                    TrackArray1.setStateVecs(kfStateVecsAlongTrajectory); 
 
                     if (TrackArray1.isGood()) {
                         trkcands.add(TrackArray1);
@@ -277,8 +279,6 @@ public class DCTBEngine extends DCEngine {
                 kFZRef.initFromHB(measSurfaces, initSV, TrackArray1.get(0).get(0).get(0).get_Beta(), useDAF);
                 kFZRef.runFitter(useDAF);    
                                
-                List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef);
-
                 StateVec fn = new StateVec();
                 if (kFZRef.setFitFailed==false && kFZRef.finalStateVec!=null) { 
                     // set the state vector at the last measurement site
@@ -296,7 +296,6 @@ public class DCTBEngine extends DCEngine {
                     TrackArray1.set_FitChi2(kFZRef.chi2);
                     TrackArray1.set_FitNDF(kFZRef.NDF);
                     TrackArray1.set_NDFDAF(kFZRef.getNDFDAF());
-                    TrackArray1.setStateVecs(kfStateVecsAlongTrajectory);
                     TrackArray1.set_FitConvergenceStatus(kFZRef.ConvStatus);
                     if (TrackArray1.get_Vtx0().toVector3D().mag() > 500) {
                         continue;
@@ -305,6 +304,10 @@ public class DCTBEngine extends DCEngine {
                     // get CovMat at vertex
                     Point3D VTCS = crosses.get(0).getCoordsInSector(TrackArray1.get_Vtx0().x(), TrackArray1.get_Vtx0().y(), TrackArray1.get_Vtx0().z());
                     TrackArray1.set_CovMat(kFZRef.propagateToVtx(crosses.get(0).get_Sector(), VTCS.z()));
+                    
+                    double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(TrackArray1.get(TrackArray1.size()-1).get_Sector(), VTCS.z());                                
+                    List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);
+                    TrackArray1.setStateVecs(kfStateVecsAlongTrajectory); 
 
                     if (TrackArray1.isGood()) {
                         trkcands.add(TrackArray1);
@@ -361,7 +364,7 @@ public class DCTBEngine extends DCEngine {
         return true;
     }
     
-    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitter kFZRef) {
+    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitter kFZRef, double deltaPathToVtx) {
     	List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = new ArrayList<>();
     	
     	for(int i = 0; i < kFZRef.kfStateVecsAlongTrajectory.size(); i++) {
@@ -369,7 +372,7 @@ public class DCTBEngine extends DCEngine {
     	    org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength()); 
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); 
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             sv.setDAFWeight(svc.getFinalDAFWeight());
@@ -380,7 +383,7 @@ public class DCTBEngine extends DCEngine {
     	return kfStateVecsAlongTrajectory;
     }
     
-    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitterStraight kFZRef) {
+    public List<org.jlab.rec.dc.trajectory.StateVec> setKFStateVecsAlongTrajectory(KFitterStraight kFZRef, double deltaPathToVtx) {
     	List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = new ArrayList<>();
     	
     	for(int i = 0; i < kFZRef.kfStateVecsAlongTrajectory.size(); i++) {
@@ -388,7 +391,7 @@ public class DCTBEngine extends DCEngine {
     	    org.jlab.rec.dc.trajectory.StateVec sv = new org.jlab.rec.dc.trajectory.StateVec(svc.x, svc.y, svc.tx, svc.ty);
             sv.setZ(svc.z);
             sv.setB(svc.B);
-            sv.setPathLength(svc.getPathLength()); 
+            sv.setPathLength(svc.getPathLength() + deltaPathToVtx); 
             sv.setProjector(svc.getProjector());
             sv.setProjectorDoca(svc.getProjectorDoca());
             kfStateVecsAlongTrajectory.add(sv);


### PR DESCRIPTION
The original point is not starting from vertex when set path length for hits on DCs. It causes that time of flight is wrong, and further causes that hit time is wrong, and finally causes that doca is wrong.
After the issue is fixed, relative parameters in CCDB need to be re-calibrated.