### PR TITLE
Fix timestamp warning printout

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -156,7 +156,7 @@ public class CodaEventDecoder {
                     if(this.timeStampErrors<100) {
                         System.err.println("WARNING: mismatch in TI time stamps: crate " 
                                         + tiEntries.get(i).getDescriptor().getCrate() + " reports " 
-                                        + tiEntries.get(i).getTimeStamp() + " instead of the " + ts
+                                        + tiEntries.get(i).getTimeStamp() + " instead of the " + tiEntries.get(i0).getTimeStamp()
                                         + " from crate " + tiEntries.get(i0).getDescriptor().getCrate());
                     }
                     else if(this.timeStampErrors==100) {


### PR DESCRIPTION
It struck again w/ RG-L test data.  After this fix:  

`WARNING: mismatch in TI time stamps: crate 78 reports 72091467389 instead of the 71823449028 from crate 79`

Closes #395 

@whit2333