### PR TITLE
fix: allow `run-groovy` users to set `JAVA_OPTS`

### DIFF
--- a/libexec/env.sh
+++ b/libexec/env.sh
@@ -30,7 +30,7 @@ if [ $# -ge 1 ]; then
     # additional variables and settings for groovy
     if [ "$1" = "groovy" ]; then
       JYPATH="${JYPATH:+${JYPATH}:}${CLAS12DIR}/lib/packages"
-      export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC"
+      export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC ${JAVA_OPTS-}"
     fi
 
     export JYPATH


### PR DESCRIPTION
`libexec/env.sh` hard codes a value of `$JAVA_OPTS` for groovy calls, (via `run-groovy`) making it impossible for `run-groovy` users to change any Java options, e.g., heap size limits. This PR allows users to override `env.sh`'s settings by appending user-level `JAVA_OPTS`.