### PR TITLE
Remove MC-specific condition in DC hit reconstruction

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -378,11 +378,6 @@ public class HitReader {
                  tFlight[i] = this.id2tidtFlight.get(id[i]);
             }
             
-            if (event.hasBank("MC::Particle") ||
-                    event.getBank("RUN::config").getInt("run", 0) < 100) {
-                tProp[i] = 0;
-                tFlight[i] = 0;
-            }
         }
 
         int size = layer.length;
@@ -405,12 +400,8 @@ public class HitReader {
                 continue;
             } 
             
-            if (!event.hasBank("MC::Particle") &&
-                    event.getBank("RUN::config").getInt("run", 0) > 100) {
-                //T_0 = this.getT0(sector[i], slayer[i], layer[i], wire[i], T0, T0ERR)[0];
-                if (event.hasBank(recBankName))
+            if (event.hasBank(recBankName))
                     T_Start = event.getBank(recBankName).getFloat("startTime", 0);
-            }  
             
             T_0 = this.getT0(sector[i], slayer[i], layer[i], wire[i], t0s)[0];
             FittedHit hit = new FittedHit(sector[i], slayer[i], layer[i], wire[i], tdc[i], jitter[i], id[i]);

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/RecoBankWriter.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/RecoBankWriter.java
@@ -551,7 +551,7 @@ public DataBank fillHBClustersBank(DataEvent event, List<FittedCluster> cluslist
             if(bank.getDescriptor().hasEntry("beta")){
                bank.setFloat("beta", i, (float) hitlist.get(i).get_Beta());
             }
-            if(hitlist.get(i).get_AssociatedTBTrackID()>-1 && !event.hasBank("MC::Particle")) {
+            if(hitlist.get(i).get_AssociatedTBTrackID()>-1) {
                 if(hitlist.get(i).getSignalPropagTimeAlongWire()==0 || hitlist.get(i).get_AssociatedTBTrackID()<1) {
                     bank.setFloat("TProp", i, (float) hitlist.get(i).getTProp()); //old value if track fit failed
                 } else {

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/hit/FittedHit.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/hit/FittedHit.java
@@ -194,8 +194,7 @@ public class FittedHit extends Hit implements Comparable<Hit> {
             }
 
             double x = this.get_Doca() / this.get_CellSize();
-            if(event.hasBank("MC::Particle") ||
-                    event.getBank("RUN::config").getInt("run", 0) < 100 ) { // for MC use functional form put in simulation
+            if(event.hasBank("MC::Particle")) { // for MC use functional form put in simulation
                 
                 double p1 = constants0.getDoubleValue("parameter1", this.get_Sector(),this.get_Superlayer(),0);
                 double p2 = constants0.getDoubleValue("parameter2", this.get_Sector(),this.get_Superlayer(),0);


### PR DESCRIPTION
Separating this from #422 and #434.

This was discussed to come after the switch to real run numbers.