### PR TITLE
feat: tell `dependabot` to check `clasweb` maven repos too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,21 @@
 version: 2
+
+registries:
+  clas12maven:
+    type: maven-repository
+    url: https://clasweb.jlab.org/clas12maven
+  jhep:
+    type: maven-repository
+    url: https://clasweb.jlab.org/jhep/maven
+
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
+    registries:
+      - clas12maven
+      - jhep
     ignore:
       - dependency-name: "org.jlab:groot" # since version numbers are not in order
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
If we can still rely on `clasweb` availability, we might as well check its maven repositories for dependency updates too.