### PR TITLE
ci: use newer `javadoc`

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,8 +21,9 @@ defaults:
     shell: bash
 
 env:
-  java_version: 24
+  java_version: 17
   java_distribution: zulu
+  javadoc_version: 24 # newer for better javadoc
   groovy_version: 4.x
 
 jobs:
@@ -170,7 +171,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ env.java_version }}
+          java-version: ${{ env.javadoc_version }}
           distribution: ${{ env.java_distribution }}
       - name: build
         run: ./build-coatjava.sh

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,7 +21,7 @@ defaults:
     shell: bash
 
 env:
-  java_version: 17
+  java_version: 24
   java_distribution: zulu
   groovy_version: 4.x
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -23,7 +23,7 @@ defaults:
 env:
   java_version: 17
   java_distribution: zulu
-  javadoc_version: 24 # newer for better javadoc
+  javadoc_version: 24 # newer than `java_version` for better javadoc
   groovy_version: 4.x
 
 jobs:


### PR DESCRIPTION
Is there any reason we should hold this back? The generated `javadoc` website is nicer when 23+, compared to 17, since it generates a navigation sidebar.

With this, `generate_documentation` also tests building with newer OpenJDK.