### PR TITLE
Updated the ALERT reconstruction services package names

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/AHDCEngine.java
@@ -1,4 +1,4 @@
-package org.jlab.rec.service;
+package org.jlab.service.ahdc;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.clas.tracking.kalmanfilter.Material;

--- a/reconstruction/alert/src/main/java/org/jlab/rec/service/ATOFEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/service/ATOFEngine.java
@@ -1,4 +1,4 @@
-package org.jlab.rec.service;
+package org.jlab.service.atof;
 
 import java.util.ArrayList;
 


### PR DESCRIPTION
This is to be consistent with  the other subsystems package naming scheme.