### PR TITLE
Undo unwanted modifications in rec/ahdc/Hit/Hit.java

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/Hit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/Hit.java
@@ -70,8 +70,8 @@ public class Hit implements Comparable<Hit> {
 		R_layer = R_layer + DR_layer * (this.layerId-1);
 		double alphaW_layer = Math.toRadians(round / (numWires));
 		//should it be at z = 0? in which case, we need to account for the positive or negative stereo angle...
-		double wx           = -R_layer * Math.sin(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
-		double wy           = -R_layer * Math.cos(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
+		double wx           = R_layer * Math.cos(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
+		double wy           = R_layer * Math.sin(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
 		
 		//System.out.println(" superlayer " + this.superLayerId + " layer " + this.layerId + " wire " + this.wireId + " R_layer " + R_layer + " wx " + wx + " wy " + wy);
 		


### PR DESCRIPTION
The issue comes from this commit "Add new entries in AHDC::Track, KFTrack and Hits". From here, we have a mismatch between the geometry service and the reconstruction service.

This will make all the AHDC geometry issues at the stage they were in the release **12.0.3t**. 