### PR TITLE
silence transformer warnings

### DIFF
--- a/common-tools/coat-lib/pom.xml
+++ b/common-tools/coat-lib/pom.xml
@@ -225,17 +225,15 @@
                           </excludes>
                       </filter>
                   </filters>
-                  <transformers>
-                      <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                          <manifestEntries>
-                              <Specification-Title>${project.artifactId}</Specification-Title>
-                              <Specification-Version>${project.version}</Specification-Version>
-                              <Implementation-Title>${project.artifactId}</Implementation-Title>
-                              <Implementation-Version>${project.version}</Implementation-Version>
-                              <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
-                          </manifestEntries>
-                      </transformer>
-                  </transformers>
+                  <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                      <manifestEntries>
+                          <Specification-Title>${project.artifactId}</Specification-Title>
+                          <Specification-Version>${project.version}</Specification-Version>
+                          <Implementation-Title>${project.artifactId}</Implementation-Title>
+                          <Implementation-Version>${project.version}</Implementation-Version>
+                          <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                      </manifestEntries>
+                  </transformer>
               </configuration>
               <executions>
                   <execution>


### PR DESCRIPTION
These:  `Warning:  Map in class org.apache.maven.plugins.shade.resource.ManifestResourceTransformer declares value type as: class java.util.jar.Attributes but saw: class java.lang.String at runtime`