### PR TITLE
Use real run numbers for geometry

### DIFF
--- a/common-tools/clas-io/src/main/java/org/jlab/utils/JsonUtils.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/utils/JsonUtils.java
@@ -113,7 +113,7 @@ public class JsonUtils {
                 ret.add(topKey,Map2Json((Map)entry.getValue()));
             }
             else {
-                ret.add(topKey, entry.getValue().toString());
+                ret.add(topKey, entry.getValue() == null ? null : entry.getValue().toString());
             }
         }
         return ret;

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
@@ -267,7 +267,7 @@ public class EngineProcessor {
     public void processEvent(DataEvent event){
         for(Map.Entry<String,ReconstructionEngine> engine : this.processorEngines.entrySet()){
             try {
-                engine.getValue().processEvent(event);
+                engine.getValue().processDataEvent(event);
             } catch (Exception e){
                 LOGGER.log(Level.SEVERE, "[Exception] >>>>> engine : {0}\n\n", engine.getKey());
                 e.printStackTrace();

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
@@ -267,7 +267,7 @@ public class EngineProcessor {
     public void processEvent(DataEvent event){
         for(Map.Entry<String,ReconstructionEngine> engine : this.processorEngines.entrySet()){
             try {
-                engine.getValue().filterEvent(event);
+                engine.getValue().processEvent(event);
             } catch (Exception e){
                 LOGGER.log(Level.SEVERE, "[Exception] >>>>> engine : {0}\n\n", engine.getKey());
                 e.printStackTrace();

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -2,6 +2,7 @@ package org.jlab.clas.reco;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -60,7 +61,8 @@ public abstract class ReconstructionEngine implements Engine {
     volatile boolean dropOutputBanks = false;
     private final Set<String> outputBanks = new HashSet<>();
 
-    private volatile int runNumber = 0;
+    private volatile List<Integer> runNumbers = new ArrayList<>();
+
     private boolean ignoreInvalidRunNumbers = true;
 
     volatile long triggerMask = 0xFFFFFFFFFFFFFFFFL;
@@ -337,15 +339,16 @@ public abstract class ReconstructionEngine implements Engine {
     
     public abstract void detectorChanged(int runNumber);
 
-    public boolean checkRunNumber(DataEvent event) {
+    public synchronized boolean checkRunNumber(DataEvent event) {
+        int r = 0;
         if (event.hasBank("RUN::config")) {
-            int r = event.getBank("RUN::config").getInt("run",0);
-            if (r != this.runNumber) {
-                this.runNumber = r;
+            r = event.getBank("RUN::config").getInt("run",0);
+            if (r != this.runNumbers.get(this.runNumbers.size()-1)) {
+                this.runNumbers.add(r);
                 this.detectorChanged(r);
             }
         }
-        return !this.ignoreInvalidRunNumbers && this.runNumber>0;
+        return !this.ignoreInvalidRunNumbers && r>0;
     }
     
     public void processEvent(DataEvent dataEvent) {

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -345,10 +345,10 @@ public abstract class ReconstructionEngine implements Engine {
             r = event.getBank("RUN::config").getInt("run",0);
             if (this.runNumbers.isEmpty() || r != this.runNumbers.get(this.runNumbers.size()-1)) {
                 this.runNumbers.add(r);
-                 this.detectorChanged(11);
+                this.detectorChanged(11);
             }
         }
-        return !this.ignoreInvalidRunNumbers && r>0;
+        return !this.ignoreInvalidRunNumbers || r>0;
     }
     
     public void processEvent(DataEvent dataEvent) {

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -345,7 +345,7 @@ public abstract class ReconstructionEngine implements Engine {
             r = event.getBank("RUN::config").getInt("run",0);
             if (this.runNumbers.isEmpty() || r != this.runNumbers.get(this.runNumbers.size()-1)) {
                 this.runNumbers.add(r);
-                 this.detectorChanged(r);
+                 this.detectorChanged(11);
             }
         }
         return !this.ignoreInvalidRunNumbers && r>0;

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -223,8 +223,7 @@ public abstract class ReconstructionEngine implements Engine {
     }
     
     protected String getStringConfigParameter(String jsonString,                                             
-            String key)  throws Exception {
-        Object js;
+                                              String key)  throws Exception {
         String variation = "";
         try {
             JSONObject base = new JSONObject(jsonString);
@@ -234,13 +233,6 @@ public abstract class ReconstructionEngine implements Engine {
             } else {
                 LOGGER.log(Level.WARNING,"[JSON]" + this.getName() + " **** warning **** does not contain key = " + key);
             }
-            /*
-            js = base.get(key);
-            if (js instanceof String) {
-                return (String) js;
-            } else {
-                throw new Exception("JSONObject[" +  "] not a string.");
-            }*/
         } catch (JSONException e) {
             throw new Exception(e.getMessage());
         }
@@ -442,42 +434,6 @@ public abstract class ReconstructionEngine implements Engine {
         }
 
         return input;
-        /*
-        if (!mt.equalsIgnoreCase()) {
-            String msg = String.format("Wrong input type: %s", mt);
-            output.setStatus(EngineStatus.ERROR);
-            output.setDescription(msg);
-            return output;
-        }*/
-        /*
-        EvioDataEvent dataevent = null;
-
-        try {
-            ByteBuffer bb = (ByteBuffer) input.getData();
-            byte[] buffer = bb.array();
-            ByteOrder endianness = bb.order();
-            dataevent = new EvioDataEvent(buffer, endianness, EvioFactory.getDictionary());
-        } catch (Exception e) {
-            String msg = String.format("Error reading input event%n%n%s", ClaraUtil.reportException(e));
-            output.setStatus(EngineStatus.ERROR);
-            output.setDescription(msg);
-            return output;
-        }
-
-        try {
-            this.processDataEvent(dataevent);
-            ByteBuffer  bbo = dataevent.getEventBuffer();
-            //byte[] buffero = bbo.array();
-            output.setData(mt, bbo);
-        } catch (Exception e) {
-            String msg = String.format("Error processing input event%n%n%s", ClaraUtil.reportException(e));
-            output.setStatus(EngineStatus.ERROR);
-            output.setDescription(msg);
-            return output;
-        }
-
-        return output;
-        */
     }
 
     @Override
@@ -582,7 +538,6 @@ public abstract class ReconstructionEngine implements Engine {
                     "\"timestamp\":333\n" +
                     "}";
             System.out.println(json);
-            //json = "{ \"ccdb\":{\"run\":10,\"variation\":\"default\"}, \"variation\":\"cosmic\"}";
             Reco reco = new Reco();
             String variation =  reco.getStringConfigParameter(json, "variation");
             System.out.println(" Variation : " + variation);

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -65,6 +65,8 @@ public abstract class ReconstructionEngine implements Engine {
 
     private boolean ignoreInvalidRunNumbers = true;
 
+    private int runNumberOverride = -1;
+
     volatile long triggerMask = 0xFFFFFFFFFFFFFFFFL;
 
     String engineName        = "UnknownEngine";
@@ -187,6 +189,9 @@ public abstract class ReconstructionEngine implements Engine {
           engineDictionary = new SchemaFactory();
       LOGGER.log(Level.INFO,"--- engine configuration is called " + this.getDescription());
       try {
+          if (this.getEngineConfigString("runNumberOverride")!=null) {
+              this.runNumberOverride = Integer.valueOf(this.getEngineConfigString("runNumberOverride"));
+          }
           if (this.getEngineConfigString("rawBankGroup")!=null) {
               this.rawBankOrders = RawBank.getFilterGroup(this.getEngineConfigString("rawBankGroup"));
           }
@@ -339,9 +344,11 @@ public abstract class ReconstructionEngine implements Engine {
     }
     
     public synchronized boolean checkRunNumber(DataEvent event) {
-        int r = 0;
-        if (event.hasBank("RUN::config")) {
+        int r = runNumberOverride;
+        if (r <= 0 && event.hasBank("RUN::config")) {
             r = event.getBank("RUN::config").getInt("run",0);
+        }
+        if (r > 0) {
             if (this.runNumbers.isEmpty() || r != this.runNumbers.get(this.runNumbers.size()-1)) {
                 this.runNumbers.add(r);
                 this.detectorChanged(11);

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -343,9 +343,9 @@ public abstract class ReconstructionEngine implements Engine {
         int r = 0;
         if (event.hasBank("RUN::config")) {
             r = event.getBank("RUN::config").getInt("run",0);
-            if (r != this.runNumbers.get(this.runNumbers.size()-1)) {
+            if (this.runNumbers.isEmpty() || r != this.runNumbers.get(this.runNumbers.size()-1)) {
                 this.runNumbers.add(r);
-                this.detectorChanged(r);
+                 this.detectorChanged(r);
             }
         }
         return !this.ignoreInvalidRunNumbers && r>0;

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -60,6 +60,7 @@ public abstract class ReconstructionEngine implements Engine {
     volatile boolean dropOutputBanks = false;
     private final Set<String> outputBanks = new HashSet<>();
 
+    private volatile int runNumber = 0;
     private boolean ignoreInvalidRunNumbers = true;
 
     volatile long triggerMask = 0xFFFFFFFFFFFFFFFFL;
@@ -333,17 +334,21 @@ public abstract class ReconstructionEngine implements Engine {
             }
         }
     }
+    
+    public abstract void detectorChanged(int runNumber);
 
     public boolean checkRunNumber(DataEvent event) {
-        if (!this.ignoreInvalidRunNumbers) return true;
-        int run = 0;
         if (event.hasBank("RUN::config")) {
-            run = event.getBank("RUN::config").getInt("run",0);
+            int r = event.getBank("RUN::config").getInt("run",0);
+            if (r != this.runNumber) {
+                this.runNumber = r;
+                this.detectorChanged(r);
+            }
         }
-        return run>0;
+        return !this.ignoreInvalidRunNumbers && this.runNumber>0;
     }
     
-    public void filterEvent(DataEvent dataEvent) {
+    public void processEvent(DataEvent dataEvent) {
         if (!this.wroteConfig) {
             this.wroteConfig = true;
             JsonUtils.extend(dataEvent, CONFIG_BANK_NAME, "json", this.generateConfig());
@@ -392,7 +397,7 @@ public abstract class ReconstructionEngine implements Engine {
             }
                     
             try {
-                this.filterEvent(dataEventHipo);
+                this.processEvent(dataEventHipo);
                 output.setData(mt, dataEventHipo.getHipoEvent());
             } catch (Exception e) {
                 String msg = String.format("Error processing input event%n%n%s", ClaraUtil.reportException(e));
@@ -509,15 +514,20 @@ public abstract class ReconstructionEngine implements Engine {
         }
         @Override
         public boolean processDataEvent(DataEvent event) {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported yet.");
         }
 
         @Override
         public boolean init() {
-            throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+            throw new UnsupportedOperationException("Not supported yet.");
         }
-    
-}
+
+        @Override
+        public void detectorChanged(int runNumber) {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+    }
+
     public static void main(String[] args){
         System.setProperty("CLAS12DIR", "/Users/gavalian/Work/Software/project-3a.0.0/Distribution/clas12-offline-software/coatjava");
         try {

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -67,10 +67,14 @@ public abstract class ReconstructionEngine implements Engine {
 
     volatile long triggerMask = 0xFFFFFFFFFFFFFFFFL;
 
-    String             engineName        = "UnknownEngine";
-    String             engineAuthor      = "N.T.";
-    String             engineVersion     = "0.0";
-    String             engineDescription = "CLARA Engine";
+    String engineName        = "UnknownEngine";
+    String engineAuthor      = "N.T.";
+    String engineVersion     = "0.0";
+    String engineDescription = "CLARA Engine";
+
+    abstract public boolean processDataEventUser(DataEvent event);
+    abstract public boolean init();
+    abstract public void detectorChanged(int runNumber);
 
     public ReconstructionEngine(String name, String author, String version){
         engineName    = name;
@@ -107,9 +111,6 @@ public abstract class ReconstructionEngine implements Engine {
         return new RawDataBank(bankName, order);
     }
 
-    abstract public boolean processDataEvent(DataEvent event);
-    abstract public boolean init();
-   
     /**
      * Use a map just to avoid name clash in ConstantsManager.
      * @param tables map of table names to #indices
@@ -337,8 +338,6 @@ public abstract class ReconstructionEngine implements Engine {
         }
     }
     
-    public abstract void detectorChanged(int runNumber);
-
     public synchronized boolean checkRunNumber(DataEvent event) {
         int r = 0;
         if (event.hasBank("RUN::config")) {
@@ -351,7 +350,7 @@ public abstract class ReconstructionEngine implements Engine {
         return !this.ignoreInvalidRunNumbers || r>0;
     }
     
-    public void processEvent(DataEvent dataEvent) {
+    public void processDataEvent(DataEvent dataEvent) {
         if (!this.wroteConfig) {
             this.wroteConfig = true;
             JsonUtils.extend(dataEvent, CONFIG_BANK_NAME, "json", this.generateConfig());
@@ -361,7 +360,7 @@ public abstract class ReconstructionEngine implements Engine {
         }
         if(this.applyTriggerMask(dataEvent)) {
             if (this.checkRunNumber(dataEvent)) {
-                this.processDataEvent(dataEvent);
+                this.processDataEventUser(dataEvent);
             }
         }        
     }
@@ -400,7 +399,7 @@ public abstract class ReconstructionEngine implements Engine {
             }
                     
             try {
-                this.processEvent(dataEventHipo);
+                this.processDataEvent(dataEventHipo);
                 output.setData(mt, dataEventHipo.getHipoEvent());
             } catch (Exception e) {
                 String msg = String.format("Error processing input event%n%n%s", ClaraUtil.reportException(e));
@@ -516,7 +515,7 @@ public abstract class ReconstructionEngine implements Engine {
             super("a","b","c");
         }
         @Override
-        public boolean processDataEvent(DataEvent event) {
+        public boolean processDataEventUser(DataEvent event) {
             throw new UnsupportedOperationException("Not supported yet.");
         }
 

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
@@ -195,4 +195,7 @@ public class MagFieldsEngine extends ReconstructionEngine {
         return true;
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {}
+
 }

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
@@ -162,7 +162,7 @@ public class MagFieldsEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         DataBank bank = event.getBank("RUN::config");
         // Load the constants
         // -------------------

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
@@ -197,5 +197,4 @@ public class MagFieldsEngine extends ReconstructionEngine {
 
     @Override
     public void detectorChanged(int runNumber) {}
-
 }

--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
@@ -51,7 +51,7 @@ public class AHDCEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
 
 		int    runNo          = 10;
 		int    eventNo        = 777;
@@ -183,7 +183,7 @@ public class AHDCEngine extends ReconstructionEngine {
 			// System.out.println("***********  NEXT EVENT ************");
 			// event.show();
 
-			en.processDataEvent(event);
+			en.processDataEventUser(event);
 			writer.writeEvent(event);
 
 		}

--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
@@ -189,4 +189,9 @@ public class AHDCEngine extends ReconstructionEngine {
 
 		System.out.println("finished " + (System.nanoTime() - starttime) * Math.pow(10, -9));
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
@@ -47,6 +47,8 @@ public class AHDCEngine extends ReconstructionEngine {
 		return true;
 	}
 
+    @Override
+    public void detectorChanged(int runNumber) {}
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
@@ -189,9 +191,4 @@ public class AHDCEngine extends ReconstructionEngine {
 
 		System.out.println("finished " + (System.nanoTime() - starttime) * Math.pow(10, -9));
 	}
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
 }

--- a/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
+++ b/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
@@ -29,7 +29,7 @@ public class BANDEngine extends ReconstructionEngine {
 	int Run = -1;
 
 	@Override
-		public boolean processDataEvent(DataEvent event) {
+		public boolean processDataEventUser(DataEvent event) {
 			//System.out.println("**** NEW EVENT ****");
 			// update calibration constants based on run number if changed
 			setRunConditionsParameters(event);
@@ -127,7 +127,7 @@ public class BANDEngine extends ReconstructionEngine {
 			//	event.getBank("band::adc").show();
 			//	event.getBank("band::tdc").show();
 			//}
-			en.processDataEvent(event);
+			en.processDataEventUser(event);
 			writer.writeEvent(event);
 			//event.getBank("band::hits").show();
 			nevent++;

--- a/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
+++ b/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
@@ -55,9 +55,9 @@ public class BANDEngine extends ReconstructionEngine {
 		}
 
 	@Override
-		public boolean init() {
+    public boolean init() {
 			
-			String[]  bandTables = new String[]{
+	    String[]  bandTables = new String[]{
 				"/calibration/band/time_jitter",
 				"/calibration/band/lr_offsets",
 				"/calibration/band/effective_velocity",
@@ -73,14 +73,15 @@ public class BANDEngine extends ReconstructionEngine {
 				"/calibration/band/energy_conversion"
 				//"/calibration/band/time_walk_corr_left",
 				//"/calibration/band/time_walk_corr_right",
-    		};
+        };
     
-			requireConstants(Arrays.asList(bandTables));
-    		
-                        this.registerOutputBank("BAND::hits","BAND::rawhits","BAND::laser");
-		
-			return true;
-		}
+		requireConstants(Arrays.asList(bandTables));
+        this.registerOutputBank("BAND::hits","BAND::rawhits","BAND::laser");
+		return true;
+	}    
+        
+    @Override
+    public void detectorChanged(int runNumber) {}
 
 	public void setRunConditionsParameters(DataEvent event) {
 		if(event.hasBank("RUN::config")==false) {
@@ -136,10 +137,4 @@ public class BANDEngine extends ReconstructionEngine {
 
 
 	}
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }

--- a/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
+++ b/reconstruction/band/src/main/java/org/jlab/service/band/BANDEngine.java
@@ -1,11 +1,7 @@
 package org.jlab.service.band;
 
-
 import java.util.ArrayList;
 import java.util.Arrays;
-
-import javax.naming.event.NamingEvent;
-
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
@@ -26,13 +22,11 @@ import org.jlab.rec.band.hit.BandHitFinder;
 
 public class BANDEngine extends ReconstructionEngine {
 
-
 	public BANDEngine() {
 		super("BAND", "hauensteinsegarra", "1.0");
 	}
 
 	int Run = -1;
-
 
 	@Override
 		public boolean processDataEvent(DataEvent event) {
@@ -142,5 +136,10 @@ public class BANDEngine extends ReconstructionEngine {
 
 
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
 }

--- a/reconstruction/bg/src/main/java/org/jlab/service/bg/BackgroundEngine.java
+++ b/reconstruction/bg/src/main/java/org/jlab/service/bg/BackgroundEngine.java
@@ -41,6 +41,9 @@ public class BackgroundEngine extends ReconstructionEngine {
         return true;
     }
 
+    @Override
+    public void detectorChanged(int run) {}
+
     public boolean init(String... filenames) {
         bgfilenames.clear();
         String detectors = getEngineConfigString(CONF_DETECTORS,"DC,FTOF");

--- a/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
+++ b/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
@@ -45,7 +45,7 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
     private int newRun = 0;
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
 
         if (!event.hasBank("RUN::config")) {
             return true;
@@ -142,7 +142,7 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 
 			//event.getBank("MC::Particle").show();
 			//if(event.hasBank("CVT::Tracks")){event.getBank("CVT::Tracks").show();};
-			en.processDataEvent(event);
+			en.processDataEventUser(event);
 
 			//			System.out.println("event après process ");
 			//			event.show();

--- a/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
+++ b/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
@@ -1,7 +1,8 @@
 package org.jlab.service.cnd;
 
-import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataBank;
@@ -15,17 +16,8 @@ import org.jlab.rec.cnd.hit.CndHit;
 import org.jlab.rec.cnd.hit.CvtGetHTrack;
 import org.jlab.rec.cnd.hit.HalfHit;
 import org.jlab.rec.cnd.hit.CndHitFinder;
-
-import java.lang.String;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
-import org.jlab.clas.physics.LorentzVector;
-
 import org.jlab.rec.cnd.cluster.CNDCluster;
 import org.jlab.rec.cnd.cluster.CNDClusterFinder;
-import org.jlab.utils.groups.IndexedTable;
 
 /**
  * Service to return reconstructed CND Hits - the output is in Hipo format
@@ -33,9 +25,7 @@ import org.jlab.utils.groups.IndexedTable;
  *
  *
  */
-
 public class CNDCalibrationEngine extends ReconstructionEngine {
-
 
 	public CNDCalibrationEngine() {
 		super("CND", "chatagnon & WANG", "1.0");
@@ -265,6 +255,11 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 
 		}		
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
 }
 

--- a/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
+++ b/reconstruction/cnd/src/main/java/org/jlab/service/cnd/CNDCalibrationEngine.java
@@ -32,9 +32,7 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 	
 	}
 
-	//int Run = -1;
 	RecoBankWriter rbc;
-	//test
 	static int enb =0;
 	static int ecnd=0;
 	static int hcvt=0;
@@ -43,41 +41,33 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 	static int ctof=0;
 	static int ctoftot=0;
         
-        private AtomicInteger Run = new AtomicInteger(0);
-        private int newRun = 0;
+    private AtomicInteger Run = new AtomicInteger(0);
+    private int newRun = 0;
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
 
-            
-            if (!event.hasBank("RUN::config")) {
+        if (!event.hasBank("RUN::config")) {
             return true;
-            }
+        }
 
-           DataBank bank = event.getBank("RUN::config");
+        DataBank bank = event.getBank("RUN::config");
 
-            // Load the constants
-            //-------------------
-            int newRun = bank.getInt("run", 0);
-            if (newRun == 0)
-               return true;
-
-            if (Run.get() == 0 || (Run.get() != 0 && Run.get() != newRun)) {
-                 Run.set(newRun);
-            }
+        // Load the constants
+        int newRun = bank.getInt("run", 0);
+        if (newRun == 0)
+           return true;
+        if (Run.get() == 0 || (Run.get() != 0 && Run.get() != newRun)) {
+            Run.set(newRun);
+        }
+        CalibrationConstantsLoader constantsLoader = new CalibrationConstantsLoader(newRun, this.getConstantsManager());
             
-                CalibrationConstantsLoader constantsLoader = new CalibrationConstantsLoader(newRun, this.getConstantsManager());
-		//event.show();
-		//System.out.println("in data process ");
-            
-                ArrayList<HalfHit> halfhits = new ArrayList<HalfHit>();   
+        ArrayList<HalfHit> halfhits = new ArrayList<HalfHit>();   
 		ArrayList<CndHit> hits = new ArrayList<CndHit>();
 
 		halfhits = HitReader.getCndHalfHits(event, constantsLoader);		
 		//1) exit if halfhit list is empty
 		if(halfhits.size()==0 ){
-			//			System.out.println("fin de process (0) : ");
-			//			event.show();
 			return true;
 		}
 
@@ -93,89 +83,32 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 			double length =hitFinder.findLength(hit, cvttry.getHelices(),0,constantsLoader);
 			if (length!=0){
 				hit.set_tLength(length); // the path length is non zero only when there is a match with cvt track
-				//if(flag==0){match++;}
-				//flag=1;
 			}
-
 		}
-
-		//	   			GetVertex getVertex = new GetVertex();
-		//	   			Point3D vertex = getVertex.getVertex(event);
-		//	   			for (CndHit hit : hits){ // check findlengthneutral
-		//	   				hitFinder.findLengthNeutral( vertex, hit);
-		//		   			}
-		//	   			
-
-		//		if(hits.size()!=0){
-		//
-		//			DataBank outbank = RecoBankWriter.fillCndHitBanks(event, hits);
-		////			System.out.println("event before process : ");
-		////			event.show();
-		//			event.appendBanks(outbank);
-		//			//System.out.println("event after process : ");
-		//			//event.show();
-		//			ecnd++;
-		//			if(event.hasBank("CVT::Tracks")){
-		//				posmatch++;
-		//				//event.getBank("MC::Particle").show();
-		//				//outbank.show();
-		//			}
-		//			
-		//		}
-		////		System.out.println("fin de process : ");
-		////		event.show();
-		//		return true;
-		//	}
-        
-        
-        
 
         //// clustering of the CND hits
         CNDClusterFinder cndclusterFinder = new CNDClusterFinder();
         ArrayList<CNDCluster> cndclusters = cndclusterFinder.findClusters(hits,constantsLoader);
-            
-        
-        
-        
+
 		if(hits.size()!=0){
-
-			//          DataBank outbank = RecoBankWriter.fillCndHitBanks(event, hits);
-			//          event.appendBanks(outbank);
-			// event.show();
-		//	System.out.println("in process event ");
 			rbc.appendCNDBanks(event,hits,cndclusters);
-			//      ecnd++;
-			//      if(event.hasBank("CVT::Tracks")){
-			//              posmatch++;
-			//event.getBank("MC::Particle").show();
-			//outbank.show();
-			//      }
-		//	event.show();
-
 		}
 
-
-
-
-
 		return true;
-		
 	}
 
 	@Override
 	public boolean init() {
-            rbc = new RecoBankWriter();
-            
-            requireConstants(Arrays.asList(CalibrationConstantsLoader.getCndTables()));
-            this.getConstantsManager().setVariation("default");
-
-            this.registerOutputBank("CND::hits","CND::clusters");
-
-            return true;
+        rbc = new RecoBankWriter();
+        requireConstants(Arrays.asList(CalibrationConstantsLoader.getCndTables()));
+        this.getConstantsManager().setVariation("default");
+        this.registerOutputBank("CND::hits","CND::clusters");
+        return true;
 	}
+    
+    @Override
+    public void detectorChanged(int runNumber) {}
 
-
-	
 	public static void main (String arg[]) {
 		CNDCalibrationEngine en = new CNDCalibrationEngine();
 
@@ -197,7 +130,6 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 		String outputFile="/projet/nucleon/pierre/RecCND/test1.hipo";
 		HipoDataSync  writer = new HipoDataSync();
 		writer.open(outputFile);
-
 
 		while(reader.hasEvent()) {
 			enb++;		
@@ -255,11 +187,5 @@ public class CNDCalibrationEngine extends ReconstructionEngine {
 
 		}		
 	}
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }
 

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
@@ -133,12 +133,14 @@ public class CVTEngine extends ReconstructionEngine {
         this.initConstantsTables();
         this.registerBanks();
         this.printConfiguration();
-        return true;    
+        return true;
     }
 
     @Override
     public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        IndexedTable svtLorentz = this.getConstantsManager().getConstants(runNumber, "/calibration/svt/lorentz_angle");
+        IndexedTable bmtVoltage = this.getConstantsManager().getConstants(runNumber, "/calibration/mvt/bmt_voltage");
+        Geometry.getInstance().initialize(this.getConstantsManager().getVariation(), runNumber, svtLorentz, bmtVoltage);
     }
     
     public final void setOutputBankPrefix(String prefix) {
@@ -286,15 +288,11 @@ public class CVTEngine extends ReconstructionEngine {
         int run = this.getRun(event); 
         
         IndexedTable svtStatus          = this.getConstantsManager().getConstants(run, "/calibration/svt/status");
-        IndexedTable svtLorentz         = this.getConstantsManager().getConstants(run, "/calibration/svt/lorentz_angle");
         IndexedTable bmtStatus          = this.getConstantsManager().getConstants(run, "/calibration/mvt/bmt_status");
         IndexedTable bmtTime            = this.getConstantsManager().getConstants(run, "/calibration/mvt/bmt_time");
-        IndexedTable bmtVoltage         = this.getConstantsManager().getConstants(run, "/calibration/mvt/bmt_voltage");
         IndexedTable bmtStripVoltage    = this.getConstantsManager().getConstants(run, "/calibration/mvt/bmt_strip_voltage");
         IndexedTable bmtStripThreshold  = this.getConstantsManager().getConstants(run, "/calibration/mvt/bmt_strip_voltage_thresholds");
         IndexedTable beamPos            = this.getConstantsManager().getConstants(run, "/geometry/beam/position");
-        
-        Geometry.getInstance().initialize(this.getConstantsManager().getVariation(), run, svtLorentz, bmtVoltage);
         
         CVTReconstruction reco = new CVTReconstruction(swimmer);
         

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
@@ -28,7 +28,6 @@ import org.jlab.utils.groups.IndexedTable;
  */
 public class CVTEngine extends ReconstructionEngine {
 
-
     /**
      * @param docacutsum the docacutsum to set
      */
@@ -609,6 +608,9 @@ public class CVTEngine extends ReconstructionEngine {
         
     }
 
-    
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 
 }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
@@ -281,7 +281,7 @@ public class CVTEngine extends ReconstructionEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         Swim swimmer = new Swim();
         

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTEngine.java
@@ -135,6 +135,11 @@ public class CVTEngine extends ReconstructionEngine {
         this.printConfiguration();
         return true;    
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
     
     public final void setOutputBankPrefix(String prefix) {
         this.bankPrefix = prefix;
@@ -574,7 +579,6 @@ public class CVTEngine extends ReconstructionEngine {
         return cvtCovMatBank;
     }
     
-    
     public void printConfiguration() {            
         
         System.out.println("["+this.getName()+"] run with cosmics setting set to "+Constants.getInstance().isCosmics);        
@@ -607,10 +611,4 @@ public class CVTEngine extends ReconstructionEngine {
         
         
     }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTSecondPassEngine.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/services/CVTSecondPassEngine.java
@@ -30,7 +30,7 @@ public class CVTSecondPassEngine extends CVTEngine {
 
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
 
         int run = this.getRun(event);
         if(Constants.getInstance().seedingDebugMode)

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
@@ -49,6 +49,8 @@ public class Constants {
     
     public static boolean DEBUG = false;
     
+    public static double[][] SHIFTS = null;
+
     // CONSTATNS for TRANSFORMATION
     public static final double SIN25 = Math.sin(Math.toRadians(25.));
     public static final double COS25 = Math.cos(Math.toRadians(25.));
@@ -366,7 +368,6 @@ public class Constants {
     public void setSWAPDCRBBITS(boolean SWAPDCRBBITS) {
         this.SWAPDCRBBITS = SWAPDCRBBITS;
     }
-   
 
     public synchronized void initialize(String engine,
                                         String variation, 
@@ -397,12 +398,14 @@ public class Constants {
             DCRBJITTER          = dcrbJitter;  
             SWAPDCRBBITS        = swapDCRBBits;
             NSUPERLAYERTRACKING = nSuperLayer;
+<<<<<<< HEAD
             SECTORSELECT        = selectedSector;
+=======
+            SECTORSELECT    = selectedSector;
+            SHIFTS          = shifts;
+>>>>>>> 5f8a48671 (implement detector changed for dc)
 
             LoadConstants();
-
-            LoadGeometry(GEOVARIATION, shifts);
-
             ConstantsLoaded = true;
             printConfig(engine);
         }
@@ -414,9 +417,6 @@ public class Constants {
         }
         else {
             LoadConstants();
-
-            LoadGeometry(GEOVARIATION, null);
-
             ConstantsLoaded = true;
             printConfig(engine);
         }
@@ -531,24 +531,24 @@ public class Constants {
         reverseTTs.put(run, reverse);
     }
     
-    private synchronized void LoadGeometry(String geoVariation, double[][] shifts) {
+    public synchronized void LoadGeometry(int runNumber, String geoVariation, double[][] shifts) {
         // Load the geometry
-        ConstantProvider provider = GeometryFactory.getConstants(DetectorType.DC, 11, geoVariation);
+        ConstantProvider provider = GeometryFactory.getConstants(DetectorType.DC, runNumber, geoVariation);
         dcDetector = new DCGeant4Factory(provider, MINISTAGGERSTATUS, FEEDTHROUGHSSTATUS, ENDPLATESBOWING, shifts);
         for(int l=0; l<6; l++) {
             wpdist[l] = provider.getDouble("/geometry/dc/superlayer/wpdist", l);
         }
         // Load target
-        ConstantProvider providerTG = GeometryFactory.getConstants(DetectorType.TARGET, 11, geoVariation);
+        ConstantProvider providerTG = GeometryFactory.getConstants(DetectorType.TARGET, runNumber, geoVariation);
         double targetPosition = providerTG.getDouble("/geometry/shifts/target/z",0);
         double targetLength   = providerTG.getDouble("/geometry/materials/target/length",0);
         // Load other geometries
-        ConstantProvider providerFTOF = GeometryFactory.getConstants(DetectorType.FTOF, 11, geoVariation);
+        ConstantProvider providerFTOF = GeometryFactory.getConstants(DetectorType.FTOF, runNumber, geoVariation);
         ftofDetector = new FTOFGeant4Factory(providerFTOF);        
-        ecalDetector =  GeometryFactory.getDetector(DetectorType.ECAL, 11, geoVariation);
-        fmtDetector =  GeometryFactory.getDetector(DetectorType.FMT, 11, geoVariation);
-        ConstantsManager managerRICH = new ConstantsManager(geoVariation);;
-        richDetector = new RICHGeoFactory(0, managerRICH, 11, false);
+        ecalDetector =  GeometryFactory.getDetector(DetectorType.ECAL, runNumber, geoVariation);
+        fmtDetector =  GeometryFactory.getDetector(DetectorType.FMT, runNumber, geoVariation);
+        ConstantsManager managerRICH = new ConstantsManager(geoVariation);
+        richDetector = new RICHGeoFactory(0, managerRICH, runNumber, false);
         // create the surfaces
         trajSurfaces = new TrajectorySurfaces();
         trajSurfaces.loadSurface(targetPosition, targetLength, dcDetector, ftofDetector, ecalDetector, fmtDetector, richDetector);        

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
@@ -41,7 +41,6 @@ public class DCEngine extends ReconstructionEngine {
     
     public static final Logger LOGGER = Logger.getLogger(ReconstructionEngine.class.getName());
 
-
     public DCEngine(String name) {
         super(name,"ziegler","5.0");
     }
@@ -195,6 +194,11 @@ public class DCEngine extends ReconstructionEngine {
         this.initBanks();
         this.setDropBanks();
         return true;
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
     private void initBanks() {

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
@@ -198,7 +198,7 @@ public class DCEngine extends ReconstructionEngine {
 
     @Override
     public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        Constants.getInstance().LoadGeometry(runNumber, geoVariation, shifts);
     }
 
     private void initBanks() {

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
@@ -169,7 +169,7 @@ public class DCEngine extends ReconstructionEngine {
         
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         return true;
     }
 

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBClustering.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBClustering.java
@@ -36,7 +36,7 @@ public class DCHBClustering extends DCEngine {
      
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         int run = this.getRun(event);
         if(run==0) return true;

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBEngine.java
@@ -55,7 +55,7 @@ public class DCHBEngine extends DCEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
 
         int run = this.getRun(event);
         if(run==0) return true;

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
@@ -44,7 +44,7 @@ public class DCHBPostClusterAI extends DCEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         int run = this.getRun(event);
         if(run==0) {

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterConv.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterConv.java
@@ -46,7 +46,7 @@ public class DCHBPostClusterConv extends DCEngine {
     }
         
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
     
         int run = this.getRun(event);
         if(run==0) return true;

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCTBEngine.java
@@ -70,7 +70,7 @@ public class DCTBEngine extends DCEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         int run = this.getRun(event);
         if(run==0) return true;
         

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/LayerEfficiencyAnalyzer.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/LayerEfficiencyAnalyzer.java
@@ -214,7 +214,7 @@ public class LayerEfficiencyAnalyzer extends DCEngine implements IDataEventListe
     private final ArrayList<HashMap<Coordinate, H1F>> LayerEffsTrkD = new ArrayList<HashMap<Coordinate, H1F>>();
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         int run = this.getRun(event);
         if(run==0) return true;
@@ -449,7 +449,7 @@ public class LayerEfficiencyAnalyzer extends DCEngine implements IDataEventListe
             while (reader.hasEvent()) {
                 counter++;
                 DataEvent event = reader.getNextEvent();
-                tm.processDataEvent(event);
+                tm.processDataEventUser(event);
                 tm.ProcessLayerEffs(event);
                 //event.show();
                 if(counter%1000==0) {

--- a/reconstruction/dc/src/test/java/org/jlab/service/dc/DCReconstructionTest.java
+++ b/reconstruction/dc/src/test/java/org/jlab/service/dc/DCReconstructionTest.java
@@ -50,8 +50,8 @@ public class DCReconstructionTest {
     DCHBPostClusterConv engineHB = new DCHBPostClusterConv();
     engineCL.init();
     engineHB.init();
-    engineCL.processDataEvent(testEvent); 
-    engineHB.processDataEvent(testEvent); 
+    engineCL.processEvent(testEvent); 
+    engineHB.processEvent(testEvent); 
     if(testEvent.hasBank("HitBasedTrkg::HBTracks")) {
         testEvent.getBank("HitBasedTrkg::HBTracks").show();
     }

--- a/reconstruction/dc/src/test/java/org/jlab/service/dc/DCReconstructionTest.java
+++ b/reconstruction/dc/src/test/java/org/jlab/service/dc/DCReconstructionTest.java
@@ -50,8 +50,8 @@ public class DCReconstructionTest {
     DCHBPostClusterConv engineHB = new DCHBPostClusterConv();
     engineCL.init();
     engineHB.init();
-    engineCL.processEvent(testEvent); 
-    engineHB.processEvent(testEvent); 
+    engineCL.processDataEvent(testEvent); 
+    engineHB.processDataEvent(testEvent); 
     if(testEvent.hasBank("HitBasedTrkg::HBTracks")) {
         testEvent.getBank("HitBasedTrkg::HBTracks").show();
     }

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -65,7 +65,7 @@ public class EBEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
+    public boolean processDataEventUser(DataEvent de) {
         throw new RuntimeException("EBEngine cannot be used directly.  Use EBTBEngine/EBHBEngine instead.");
     }
 
@@ -90,7 +90,7 @@ public class EBEngine extends ReconstructionEngine {
         }
     }
 
-    public boolean processDataEvent(DataEvent de,EBScalers ebs) {
+    public boolean processDataEventUser(DataEvent de,EBScalers ebs) {
 
         // check run number, get constants from CCDB:
         int run=-1;

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -1,6 +1,5 @@
 package org.jlab.service.eb;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -353,5 +352,8 @@ public class EBEngine extends ReconstructionEngine {
 
         return true;
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {}
     
 }

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBHBAIEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBHBAIEngine.java
@@ -18,8 +18,8 @@ public class EBHBAIEngine extends EBEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
-        return super.processDataEvent(de,ebScalers);
+    public boolean processDataEventUser(DataEvent de) {
+        return super.processDataEventUser(de,ebScalers);
     }
 
     @Override

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBHBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBHBEngine.java
@@ -18,8 +18,8 @@ public class EBHBEngine extends EBEngine {
     }
    
     @Override
-    public boolean processDataEvent(DataEvent de) {
-        return super.processDataEvent(de,ebScalers);
+    public boolean processDataEventUser(DataEvent de) {
+        return super.processDataEventUser(de,ebScalers);
     }
 
     @Override

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBAIEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBAIEngine.java
@@ -18,8 +18,8 @@ public class EBTBAIEngine extends EBEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
-        return super.processDataEvent(de,ebScalers);
+    public boolean processDataEventUser(DataEvent de) {
+        return super.processDataEventUser(de,ebScalers);
     }
 
     @Override

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBEngine.java
@@ -24,8 +24,8 @@ public class EBTBEngine extends EBEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
-        final boolean ret = super.processDataEvent(de,ebScalers);
+    public boolean processDataEventUser(DataEvent de) {
+        final boolean ret = super.processDataEventUser(de,ebScalers);
         this.linkTracks(de);
         return ret;
     }

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/VersionEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/VersionEngine.java
@@ -25,7 +25,7 @@ public class VersionEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         if (!done) {
             JsonObject versions = Versions.getVersionsJson();
             JsonObject config = new JsonObject();

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/VersionEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/VersionEngine.java
@@ -44,4 +44,7 @@ public class VersionEngine extends ReconstructionEngine {
         return true;
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {}
+
 }

--- a/reconstruction/ec/src/main/java/org/jlab/display/ec/ECRECMonitor.java
+++ b/reconstruction/ec/src/main/java/org/jlab/display/ec/ECRECMonitor.java
@@ -22,9 +22,12 @@ public class ECRECMonitor extends ReconstructionEngine {
     public ECRECMonitor(){
         super("ECMon","gavalian","1.0");
     }
-    
+   
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public void detectorChanged(int runNumber) {}
+
+    @Override
+    public boolean processDataEventUser(DataEvent event) {
         if(event.hasBank("REC::Particle")==true){
             DataBank bank = event.getBank("REC::Particle");
             int index1 = this.index(bank, 22, 0);
@@ -62,6 +65,7 @@ public class ECRECMonitor extends ReconstructionEngine {
         }
         return -1; 
     }
+
     @Override
     public boolean init() {
         canvas = new TGCanvas("c","EC Engine Monitoring",500,500);

--- a/reconstruction/ec/src/main/java/org/jlab/display/ec/ECRECMonitor.java
+++ b/reconstruction/ec/src/main/java/org/jlab/display/ec/ECRECMonitor.java
@@ -69,5 +69,8 @@ public class ECRECMonitor extends ReconstructionEngine {
         pion = new H1F("pion",120,0.005,0.6);
         return true;
     }
-    
+
+    public void detectorChanged(int run) {
+    }
+
 }

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -466,5 +466,10 @@ public class ECEngine extends ReconstructionEngine {
         
         return true;
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
     
 }

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -30,7 +30,7 @@ public class ECEngine extends ReconstructionEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent de) {
+    public boolean processDataEventUser(DataEvent de) {
                            
         List<ECStrip>     ecStrips = ECCommon.initEC(de, this.getConstantsManager()); // thresholds, ADC/TDC match        
         List<ECPeak>       ecPeaks = ECCommon.processPeaks(ECCommon.createPeaks(ecStrips)); // thresholds, split peaks -> update peak-lines          

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -423,12 +423,8 @@ public class ECEngine extends ReconstructionEngine {
         
         
         requireConstants(Arrays.asList(ecTables));
-        
+
         getConstantsManager().setVariation(ECCommon.variation);
-        String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        if(!(ECCommon.geomVariation.equals("default"))) variationName = ECCommon.geomVariation;
-        LOGGER.log(Level.INFO,"GEOMETRY VARIATION IS "+variationName);
-        ECCommon.ecDetector =  GeometryFactory.getDetector(DetectorType.ECAL,11,variationName);
 
         setConfig("test");
         
@@ -469,7 +465,10 @@ public class ECEngine extends ReconstructionEngine {
 
     @Override
     public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
+        String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
+        if(!(ECCommon.geomVariation.equals("default"))) variationName = ECCommon.geomVariation;
+        LOGGER.log(Level.INFO,"GEOMETRY VARIATION IS "+variationName);
+        ECCommon.ecDetector =  GeometryFactory.getDetector(DetectorType.ECAL,11,variationName);
     }
     
 }

--- a/reconstruction/ec/src/main/java/org/jlab/service/swim/SwimEngine.java.old
+++ b/reconstruction/ec/src/main/java/org/jlab/service/swim/SwimEngine.java.old
@@ -48,7 +48,7 @@ public class SwimEngine extends ReconstructionEngine {
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         //this.test_caching_index();
         //this.test_caching();
         this.swimParticles(event);

--- a/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
+++ b/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
@@ -30,7 +30,7 @@ public class ECReconstructionTest {
     
     ECEngine engineEC = new ECEngine();
     engineEC.init();
-    engineEC.processEvent(testEvent);
+    engineEC.processDataEvent(testEvent);
 
     testEvent.show();
     testEvent.getBank("ECAL::hits").show();

--- a/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
+++ b/reconstruction/ec/src/test/java/org/jlab/service/ec/ECReconstructionTest.java
@@ -30,7 +30,7 @@ public class ECReconstructionTest {
     
     ECEngine engineEC = new ECEngine();
     engineEC.init();
-    engineEC.processDataEvent(testEvent);
+    engineEC.processEvent(testEvent);
 
     testEvent.show();
     testEvent.getBank("ECAL::hits").show();

--- a/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
+++ b/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
@@ -233,4 +233,9 @@ public class FMTEngine extends ReconstructionEngine {
         return true;
    }
 
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
 }

--- a/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
+++ b/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
@@ -26,6 +26,7 @@ import org.jlab.rec.fmt.track.fit.StateVecs.StateVec;
  */
 public class FMTEngine extends ReconstructionEngine {
 
+    String variation = null;
     boolean debug = false;
 
     public FMTEngine() {
@@ -36,7 +37,7 @@ public class FMTEngine extends ReconstructionEngine {
     public boolean init() {
         
         // Get the constants for the correct variation
-        String variation = this.getEngineConfigString("variation");
+        variation = this.getEngineConfigString("variation");
         if (variation!=null) {
             System.out.println("["+this.getName()+"] " +
                     "run with FMT geometry variation based on yaml = " + variation);
@@ -45,7 +46,6 @@ public class FMTEngine extends ReconstructionEngine {
             variation = "default";
             System.out.println("["+this.getName()+"] run with FMT default geometry");
         }
-        
 
         String[] tables = new String[]{
             "/geometry/beam/position",
@@ -55,10 +55,6 @@ public class FMTEngine extends ReconstructionEngine {
         requireConstants(Arrays.asList(tables));
         this.getConstantsManager().setVariation(variation);
 
-        // Load the geometry
-        int run = 10;
-        Constants.setDetector(GeometryFactory.getDetector(DetectorType.FMT,run, variation));
-
         // Register output banks
         super.registerOutputBank("FMT::Hits");
         super.registerOutputBank("FMT::Clusters");
@@ -67,6 +63,12 @@ public class FMTEngine extends ReconstructionEngine {
         super.registerOutputBank("FMT::Trajectory");
         
         return true;
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        Constants.setDetector(GeometryFactory.getDetector(DetectorType.FMT,runNumber,
+            getConstantsManager().getVariation()));
     }
 
     @Override
@@ -232,10 +234,4 @@ public class FMTEngine extends ReconstructionEngine {
 
         return true;
    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }

--- a/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
+++ b/reconstruction/fmt/src/main/java/org/jlab/service/fmt/FMTEngine.java
@@ -72,7 +72,7 @@ public class FMTEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         // Initial setup.
         if(debug) System.out.println("\nNew event");
         

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
@@ -61,7 +61,7 @@ public class FTEBEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         int run = this.setRunConditionsParameters(event);
         if (run>=0) {
@@ -376,10 +376,10 @@ public class FTEBEngine extends ReconstructionEngine {
             // always print to keep track of running
             if(debugMode>-1) System.out.println("////////////// event read " + bankEvt + " - sequential number " + nev);
             //if(nev > 10239) System.exit(0); if(nev != 10239) continue; // stop at a given evt number
-            cal.processDataEvent(event);
-            hodo.processDataEvent(event);
-	    trk.processDataEventAndGetClusters(event);
-            en.processDataEvent(event);
+            cal.processDataEventUser(event);
+            hodo.processDataEventUser(event);
+	        trk.processDataEventAndGetClusters(event);
+            en.processDataEventUser(event);
             if(!event.hasBank("FTCAL::hits")) continue; 
             if (event instanceof EvioDataEvent) {
                 GenericKinematicFitter fitter = new GenericKinematicFitter(11);

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
@@ -53,11 +53,12 @@ public class FTEBEngine extends ReconstructionEngine {
         };
         requireConstants(Arrays.asList(tables));
         this.getConstantsManager().setVariation("default");
-
         this.registerOutputBank("FT::particles");
-
         return true;
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {}
 
     @Override
     public boolean processDataEvent(DataEvent event) {
@@ -1004,10 +1005,5 @@ public class FTEBEngine extends ReconstructionEngine {
         frameCALTRK.setLocationRelativeTo(null);
         frameCALTRK.setVisible(true);
             
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/FTEBEngine.java
@@ -1,6 +1,5 @@
 package org.jlab.rec.ft;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -1005,5 +1004,10 @@ public class FTEBEngine extends ReconstructionEngine {
         frameCALTRK.setLocationRelativeTo(null);
         frameCALTRK.setVisible(true);
             
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
@@ -32,22 +32,23 @@ public class FTCALEngine extends ReconstructionEngine {
 		reco = new FTCALReconstruction();
 		reco.debugMode=0;
 
-                String[]  tables = new String[]{ 
-                    "/calibration/ft/ftcal/charge_to_energy",
-                    "/calibration/ft/ftcal/time_offsets",
-                    "/calibration/ft/ftcal/time_walk",
-                    "/calibration/ft/ftcal/status",
-                    "/calibration/ft/ftcal/thresholds",
-                    "/calibration/ft/ftcal/cluster",
-                    "/calibration/ft/ftcal/energycorr"
-                };
-                requireConstants(Arrays.asList(tables));
-                this.getConstantsManager().setVariation("default");
-
-                this.registerOutputBank("FTCAL::hits","FTCAL::clusters");
-                
-                return true;
+        String[]  tables = new String[]{ 
+            "/calibration/ft/ftcal/charge_to_energy",
+            "/calibration/ft/ftcal/time_offsets",
+            "/calibration/ft/ftcal/time_walk",
+            "/calibration/ft/ftcal/status",
+            "/calibration/ft/ftcal/thresholds",
+            "/calibration/ft/ftcal/cluster",
+            "/calibration/ft/ftcal/energycorr"
+        };
+        requireConstants(Arrays.asList(tables));
+        this.getConstantsManager().setVariation("default");
+        this.registerOutputBank("FTCAL::hits","FTCAL::clusters");       
+        return true;
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {}
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
@@ -178,10 +179,4 @@ public class FTCALEngine extends ReconstructionEngine {
         frame.setVisible(true);     
 
 	}	
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-	
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
@@ -19,7 +19,6 @@ import org.jlab.io.evio.EvioDataBank;
 import org.jlab.io.evio.EvioDataEvent;
 import org.jlab.io.hipo.HipoDataSource;
 
-
 public class FTCALEngine extends ReconstructionEngine {
 
 	public FTCALEngine() {
@@ -179,5 +178,10 @@ public class FTCALEngine extends ReconstructionEngine {
         frame.setVisible(true);     
 
 	}	
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 	
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/cal/FTCALEngine.java
@@ -51,7 +51,7 @@ public class FTCALEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
             List<FTCALHit>     allHits           = new ArrayList();
             List<FTCALHit>     selectedHits      = new ArrayList();
             List<FTCALCluster> clusters          = new ArrayList();
@@ -123,7 +123,7 @@ public class FTCALEngine extends ReconstructionEngine {
         while(reader.hasEvent()){
 //        for(int nev=0; nev<2; nev++){
             DataEvent event = (DataEvent) reader.getNextEvent();
-            cal.processDataEvent(event);
+            cal.processDataEventUser(event);
 
             if(event instanceof EvioDataEvent) {
                 GenericKinematicFitter      fitter = new GenericKinematicFitter(11);

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
@@ -1,6 +1,5 @@
 package org.jlab.rec.ft.hodo;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import javax.swing.JFrame;
@@ -134,4 +133,9 @@ public class FTHODOEngine extends ReconstructionEngine {
         frame.setVisible(true);     
 
 	}		
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
@@ -45,7 +45,7 @@ public class FTHODOEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
 
             // update calibration constants based on run number if changed
             int run = setRunConditionsParameters(event);
@@ -104,7 +104,7 @@ public class FTHODOEngine extends ReconstructionEngine {
 
         while(reader.hasEvent()){
             DataEvent event = (DataEvent) reader.getNextEvent();
-            cal.processDataEvent(event);
+            cal.processDataEventUser(event);
 
             DetectorEvent detectorEvent = DetectorData.readDetectorEvent(event);
             PhysicsEvent            gen = detectorEvent.getGeneratedEvent();

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/hodo/FTHODOEngine.java
@@ -29,19 +29,20 @@ public class FTHODOEngine extends ReconstructionEngine {
 		reco = new FTHODOReconstruction();
 		reco.debugMode=0;
 
-                String[]  tables = new String[]{ 
-                    "/calibration/ft/fthodo/charge_to_energy",
-                    "/calibration/ft/fthodo/time_offsets",
-                    "/calibration/ft/fthodo/status",
-                    "/geometry/ft/fthodo"
-                };
-                requireConstants(Arrays.asList(tables));
-                this.getConstantsManager().setVariation("default");
-
-                this.registerOutputBank("FTHODO::hits","FTHODO::clusters");
-                
-                return true;
+        String[]  tables = new String[]{ 
+            "/calibration/ft/fthodo/charge_to_energy",
+            "/calibration/ft/fthodo/time_offsets",
+            "/calibration/ft/fthodo/status",
+            "/geometry/ft/fthodo"
+        };
+        requireConstants(Arrays.asList(tables));
+        this.getConstantsManager().setVariation("default");
+        this.registerOutputBank("FTHODO::hits","FTHODO::clusters");
+        return true;
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {}
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
@@ -133,9 +134,4 @@ public class FTHODOEngine extends ReconstructionEngine {
         frame.setVisible(true);     
 
 	}		
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
 }

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
@@ -362,6 +362,11 @@ public class FTTRKEngine extends ReconstructionEngine {
         frame3.setVisible(true); 
         
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }
 
         

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
@@ -44,9 +44,7 @@ public class FTTRKEngine extends ReconstructionEngine {
             };
             requireConstants(Arrays.asList(tables));
             this.getConstantsManager().setVariation("default");
-            
-            // use 11 provisionally as run number to download the basic FTTK geometry constants
-            FTTRKConstantsLoader.Load(11, this.getConstantsManager().getVariation());
+
             reco = new FTTRKReconstruction();
 	        reco.debugMode=0;
             
@@ -56,6 +54,11 @@ public class FTTRKEngine extends ReconstructionEngine {
 
             return true;
 	}
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        FTTRKConstantsLoader.Load(runNumber, this.getConstantsManager().getVariation());
+    }
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
@@ -344,11 +347,6 @@ public class FTTRKEngine extends ReconstructionEngine {
         frame3.setLocationRelativeTo(null);
         frame3.setVisible(true); 
         
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }
 

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
@@ -48,70 +48,57 @@ public class FTTRKEngine extends ReconstructionEngine {
             // use 11 provisionally as run number to download the basic FTTK geometry constants
             FTTRKConstantsLoader.Load(11, this.getConstantsManager().getVariation());
             reco = new FTTRKReconstruction();
-	    reco.debugMode=0;
+	        reco.debugMode=0;
             
             if(this.getEngineConfigString("fall18TT")!=null) {
                 FTTRKConstantsLoader.ADJUSTTT = Boolean.parseBoolean(this.getEngineConfigString("fall18TT"));
             }
-/*
-            String[]  tables = new String[]{ 
-                "/calibration/ft/fthodo/charge_to_energy",
-                "/calibration/ft/fthodo/time_offsets",
-                "/calibration/ft/fthodo/status",
-                "/geometry/ft/fthodo",
-                "/geometry/ft/fttrk"
-            };
-            requireConstants(Arrays.asList(tables));
-            this.getConstantsManager().setVariation("default");
-*/            
-            
 
             return true;
 	}
 
 	@Override
 	public boolean processDataEvent(DataEvent event) {
-            // update calibration constants based on run number if changed
-            int run = setRunConditionsParameters(event);
+        // update calibration constants based on run number if changed
+        int run = setRunConditionsParameters(event);
+        if(run>=0) {
+            // get hits fron banks
+            List<FTTRKHit> allHits = reco.initFTTRK(event,this.getConstantsManager(), run); 
+            // create clusters
+            List<FTTRKCluster> clusters = reco.findClusters(allHits);
+            // create crosses
+            List<FTTRKCross> crosses = reco.findCrosses(clusters);
+            // update hit banks with associated clusters/crosses information
+            reco.updateAllHitsWithAssociatedIDs(allHits, clusters);
+            // write output banks
+            reco.writeBanks(event, allHits, clusters, crosses);
+        }
+        return true;
+	}
+        
+    public ArrayList<FTTRKCluster> processDataEventAndGetClusters(DataEvent event) {
+        List<FTTRKHit> allHits      = new ArrayList();
+        ArrayList<FTTRKCluster> clusters = new ArrayList();   // era ArrayList
+        ArrayList<FTTRKCross>   crosses  = new ArrayList();
             
-            if(run>=0) {
-                // get hits fron banks
-                List<FTTRKHit> allHits = reco.initFTTRK(event,this.getConstantsManager(), run); 
+        // update calibration constants based on run number if changed
+        int run = setRunConditionsParameters(event);
+            
+        if(run>=0) {
+            // get hits from banks
+            allHits = reco.initFTTRK(event,this.getConstantsManager(), run);
+            if(allHits.size()>0){
                 // create clusters
-                List<FTTRKCluster> clusters = reco.findClusters(allHits);
+                clusters = reco.findClusters(allHits);
                 // create crosses
-                List<FTTRKCross> crosses = reco.findCrosses(clusters);
+                crosses = reco.findCrosses(clusters);
                 // update hit banks with associated clusters/crosses information
                 reco.updateAllHitsWithAssociatedIDs(allHits, clusters);
                 // write output banks
                 reco.writeBanks(event, allHits, clusters, crosses);
             }
-            return true;
-	}
-        
-        public ArrayList<FTTRKCluster> processDataEventAndGetClusters(DataEvent event) {
-            List<FTTRKHit> allHits      = new ArrayList();
-            ArrayList<FTTRKCluster> clusters = new ArrayList();   // era ArrayList
-            ArrayList<FTTRKCross>   crosses  = new ArrayList();
-            
-            // update calibration constants based on run number if changed
-            int run = setRunConditionsParameters(event);
-            
-            if(run>=0) {
-                // get hits from banks
-                allHits = reco.initFTTRK(event,this.getConstantsManager(), run);
-                if(allHits.size()>0){
-                    // create clusters
-                    clusters = reco.findClusters(allHits);
-                    // create crosses
-                    crosses = reco.findCrosses(clusters);
-                    // update hit banks with associated clusters/crosses information
-                    reco.updateAllHitsWithAssociatedIDs(allHits, clusters);
-                    // write output banks
-                    reco.writeBanks(event, allHits, clusters, crosses);
-                }
-            }
-            return clusters;
+        }
+        return clusters;
 	}      
 
     public int setRunConditionsParameters(DataEvent event) {
@@ -119,25 +106,22 @@ public class FTTRKEngine extends ReconstructionEngine {
         if(event.hasBank("RUN::config")==false) {
                 System.out.println("RUN CONDITIONS NOT READ!");
         }       
-    
         DataBank bank = event.getBank("RUN::config");
-            run = bank.getInt("run")[0];
-        
-	return run;	
+        run = bank.getInt("run")[0];
+	    return run;	
     }
-
     
     public static void main (String arg[]) {
         int debug = FTTRKReconstruction.debugMode;
-	FTTRKEngine trk = new FTTRKEngine();
-	trk.init();
+	    FTTRKEngine trk = new FTTRKEngine();
+	    trk.init();
         // insert input filename here
         String input = "/home/filippi/clas12/fttrkDev/clas12-offline-software-6.5.13-fttrkDev/filter_005418_newbanks.hipo";
         System.out.println("input file " + input);
-	HipoDataSource  reader = new HipoDataSource();
-	reader.open(input);
+	    HipoDataSource  reader = new HipoDataSource();
+	    reader.open(input);
 		
-	// initialize histos
+	    // initialize histos
         H2F h1 = new H2F("h1", "Layer vs. Component", 768, 0., 769., 4, 0.5, 4.5);
         h1.setTitleX("Component");
         h1.setTitleY("Layer");
@@ -177,7 +161,6 @@ public class FTTRKEngine extends ReconstructionEngine {
         int nc1 = 0, nc2 = 0, ncmatch = 0;
         int nev=0;
         while(reader.hasEvent()){
-//        int nev1 = 0; int nev2 = 20000; for(nev=nev1; nev<nev2; nev++){   // debug only a set of events (uncomment while loop in case)
             DataEvent event = (DataEvent) reader.getNextEvent();
             if(debug>=1) System.out.println("~~~~~~~~~~~~~~~~~~~~~~~~ processing event ~~~~~~~~~~~ " + nev); 
                         

--- a/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
+++ b/reconstruction/ft/src/main/java/org/jlab/rec/ft/trk/FTTRKEngine.java
@@ -61,7 +61,7 @@ public class FTTRKEngine extends ReconstructionEngine {
     }
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
         // update calibration constants based on run number if changed
         int run = setRunConditionsParameters(event);
         if(run>=0) {

--- a/reconstruction/ft/src/test/java/org/jlab/service/ft/FTEBEngineTest.java
+++ b/reconstruction/ft/src/test/java/org/jlab/service/ft/FTEBEngineTest.java
@@ -1676,4 +1676,9 @@ public class FTEBEngineTest extends ReconstructionEngine {
         frametrkonlyresVsCoord.setLocationRelativeTo(null);
         frametrkonlyresVsCoord.setVisible(true);
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/ft/src/test/java/org/jlab/service/ft/FTEBEngineTest.java
+++ b/reconstruction/ft/src/test/java/org/jlab/service/ft/FTEBEngineTest.java
@@ -99,7 +99,7 @@ public class FTEBEngineTest extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         List<FTParticle> FTparticles = new ArrayList<FTParticle>();
         List<FTResponse> FTresponses = new ArrayList<FTResponse>();
 
@@ -486,7 +486,7 @@ public class FTEBEngineTest extends ReconstructionEngine {
             //if(nev > 10239) System.exit(0); if(nev != 10239) continue; // stop at a given evt number
             cal.processDataEvent(event);
             hodo.processDataEvent(event);
-	    trk.processDataEventAndGetClusters(event);
+	        trk.processDataEventAndGetClusters(event);
             en.processDataEvent(event);
             if(!event.hasBank("FTCAL::hits")) continue; 
             if (event instanceof EvioDataEvent) {

--- a/reconstruction/ft/src/test/java/org/jlab/service/ft/FTTRKEngineTest.java
+++ b/reconstruction/ft/src/test/java/org/jlab/service/ft/FTTRKEngineTest.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.jlab.service.ft;
 
 import java.util.ArrayList;
@@ -560,6 +555,11 @@ public class FTTRKEngineTest extends ReconstructionEngine {
         frame3.setLocationRelativeTo(null);
         frame3.setVisible(true); 
         
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }
 

--- a/reconstruction/ft/src/test/java/org/jlab/service/ft/FTTRKEngineTest.java
+++ b/reconstruction/ft/src/test/java/org/jlab/service/ft/FTTRKEngineTest.java
@@ -61,7 +61,7 @@ public class FTTRKEngineTest extends ReconstructionEngine {
 	}
 
 	@Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
             List<FTTRKHit> allHits      = new ArrayList();
             ArrayList<FTTRKCluster> clusters = new ArrayList();
             ArrayList<FTTRKCross>   crosses  = new ArrayList();

--- a/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
@@ -20,7 +20,7 @@ public class HTCCReconstructionService extends ReconstructionEngine{
     }
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         int runNo = 10;
 
         if(event.hasBank("RUN::config")==true){

--- a/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
@@ -66,6 +66,11 @@ public class HTCCReconstructionService extends ReconstructionEngine{
         return true;
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
    
     
 }

--- a/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
@@ -48,9 +48,7 @@ public class HTCCReconstructionService extends ReconstructionEngine{
 
     @Override
     public boolean init() {
-        
-
-            String[]  htccTables = new String[]{
+        String[]  htccTables = new String[]{
             "/calibration/htcc/gain", 
             "/calibration/htcc/time", 
             "/calibration/htcc/ring_time", 
@@ -59,18 +57,12 @@ public class HTCCReconstructionService extends ReconstructionEngine{
             "/geometry/htcc/htcc", 
     
         };
-            
         this.registerOutputBank("HTCC::rec");
-        
         requireConstants(Arrays.asList(htccTables));
         return true;
     }
 
     @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
-   
+    public void detectorChanged(int runNumber) {}
     
 }

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
@@ -24,7 +24,7 @@ public class LTCCEngine extends ReconstructionEngine {
     }
     
     @Override
-	public boolean processDataEvent(DataEvent event) {
+	public boolean processDataEventUser(DataEvent event) {
         if (DEBUG) event.show();
         // only process the event if the LTCC bank is present
         if (event.hasBank("LTCC::adc")) {

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
@@ -4,7 +4,6 @@ import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataEvent;
 import java.util.List;
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -51,5 +50,10 @@ public class LTCCEngine extends ReconstructionEngine {
             this.registerOutputBank("LTCC::clusters");
             return true;
         }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
        
 }

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
@@ -17,9 +17,7 @@ public class LTCCEngine extends ReconstructionEngine {
 
     private static final boolean DEBUG = false;
     private static final List<String> CC_TABLES = 
-        Arrays.asList("/calibration/ltcc/spe",
-                      "/calibration/ltcc/status"
-                );
+        Arrays.asList("/calibration/ltcc/spe","/calibration/ltcc/status");
     
     public LTCCEngine() {
     	super("LTCC", "joosten", "1.0");
@@ -27,33 +25,28 @@ public class LTCCEngine extends ReconstructionEngine {
     
     @Override
 	public boolean processDataEvent(DataEvent event) {
-            if (DEBUG) event.show();
-            // only process the event if the LTCC bank is present
-            if (event.hasBank("LTCC::adc")) {
-                if (DEBUG) event.getBank("LTCC::adc").show();
-                List<LTCCHit> hits = 
-                        LTCCHit.loadHits(event, this.getConstantsManager());
-                List<LTCCCluster> clusters =
-                        LTCCClusterFinder.findClusters(hits);
-                LTCCCluster.saveClusters(event, clusters);
-                if (DEBUG) {
-                    event.getBank("LTCC::clusters").show();
-                }
-            }
-            
-            return true;
-        }
+        if (DEBUG) event.show();
+        // only process the event if the LTCC bank is present
+        if (event.hasBank("LTCC::adc")) {
+            if (DEBUG) event.getBank("LTCC::adc").show();
+            List<LTCCHit> hits = 
+                    LTCCHit.loadHits(event, this.getConstantsManager());
+            List<LTCCCluster> clusters =
+                    LTCCClusterFinder.findClusters(hits);
+            LTCCCluster.saveClusters(event, clusters);
+            if (DEBUG) event.getBank("LTCC::clusters").show();
+        }    
+        return true;
+    }
         
     @Override
-        public boolean init() {
-            this.requireConstants(CC_TABLES);            
-            this.registerOutputBank("LTCC::clusters");
-            return true;
-        }
+    public boolean init() {
+        this.requireConstants(CC_TABLES);            
+        this.registerOutputBank("LTCC::clusters");
+        return true;
+    }
 
     @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
+    public void detectorChanged(int runNumber) {}
        
 }

--- a/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
+++ b/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
@@ -233,6 +233,11 @@ public class TruthMatch extends ReconstructionEngine {
 
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
+
     /**
      * ************************************************************************
      * Defining objects that will be needed int the matching process

--- a/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
+++ b/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
@@ -46,7 +46,7 @@ public class TruthMatch extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
 
         if (event.hasBank("MC::True") == false) {
             return false;

--- a/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
+++ b/reconstruction/mc/src/main/java/org/jlab/service/mc/TruthMatch.java
@@ -234,9 +234,7 @@ public class TruthMatch extends ReconstructionEngine {
     }
 
     @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
+    public void detectorChanged(int runNumber) {}
 
     /**
      * ************************************************************************

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
@@ -83,7 +83,7 @@ public class MLTDEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
+    public boolean processDataEventUser(DataEvent de) {
         if(de.hasBank(inputBank)==true){
             DataBank bank = de.getBank(inputBank);
                         

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
@@ -141,5 +141,10 @@ public class MLTDEngine extends ReconstructionEngine {
         //System.out.println("appending bank");
         event.appendBank(bank);
     }*/
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
     
 }

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
@@ -80,6 +80,9 @@ public class MLTDEngine extends ReconstructionEngine {
     }
 
     @Override
+    public void detectorChanged(int runNumber) {}
+
+    @Override
     public boolean processDataEvent(DataEvent de) {
         if(de.hasBank(inputBank)==true){
             DataBank bank = de.getBank(inputBank);
@@ -141,10 +144,4 @@ public class MLTDEngine extends ReconstructionEngine {
         //System.out.println("appending bank");
         event.appendBank(bank);
     }*/
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-    
 }

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
@@ -19,44 +19,39 @@ import org.jlab.utils.CLASResources;
  */
 public class MLTDEngine extends ReconstructionEngine {
     
-
     EJMLTrackNeuralNetwork       network = null;
     private String         networkFlavor = "default";
-    private Integer           networkRun = 5038;
+    private Integer        userRunNumber = -1;
     private String       inputBankPrefix = "";
     private String      outputBankPrefix = "ai";
     private String             inputBank = null;
     private String            outputBank = null;
-    
+    private ArchiveProvider     provider = null;
+
     public MLTDEngine(){
         super("MLTD","gavalian","1.0");
     }
     
     @Override
     public boolean init() {
-        
-        //Set bank names
         inputBankPrefix  = Optional.ofNullable(this.getEngineConfigString("inputBankPrefix")).orElse("");
         outputBankPrefix = Optional.ofNullable(this.getEngineConfigString("outputBankPrefix")).orElse("ai");
         inputBank  = "HitBasedTrkg::"+inputBankPrefix+"Clusters";
         outputBank = outputBankPrefix+"::tracks";
-        
         networkFlavor = Optional.ofNullable(this.getEngineConfigString("flavor")).orElse("default");
-        String runNumber = Optional.ofNullable(this.getEngineConfigString("run")).orElse("5038");
-        networkRun = Integer.parseInt(runNumber);
-        
+        userRunNumber = Integer.valueOf(Optional.ofNullable(this.getEngineConfigString("run")).orElse("-1"));
+        return true;
+    }
+
+    public boolean load(int run) {
         String path = CLASResources.getResourcePath("etc/ejml/ejmlclas12.network"); 
         if(this.getEngineConfigString("network")!=null) 
             path = this.getEngineConfigString("network");
         System.out.println("[neural-network] info : Loading neural network from " + path);
-        
         network = new EJMLTrackNeuralNetwork();        
-        Map<String,String>  files = new HashMap<String,String>();
+        Map<String,String>  files = new HashMap<>();
         files.put("classifier", "trackClassifier.network");
-        files.put("fixer", "trackFixer.network");        
-        
         ArchiveProvider provider = new ArchiveProvider(path.trim());
-        
         //----- This will find in the archive the last run number closest
         //----- to provided run number that contains trained network.
         //----- it works similar to CCDB, but not exatly, for provided 
@@ -64,42 +59,27 @@ public class MLTDEngine extends ReconstructionEngine {
         //----- however it the provided run # it lower than anything 
         //----- existing in the arhive, it will return the closest run 
         //----- number entry.
-        int adjustedRun = provider.findEntry(networkRun);
-        
+        int adjustedRun = provider.findEntry(run);
         String directory = String.format("network/%d/%s", adjustedRun, networkFlavor);
-        network.initZip(path.trim(),directory, files);
-        
-        //trackFinder = Clas12TrackFinder.createEJML("CLAS12DIR","etc/ejml/ejmlclas12.network");
-        //classifier.setEnvDirectory("CLAS12DIR");
-        //classifier.setEnvPath("etc/nnet/neuroph");
-        //classifier.load("trackClassifier.nnet", "trackFixer.nnet");
-        System.out.println("[neural-network] info : Loading neural network files done...");
-        System.out.println("[neural-network] info : Only network is initialized...");
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
+        network.initZip(path.trim(), directory, files);
         return true;
     }
 
     @Override
-    public void detectorChanged(int runNumber) {}
+    public void detectorChanged(int runNumber) {
+        if (userRunNumber < 0) {
+            load(runNumber);
+        }
+        else if (network == null) {
+            load(userRunNumber);
+        }
+    }
 
     @Override
     public boolean processDataEventUser(DataEvent de) {
         if(de.hasBank(inputBank)==true){
-            DataBank bank = de.getBank(inputBank);
-                        
+            DataBank bank = de.getBank(inputBank);           
             HipoDataBank hipoBank = (HipoDataBank) bank;
-                        
-            //classifier.processBank(hipoBank.getBank());
-            
-            /*Clas12TrackAnalyzer analyzer = new Clas12TrackAnalyzer();
-            for(int sector = 1; sector <=6; sector++){
-                analyzer.readBank(hipoBank.getBank(), sector);
-                classifier.evaluate(analyzer.getCombinations());
-                //analyzer.getCombinations().analyze();
-                //System.out.println(analyzer.getCombinations());
-                classifier.evaluate5(analyzer.getCombinationsPartial());
-                analyzer.analyze();
-            }*/            
             Clas12TrackFinder trackFinder = new Clas12TrackFinder();
             trackFinder.setTrackingNetwork(network);
             trackFinder.process(hipoBank.getBank());            
@@ -109,8 +89,6 @@ public class MLTDEngine extends ReconstructionEngine {
     }
     
     public void writeBank(DataEvent event, ClusterCombinations combi){
-        //ClusterCombinations combi = cl.getTracks();
-        //System.out.println(">>> writing ai bank with entries = " + combi.getSize());        
         DataBank bank = event.createBank(outputBank, combi.getSize());
         for(int i = 0; i < combi.getSize(); i++){
             bank.setByte("id", i, (byte) (i+1));
@@ -123,25 +101,8 @@ public class MLTDEngine extends ReconstructionEngine {
                 bank.setShort("c"+order, i, (short) ids[c]);
             }
         }
-        //System.out.println("appending bank");
         event.removeBank(outputBank);
         event.appendBank(bank);
     }
 
-    /*public void writeBank(DataEvent event, Clas12TrackClassifier cl){
-        ClusterCombinations combi = cl.getTracks();
-        //System.out.println(">>> writing ai bank with entries = " + combi.getSize());
-        DataBank bank = event.createBank("ai::tracks", combi.getSize());
-        for(int i = 0; i < combi.getSize(); i++){
-            bank.setByte("id", i, (byte) (i+1));
-            bank.setByte("sector", i, (byte) 1);
-            int[] ids = combi.getLabels(i);
-            for(int c = 0; c < 6; c++){
-                int order = c+1;
-                bank.setShort("c"+order, i, (short) ids[c]);
-            }
-        }
-        //System.out.println("appending bank");
-        event.appendBank(bank);
-    }*/
 }

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTDEngine.java
@@ -26,7 +26,6 @@ public class MLTDEngine extends ReconstructionEngine {
     private String      outputBankPrefix = "ai";
     private String             inputBank = null;
     private String            outputBank = null;
-    private ArchiveProvider     provider = null;
 
     public MLTDEngine(){
         super("MLTD","gavalian","1.0");

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.jlab.service.mltn;
 
 import j4ml.clas12.Clas12TrackAnalyzer;
@@ -96,5 +91,10 @@ public class MLTNEngine extends ReconstructionEngine {
         //System.out.println("appending bank");
         event.appendBank(bank);
     }*/
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
     
 }

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
@@ -34,7 +34,7 @@ public class MLTNEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
 
     @Override
-    public boolean processDataEvent(DataEvent de) {
+    public boolean processDataEventUser(DataEvent de) {
         if(de.hasBank("HitBasedTrkg::Clusters")==true){
             DataBank bank = de.getBank("HitBasedTrkg::Clusters");
             

--- a/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
+++ b/reconstruction/mltn/src/main/java/org/jlab/service/mltn/MLTNEngine.java
@@ -11,7 +11,7 @@ import org.jlab.io.hipo.HipoDataBank;
 /**
  *
  * @author gavalian
- @deprecated 
+ @Deprecated 
  */
 public class MLTNEngine extends ReconstructionEngine {
     
@@ -27,9 +27,11 @@ public class MLTNEngine extends ReconstructionEngine {
         classifier.setEnvPath("etc/nnet/neuroph");
         classifier.load("trackClassifier.nnet", "trackFixer.nnet");
         System.out.println("Loading neural network files done...");
-        //throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
         return true;
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {}
 
     @Override
     public boolean processDataEvent(DataEvent de) {
@@ -91,10 +93,4 @@ public class MLTNEngine extends ReconstructionEngine {
         //System.out.println("appending bank");
         event.appendBank(bank);
     }*/
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-    
 }

--- a/reconstruction/postproc/src/main/java/org/jlab/service/postproc/PostprocEngine.java
+++ b/reconstruction/postproc/src/main/java/org/jlab/service/postproc/PostprocEngine.java
@@ -47,6 +47,9 @@ public class PostprocEngine extends ReconstructionEngine {
     }
 
     @Override
+    public void detectorChanged(int run) {}
+
+    @Override
     public boolean processDataEvent(DataEvent event) {
         processor.processEvent(event);
         return true;

--- a/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
+++ b/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
@@ -51,7 +51,7 @@ public class RasterEngine extends ReconstructionEngine {
     public void detectorChanged(int runNumber) {}
     
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
                
         // Read run number from RUN::config bank
         int run=-1;
@@ -131,7 +131,7 @@ public class RasterEngine extends ReconstructionEngine {
             System.out.print("MC position read : " + MC_Part.getFloat("vx",0) +"\n");
             
             // run the raster engine
-            engine.processDataEvent(event);
+            engine.processDataEventUser(event);
             
             // read the output bank and fill the histograms
             if(event.hasBank("RASTER::position")) {

--- a/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
+++ b/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
@@ -157,4 +157,9 @@ public class RasterEngine extends ReconstructionEngine {
         frame.setVisible(true);
 
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
+++ b/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
@@ -47,6 +47,8 @@ public class RasterEngine extends ReconstructionEngine {
         return true;
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {}
     
     @Override
     public boolean processDataEvent(DataEvent event) {
@@ -156,10 +158,5 @@ public class RasterEngine extends ReconstructionEngine {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
 
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
+++ b/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
@@ -72,12 +72,12 @@ public class RICHEBEngine extends ReconstructionEngine {
 
     @Override
     // ----------------
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
     // ----------------
 
         int debugMode = 0;
 
-        // create instances of all event-dependent classes in processDataEvent to avoid interferences between different threads when running in clara
+        // create instances of all event-dependent classes in processDataEventUser to avoid interferences between different threads when running in clara
         RICHEvent              richevent = new RICHEvent();
         RICHio                 richio    = new RICHio();
         RICHCalibration        richcal   = new RICHCalibration();

--- a/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
+++ b/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
@@ -10,30 +10,20 @@ public class RICHEBEngine extends ReconstructionEngine {
 
     private int Run = -1;
     private int Ncalls = 0;
-
     private long EBRICH_start_time;
-    
     private RICHGeoFactory       richgeo;
     private RICHTime             richtime = new RICHTime();
     private boolean engineDebug = false;
 
-
-    // ----------------
     public RICHEBEngine() {
-    // ----------------
         super("RICHEB", "mcontalb", "3.0");
-
     }
 
-
     @Override
-    // ----------------
     public boolean init() {
-    // ----------------
 
         int debugMode = 0;
         if(debugMode>=1)System.out.format("I am in RICHEBEngine init \n");
-
 
         String[] richTables = new String[]{
                     "/geometry/rich/setup",
@@ -70,16 +60,15 @@ public class RICHEBEngine extends ReconstructionEngine {
         if(this.getEngineConfigString("debug")!=null) 
             this.engineDebug = Boolean.parseBoolean(this.getEngineConfigString("debug"));
 
-        // Get the constant tables for reconstruction parameters, geometry and optical characterization
-        int run = 11;
-
-        richgeo   = new RICHGeoFactory(1, this.getConstantsManager(), run, engineDebug);
-        richtime.init_ProcessTime();
-
         return true;
 
     }
-
+    
+    @Override
+    public void detectorChanged(int runNumber) {
+        richgeo = new RICHGeoFactory(1, this.getConstantsManager(), runNumber, engineDebug);
+        richtime.init_ProcessTime();
+    }
 
     @Override
     // ----------------
@@ -146,10 +135,4 @@ public class RICHEBEngine extends ReconstructionEngine {
         return true;
 
     }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }

--- a/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
+++ b/reconstruction/rich/src/main/java/org/jlab/rec/rich/RICHEBEngine.java
@@ -1,22 +1,9 @@
 package org.jlab.rec.rich;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.swing.JFrame;
-
-import org.jlab.clas.reco.ReconstructionEngine;
-import org.jlab.io.base.DataEvent;
-import org.jlab.io.base.DataBank;
-
-import org.jlab.utils.groups.IndexedTable;
 import java.util.Arrays;
 import java.util.Optional;
-
-import org.jlab.geom.prim.Plane3D;
-import org.jlab.geom.prim.Line3D;
-
+import org.jlab.clas.reco.ReconstructionEngine;
+import org.jlab.io.base.DataEvent;
 import org.jlab.detector.geom.RICH.RICHGeoFactory;
 
 public class RICHEBEngine extends ReconstructionEngine {
@@ -158,6 +145,11 @@ public class RICHEBEngine extends ReconstructionEngine {
 
         return true;
 
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
 }

--- a/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
+++ b/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
@@ -47,8 +47,7 @@ public class RTPCEngine extends ReconstructionEngine{
         String cosm = this.getEngineConfigString("rtpcCosmic");
         String beamfit = this.getEngineConfigString("rtpcBeamlineFit");
         String disentangler = this.getEngineConfigString("rtpcDisentangler");
-	String chi2cull = this.getEngineConfigString("rtpcChi2Cull");
-        //System.out.println(sim + " " + cosm + " " + beamfit);
+	    String chi2cull = this.getEngineConfigString("rtpcChi2Cull");
         String kfstatus = this.getEngineConfigString("rtpcKF");
 
         if(sim != null){
@@ -91,8 +90,9 @@ public class RTPCEngine extends ReconstructionEngine{
 
         return true;
     }
-
-
+    
+    @Override
+    public void detectorChanged(int runNumber) {}
 
     @Override
     public boolean processDataEvent(DataEvent event) {
@@ -285,10 +285,5 @@ public class RTPCEngine extends ReconstructionEngine{
                 put("BONuS12Gas", BONuS12);
             }
         };
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
+++ b/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
@@ -95,7 +95,7 @@ public class RTPCEngine extends ReconstructionEngine{
     public void detectorChanged(int runNumber) {}
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
 
         HitParameters params = new HitParameters();
 
@@ -223,7 +223,7 @@ public class RTPCEngine extends ReconstructionEngine{
         while(reader.hasEvent()){
             DataEvent event = reader.getNextEvent();
             //if(eventcount == eventselect){
-            en.processDataEvent(event);
+            en.processDataEventUser(event);
             writer.writeEvent(event);
             //}else if(eventcount > eventselect) break;
             eventcount ++;

--- a/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
+++ b/reconstruction/rtpc/src/main/java/org/jlab/service/rtpc/RTPCEngine.java
@@ -1,9 +1,6 @@
 package org.jlab.service.rtpc;
 
 import java.io.File;
-
-
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -26,15 +23,11 @@ import org.jlab.rec.rtpc.hit.TrackDisentangler;
 import org.jlab.rec.rtpc.hit.TrackFinder;
 import org.jlab.rec.rtpc.hit.TrackHitReco;
 import org.jlab.rec.rtpc.hit.HelixFitTest;
-import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.utils.groups.IndexedTable;
 
 import org.jlab.clas.tracking.kalmanfilter.Material;
 
-
-
 public class RTPCEngine extends ReconstructionEngine{
-
 
     public RTPCEngine() {
         super("RTPC","davidp","3.0");
@@ -292,5 +285,10 @@ public class RTPCEngine extends ReconstructionEngine{
                 put("BONuS12Gas", BONuS12);
             }
         };
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/swaps/src/main/java/org/jlab/service/swaps/SwapEngine.java
+++ b/reconstruction/swaps/src/main/java/org/jlab/service/swaps/SwapEngine.java
@@ -37,7 +37,7 @@ public class SwapEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         DataBank bank = event.getBank("RUN::config");
         final int run = bank.getInt("run",0);
         for (String detectorName : this.swapman.getDetectors()) {

--- a/reconstruction/swaps/src/main/java/org/jlab/service/swaps/SwapEngine.java
+++ b/reconstruction/swaps/src/main/java/org/jlab/service/swaps/SwapEngine.java
@@ -87,4 +87,7 @@ public class SwapEngine extends ReconstructionEngine {
         return true;
     }
 
+    @Override
+    public void detectorChanged(int runNumber) {}
+
 }

--- a/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
@@ -75,7 +75,7 @@ public class CTOFEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         //setRunConditionsParameters( event) ;
         if(event.hasBank("RUN::config")==false ) {
             System.err.println("RUN CONDITIONS NOT READ!");
@@ -210,7 +210,7 @@ public class CTOFEngine extends ReconstructionEngine {
             counter++;
             DataEvent event = reader.getNextEvent();
            
-            en.processDataEvent(event);
+            en.processDataEventUser(event);
             writer.writeEvent(event);
             if (counter > 3) {
                 break;

--- a/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
@@ -1,6 +1,5 @@
 package org.jlab.service.ctof;
 
-import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -8,12 +7,10 @@ import java.util.List;
 import java.util.Optional;
 
 import org.jlab.clas.reco.ReconstructionEngine;
-import org.jlab.coda.jevio.EvioException;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.base.GeometryFactory;
 import org.jlab.detector.geant4.v2.CTOFGeant4Factory;
 import org.jlab.geom.base.ConstantProvider;
-import org.jlab.geometry.prim.Line3d;
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
 import org.jlab.io.hipo.HipoDataSource;
@@ -230,6 +227,11 @@ public class CTOFEngine extends ReconstructionEngine {
         double t = System.currentTimeMillis() - t1;
         System.out.println("TOTAL  PROCESSING TIME = " + t);
         writer.close();
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 
 }

--- a/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ctof/CTOFEngine.java
@@ -43,13 +43,9 @@ public class CTOFEngine extends ReconstructionEngine {
     
     @Override
     public boolean init() {
-        // Load the Constants
-        // if (Constants.CSTLOADED == false) {
         Constants.Load();
-        // }
         rbc = new RecoBankWriter();
-        // CalibrationConstantsLoader.Load();
-        // }
+
         String[]  ctofTables = new String[]{ 
                     "/calibration/ctof/attenuation",
                     "/calibration/ctof/effective_velocity",
@@ -65,16 +61,17 @@ public class CTOFEngine extends ReconstructionEngine {
                 };
         
         requireConstants(Arrays.asList(ctofTables));
-       
-       // Get the constants for the correct variation
         this.getConstantsManager().setVariation("default");
-        String engineVariation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        ConstantProvider cp = GeometryFactory.getConstants(DetectorType.CTOF, 11, engineVariation);
-        geometry = new CTOFGeant4Factory(cp);
-        
         this.registerOutputBank("CTOF::rawhits","CTOF::hits","CTOF::clusters");
-        
         return true;
+    }
+    
+    
+    @Override
+    public void detectorChanged(int runNumber) {
+        String engineVariation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
+        ConstantProvider cp = GeometryFactory.getConstants(DetectorType.CTOF, runNumber, engineVariation);
+        geometry = new CTOFGeant4Factory(cp);
     }
 
     @Override
@@ -86,8 +83,6 @@ public class CTOFEngine extends ReconstructionEngine {
         }
 
         DataBank bank = event.getBank("RUN::config");
-//	System.out.println();
-//	System.out.println(bank.getInt("event", 0));
         
         // Load the constants
         //-------------------
@@ -228,10 +223,4 @@ public class CTOFEngine extends ReconstructionEngine {
         System.out.println("TOTAL  PROCESSING TIME = " + t);
         writer.close();
     }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
-
 }

--- a/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
@@ -82,13 +82,10 @@ public class FTOFEngine extends ReconstructionEngine {
 
     @Override
     public boolean processDataEvent(DataEvent event) {
-        // System.out.println(" PROCESSING EVENT ....");
-        // Constants.DEBUGMODE = true;
-        //setRunConditionsParameters( event) ;
         if(event.hasBank("RUN::config")==false ) {
-		System.err.println("RUN CONDITIONS NOT READ!");
-		return true;
-	}
+		    System.err.println("RUN CONDITIONS NOT READ!");
+		    return true;
+	    }
 		
         DataBank bank = event.getBank("RUN::config");
 		
@@ -212,23 +209,9 @@ public class FTOFEngine extends ReconstructionEngine {
         
         // 3.4) exit if cluster list is empty but save the hits
         rbc.appendFTOFBanks(event, hits, clusters, matchedClusters, TrkType);
-//            if (event.hasBank("FTOF::adc")) {
-//                if (event.hasBank("FTOF::adc")) {
-//                    event.getBank("FTOF::adc").show();
-//                }
-//                if (event.hasBank("FTOF::tdc")) {
-//                    event.getBank("FTOF::tdc").show();
-//                }
-//                if (event.hasBank("FTOF::hits")) {
-//                    event.getBank("FTOF::hits").show();
-//                }
-//            }
-
 
         return true;
     }
-
-    
 
     public static void main(String arg[]) {
         FTOFHBEngine en = new FTOFHBEngine();

--- a/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
@@ -284,4 +284,9 @@ public class FTOFEngine extends ReconstructionEngine {
         System.out.println(t1 + " TOTAL  PROCESSING TIME = "
                 + (t / (float) counter));
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
@@ -81,7 +81,7 @@ public class FTOFEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         if(event.hasBank("RUN::config")==false ) {
 		    System.err.println("RUN CONDITIONS NOT READ!");
 		    return true;
@@ -243,11 +243,11 @@ public class FTOFEngine extends ReconstructionEngine {
                 t1 = System.currentTimeMillis();
             }
 
-            //en0.processDataEvent(event);
+            //en0.processDataEventUser(event);
             //	if (counter > 3062)
-            //en0.processDataEvent(event);
-            //en1.processDataEvent(event);
-            en.processDataEvent(event);
+            //en0.processDataEventUser(event);
+            //en1.processDataEventUser(event);
+            en.processDataEventUser(event);
             System.out.println("  EVENT " + counter);
             //if (counter > 3066)
             //	break;

--- a/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
+++ b/reconstruction/tof/src/main/java/org/jlab/service/ftof/FTOFEngine.java
@@ -45,9 +45,6 @@ public class FTOFEngine extends ReconstructionEngine {
     
     @Override
     public boolean init() {
-
-        // Load the Constants
-        // if (Constants.CSTLOADED == false) {
         Constants.Load();
         rbc = new RecoBankWriter();
 
@@ -68,19 +65,19 @@ public class FTOFEngine extends ReconstructionEngine {
                  };
         
         requireConstants(Arrays.asList(ftofTables));
-       
-       // Get the constants for the correct variation
         this.getConstantsManager().setVariation("default");
-        
-        // Get geometry database provider, load the geometry tables and create geometry
-        String engineVariation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        ConstantProvider db = GeometryFactory.getConstants(DetectorType.FTOF, 11, engineVariation);
-        geometry = new FTOFGeant4Factory(db);
 
         this.registerOutputBank("FTOF::rawhits","FTOF::hbhits","FTOF::hbclusters");
         this.registerOutputBank("FTOF::hits","FTIF::clusters","FTOF::matchedClusters");
 
         return true;
+    }
+    
+    @Override
+    public void detectorChanged(int runNumber) {
+        String engineVariation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
+        ConstantProvider db = GeometryFactory.getConstants(DetectorType.FTOF, runNumber, engineVariation);
+        geometry = new FTOFGeant4Factory(db);
     }
 
     @Override
@@ -283,10 +280,5 @@ public class FTOFEngine extends ReconstructionEngine {
         double t = System.currentTimeMillis() - t1;
         System.out.println(t1 + " TOTAL  PROCESSING TIME = "
                 + (t / (float) counter));
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
+++ b/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
@@ -38,10 +38,6 @@ public class URWellEngine extends ReconstructionEngine {
     @Override
     public boolean init() {
 
-        // init ConstantsManager to read constants from CCDB
-        String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        DatabaseConstantProvider cp = new DatabaseConstantProvider(11, variationName);
-        factory.init(cp, false, URWellConstants.NREGION);
         // register output banks for drop option        
         this.registerOutputBank("URWELL::hits");
         this.registerOutputBank("URWELL::clusters");
@@ -51,8 +47,12 @@ public class URWellEngine extends ReconstructionEngine {
         return true;
     }
 
-
-
+    @Override
+    public void detectorChanged(int runNumber) {
+        String variationName = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
+        DatabaseConstantProvider cp = new DatabaseConstantProvider(runNumber, variationName);
+        factory.init(cp, false, URWellConstants.NREGION);
+    }
 
     @Override
     public boolean processDataEvent(DataEvent event) {
@@ -241,10 +241,5 @@ public class URWellEngine extends ReconstructionEngine {
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);     
 
-    }
-
-    @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
     }
 }

--- a/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
+++ b/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
@@ -242,4 +242,9 @@ public class URWellEngine extends ReconstructionEngine {
         frame.setVisible(true);     
 
     }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
+    }
 }

--- a/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
+++ b/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
@@ -55,7 +55,7 @@ public class URWellEngine extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         
         List<URWellStrip>     strips = URWellStrip.getStrips(event, factory, this.getConstantsManager());
         List<URWellCluster> clusters = URWellCluster.createClusters(strips);
@@ -180,7 +180,7 @@ public class URWellEngine extends ReconstructionEngine {
         while(reader.hasEvent()) {
             DataEvent event = reader.getNextEvent();
 
-            engine.processDataEvent(event);
+            engine.processDataEventUser(event);
             
             double xtrue = 0;
             double ytrue = 0;

--- a/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
+++ b/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
@@ -30,8 +30,6 @@ public class VTXReconstruction extends ReconstructionEngine {
 
     String FieldsConfig = "";
     private int Run = -1;
-  
- 
 
     public int getRun() {
         return Run;
@@ -55,6 +53,7 @@ public class VTXReconstruction extends ReconstructionEngine {
         requireConstants(Arrays.asList(tables));
         this.getConstantsManager().setVariation("default");
     }
+
     @Override
     public boolean processDataEvent(DataEvent event) {
         this.FieldsConfig = this.getFieldsConfig();
@@ -97,19 +96,10 @@ public class VTXReconstruction extends ReconstructionEngine {
     public boolean init() {
         this.initConstantsTables();
         String variation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
-        //beam offset table
-        DatabaseConstantProvider dbprovider = new DatabaseConstantProvider(11, variation);
-        dbprovider.loadTable("/geometry/beam/position");
+        registerOutputBank("REC::VertDoca");
         return true;
-    }
-    private void registerBanks() {
-        super.registerOutputBank("REC::VertDoca");    
-    } 
-    public static void main(String[] args) {
     }
 
     @Override
-    public void detectorChanged(int runNumber) {
-        throw new UnsupportedOperationException("Not supported yet.");
-    }
+    public void detectorChanged(int runNumber) {}
 }

--- a/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
+++ b/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
@@ -55,7 +55,7 @@ public class VTXReconstruction extends ReconstructionEngine {
     }
 
     @Override
-    public boolean processDataEvent(DataEvent event) {
+    public boolean processDataEventUser(DataEvent event) {
         this.FieldsConfig = this.getFieldsConfig();
         if (event.hasBank("RUN::config") == false) {
             System.err.println("RUN CONDITIONS NOT READ!");

--- a/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
+++ b/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXReconstruction.java
@@ -7,11 +7,7 @@ import java.util.Optional;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.clas.swimtools.Swim;
-import org.jlab.detector.base.DetectorType;
-import org.jlab.detector.base.GeometryFactory;
 import org.jlab.detector.calib.utils.DatabaseConstantProvider;
-import org.jlab.geom.base.ConstantProvider;
-import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
 import org.jlab.rec.vtx.TrackParsHelix;
 import org.jlab.rec.vtx.Vertex;
@@ -110,5 +106,10 @@ public class VTXReconstruction extends ReconstructionEngine {
         super.registerOutputBank("REC::VertDoca");    
     } 
     public static void main(String[] args) {
+    }
+
+    @Override
+    public void detectorChanged(int runNumber) {
+        throw new UnsupportedOperationException("Not supported yet.");
     }
 }


### PR DESCRIPTION
Added abstract method `detectorChanged(int run)` to ReconstructionEngine, which is called automatically when the run number changes.

Moved every engine's geometry initialization from init or elsewhere to `detectorChanged`.

Changed the name of ReconstructionEngine's abstract event-processing method from processDataEvent to procesDataEventUser, and filterEvent to processDataEvent, such that all external uses of processDataEvent still do the right thing.