### PR TITLE
ci: test with latest `groovy` version

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ defaults:
 env:
   java_version: 17
   java_distribution: zulu
-  groovy_version: 4.0.3
+  groovy_version: 4.x
 
 jobs:
 

--- a/validation/advanced-tests/test-run-groovy.groovy
+++ b/validation/advanced-tests/test-run-groovy.groovy
@@ -15,3 +15,5 @@
 
 // try to import a local package
 import org.jlab.clas.physics.*
+
+System.out.println "TEST PASSED"


### PR DESCRIPTION
We should no longer be bothered by https://github.com/JeffersonLab/coatjava/pull/204