### PR TITLE
feat: adding index of cluster match to hit bank

### DIFF
--- a/etc/bankdefs/hipo4/alert.json
+++ b/etc/bankdefs/hipo4/alert.json
@@ -89,6 +89,10 @@
         "name": "energy",
         "type": "F",
         "info": "deposited energy in MeV"
+      },{
+        "name": "clusterid",
+        "type": "I",
+        "info": "id of cluster to which the hit was associated"
       }
     ]
   },{

--- a/reconstruction/alert/src/main/java/org/jlab/rec/atof/banks/RecoBankWriter.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/atof/banks/RecoBankWriter.java
@@ -43,6 +43,7 @@ public class RecoBankWriter {
 
         for (int i = 0; i < hitList.size(); i++) {
             bank.setShort("id", i, (short) (i + 1));
+            bank.setInt("clusterid", i, (int) hitList.get(i).getAssociatedClusterIndex());
             bank.setInt("sector", i, (int) hitList.get(i).getSector());
             bank.setInt("layer", i, (int) hitList.get(i).getLayer());
             bank.setInt("component", i, (int) hitList.get(i).getComponent());

--- a/reconstruction/alert/src/main/java/org/jlab/rec/atof/cluster/ClusterFinder.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/atof/cluster/ClusterFinder.java
@@ -57,11 +57,12 @@ public class ClusterFinder {
 
         //A list of clusters is built for each event
         clusters.clear();
-
+        int cluster_id = 1;
+        
         //Getting the list of hits, they must have been ordered by energy already
         ArrayList<ATOFHit> wedge_hits = hitfinder.getWedgeHits();
         ArrayList<BarHit> bar_hits = hitfinder.getBarHits();
-
+        
         //Looping through wedge hits first
         for (int i_wedge = 0; i_wedge < wedge_hits.size(); i_wedge++) {
             ATOFHit this_wedge_hit = wedge_hits.get(i_wedge);
@@ -76,6 +77,7 @@ public class ClusterFinder {
 
             //Indicate that this hit now is in a cluster
             this_wedge_hit.setIsInACluster(true);
+            this_wedge_hit.setAssociatedClusterIndex(cluster_id);
             //And store it
             this_cluster_wedge_hits.add(this_wedge_hit);
 
@@ -105,6 +107,7 @@ public class ClusterFinder {
                     {
                         if (delta_T < Parameters.SIGMA_T_CLUSTERING) {
                             other_wedge_hit.setIsInACluster(true);
+                            other_wedge_hit.setAssociatedClusterIndex(cluster_id);
                             this_cluster_wedge_hits.add(other_wedge_hit);
                         }
                     }
@@ -133,6 +136,7 @@ public class ClusterFinder {
                     if (delta_Z < Parameters.SIGMA_Z_CLUSTERING) {
                         if (delta_T < Parameters.SIGMA_T_CLUSTERING) {
                             other_bar_hit.setIsInACluster(true);
+                            other_bar_hit.setAssociatedClusterIndex(cluster_id);
                             this_cluster_bar_hits.add(other_bar_hit);
                         }
                     }
@@ -143,6 +147,7 @@ public class ClusterFinder {
             ATOFCluster cluster = new ATOFCluster(this_cluster_bar_hits, this_cluster_wedge_hits, event);
             //And add it to the list of clusters
             clusters.add(cluster);
+            cluster_id++;
         }//End loop on all wedge hits
         //Now make clusters from bar hits that are not associated with wedge hits
         //Loop through all bar hits
@@ -156,6 +161,7 @@ public class ClusterFinder {
             ArrayList<ATOFHit> this_cluster_wedge_hits = new ArrayList<>();
             ArrayList<BarHit> this_cluster_bar_hits = new ArrayList<>();
             this_bar_hit.setIsInACluster(true);
+            this_bar_hit.setAssociatedClusterIndex(cluster_id);
             this_cluster_bar_hits.add(this_bar_hit);
 
             //Loop through less energetic clusters
@@ -182,6 +188,7 @@ public class ClusterFinder {
                     if (delta_Z < Parameters.SIGMA_Z_CLUSTERING) {
                         if (delta_T < Parameters.SIGMA_T_CLUSTERING) {
                             other_bar_hit.setIsInACluster(true);
+                            other_bar_hit.setAssociatedClusterIndex(cluster_id);
                             this_cluster_bar_hits.add(other_bar_hit);
                         }
                     }
@@ -189,6 +196,7 @@ public class ClusterFinder {
             }
             ATOFCluster cluster = new ATOFCluster(this_cluster_bar_hits, this_cluster_wedge_hits, event);
             clusters.add(cluster);
+            cluster_id++;
         }
     }
 

--- a/reconstruction/alert/src/main/java/org/jlab/rec/atof/hit/ATOFHit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/atof/hit/ATOFHit.java
@@ -20,6 +20,7 @@ public class ATOFHit {
     private double time, energy, x, y, z;
     private String type;
     private boolean isInACluster;
+    private int associatedClusterIndex;
 
     public int getSector() {
         return sector;
@@ -123,6 +124,14 @@ public class ATOFHit {
 
     public void setIsInACluster(boolean is_in_a_cluster) {
         this.isInACluster = is_in_a_cluster;
+    }
+    
+    public int getAssociatedClusterIndex() {
+        return associatedClusterIndex;
+    }
+
+    public void setAssociatedClusterIndex(int index) {
+        this.associatedClusterIndex = index;
     }
 
     /**


### PR DESCRIPTION
Adding an index to the hit bank that corresponds to the cluster it was associated to. There is always such an index (if hit is not added to an existing cluster, a new cluster is built for it).

I will also need to add a match index between ahdc tracks and their projections, and between track projections and their clusters. I will do it once I implement ways to deal with clusters not matched to tracks.