### PR TITLE
Added more "clicks" to timestamp tolerance.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,9 @@ workflow:
     - if: '$CI_COMMIT_BRANCH == "development"'
     - if: '$CI_COMMIT_TAG'
 
+variables:
+  KUBERNETES_MEMORY_LIMIT: "8Gi"
+
 default:
   image: ubuntu:noble
   retry: 2

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -151,7 +151,7 @@ public class CodaEventDecoder {
             for(int i=0; i<tiEntries.size(); i++) {
                 long deltaTS = this.timeStampTolerance;       
                 if(tiEntries.get(i).getDescriptor().getCrate()==this.tiMaster) deltaTS = deltaTS + 1;  // add 1 click tolerance for tiMaster
-                if(Math.abs(tiEntries.get(i).getTimeStamp()-tiEntries.get(i0).getTimeStamp())>deltaTS) {
+                if(Math.abs(tiEntries.get(i).getTimeStamp()-tiEntries.get(i0).getTimeStamp())>deltaTS+5) {
                     tiSync=false;
                     if(this.timeStampErrors<100) {
                         System.err.println("WARNING: mismatch in TI time stamps: crate " 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -151,6 +151,7 @@ public class CodaEventDecoder {
             for(int i=0; i<tiEntries.size(); i++) {
                 long deltaTS = this.timeStampTolerance;       
                 long offsetT = 0;
+		// crate 78 is ATOF which is a TIpcie based ROC 
                 if( tiEntries.get(i).getDescriptor().getCrate() == 78 ) offsetT = 5;
                 if(tiEntries.get(i).getDescriptor().getCrate()==this.tiMaster) deltaTS = deltaTS + 1;  // add 1 click tolerance for tiMaster
                 if(Math.abs(tiEntries.get(i).getTimeStamp()-offsetT-tiEntries.get(i0).getTimeStamp())>deltaTS) { // not sure about the sign of offsetT

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -153,7 +153,7 @@ public class CodaEventDecoder {
                 long offsetT = 0;
                 if( tiEntries.get(i).getDescriptor().getCrate() == 78 ) offsetT = 5;
                 if(tiEntries.get(i).getDescriptor().getCrate()==this.tiMaster) deltaTS = deltaTS + 1;  // add 1 click tolerance for tiMaster
-                if(Math.abs(tiEntries.get(i).getTimeStamp()+offsetT-tiEntries.get(i0).getTimeStamp())>deltaTS) { // not sure about the sign of offsetT
+                if(Math.abs(tiEntries.get(i).getTimeStamp()-offsetT-tiEntries.get(i0).getTimeStamp())>deltaTS) { // not sure about the sign of offsetT
                     tiSync=false;
                     if(this.timeStampErrors<100) {
                         System.err.println("WARNING: mismatch in TI time stamps: crate " 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -150,8 +150,10 @@ public class CodaEventDecoder {
             }
             for(int i=0; i<tiEntries.size(); i++) {
                 long deltaTS = this.timeStampTolerance;       
+                long offsetT = 0;
+                if( tiEntries.get(i).getDescriptor().getCrate() == 78 ) offsetT = 5;
                 if(tiEntries.get(i).getDescriptor().getCrate()==this.tiMaster) deltaTS = deltaTS + 1;  // add 1 click tolerance for tiMaster
-                if(Math.abs(tiEntries.get(i).getTimeStamp()-tiEntries.get(i0).getTimeStamp())>deltaTS+5) {
+                if(Math.abs(tiEntries.get(i).getTimeStamp()+offsetT-tiEntries.get(i0).getTimeStamp())>deltaTS) { // not sure about the sign of offsetT
                     tiSync=false;
                     if(this.timeStampErrors<100) {
                         System.err.println("WARNING: mismatch in TI time stamps: crate " 


### PR DESCRIPTION
Addresses issue #475.

I just added the 5 clicks that Sergey mentioned. To do this right, we need to know if the detector is using a TI board or TIpcie card. But I have verified this works with a recent "fixed" run 20764 where I can see the CTOF reconstruction.

Tests: 
- [no more errors in decoder](https://code.jlab.org/hallb/alert/c12/-/jobs/5862#L318)
- [no mismatches from CTOF in reconstruction](https://code.jlab.org/hallb/alert/c12/-/jobs/5866#L61)