### PR TITLE
Ahdc geo revert and redo

### DIFF
--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -132,13 +132,13 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 		for (int wireId = 0; wireId < numWires; wireId++) {
 
 			// The point given by (wx, wy, wz) is the midpoint of the current wire.
-			double wx = R_layer * Math.cos(alphaW_layer * wireId);
-			double wy = R_layer * Math.sin(alphaW_layer * wireId);
+			double wx = -R_layer * Math.sin(alphaW_layer * wireId);
+			double wy = -R_layer * Math.cos(alphaW_layer * wireId);
 
 			// Find the interesection of the current wire with the end-plate
 			// planes by construciting a long line that passes through the midpoint
-			double wx_end = R_layer * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double wy_end = R_layer * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double wx_end = -R_layer * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double wy_end = -R_layer * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
 			Line3D line   = new Line3D(wx, wy, 0, wx_end, wy_end, zl);
 
 			Point3D lPoint = new Point3D();
@@ -150,31 +150,31 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			// Do not change the code above. It is for signal wires positioning
 
 			// Construct the cell around the signal wires created above top
-			double px_0 = (R_layer + 2) * Math.cos(alphaW_layer * wireId);
-			double py_0 = (R_layer + 2) * Math.sin(alphaW_layer * wireId);
-			double px_1 = (R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
-			double py_1 = (R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
-			double px_2 = (R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
-			double py_2 = (R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
-			double px_3 = (R_layer - 2) * Math.cos(alphaW_layer * wireId);
-			double py_3 = (R_layer - 2) * Math.sin(alphaW_layer * wireId);
-			double px_4 = (R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
-			double py_4 = (R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
-			double px_5 = (R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
-			double py_5 = (R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
+			double px_0 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId);
+			double py_0 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId);
+			double px_1 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
+			double py_1 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
+			double px_2 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
+			double py_2 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
+			double px_3 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId);
+			double py_3 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId);
+			double px_4 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
+			double py_4 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
+			double px_5 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
+			double py_5 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
 			// bottom (do not forget to add the +20 deg. twist respect to the "straight" version)
-			double px_6  = (R_layer + 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double py_6  = (R_layer + 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double px_7  = (R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_7  = (R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_8  = (R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_8  = (R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_9  = (R_layer - 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double py_9  = (R_layer - 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double px_10 = (R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_10 = (R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_11 = (R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_11 = (R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_6  = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double py_6  = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double px_7  = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_7  = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_8  = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_8  = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_9  = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double py_9  = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double px_10 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_10 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_11 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_11 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
 
 			// Group into points with (x,y,z) coordinates
 			List<Point3D> firstF  = new ArrayList<>();

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -125,20 +125,25 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 		double alphaW_layer = Math.toRadians(round / (numWires));
 
 		// shift the wire end point +-20deg in XY plan
-		double thster = Math.toRadians(20.0d);
+		double thster = Math.toRadians(-20.0d);
 		double zl     = 300.0d;
 
 		// Create AHDC sense wires
-		for (int wireId = 0; wireId < numWires; wireId++) {
+		for (int iw = 0; iw < numWires; iw++) {
 
-			// The point given by (wx, wy, wz) is the midpoint of the current wire.
-			double wx = -R_layer * Math.sin(alphaW_layer * wireId);
-			double wy = -R_layer * Math.cos(alphaW_layer * wireId);
+                        int wireId = iw + 1 + (int) (numWires/2);
+                        if(wireId>numWires) wireId -= numWires;
+
+                        double wirePhiIndex = (numWires/2) + iw - 0.5*(layerId-1); // start at phi=180
+
+                        // The point given by (wx, wy, wz) is the origin of the current wire.
+			double wx = R_layer * Math.cos(alphaW_layer * wirePhiIndex);
+			double wy = R_layer * Math.sin(alphaW_layer * wirePhiIndex);
 
 			// Find the interesection of the current wire with the end-plate
 			// planes by construciting a long line that passes through the midpoint
-			double wx_end = -R_layer * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double wy_end = -R_layer * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
+			double wx_end = R_layer * Math.cos(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
+			double wy_end = R_layer * Math.sin(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
 			Line3D line   = new Line3D(wx, wy, 0, wx_end, wy_end, zl);
 
 			Point3D lPoint = new Point3D();
@@ -150,31 +155,31 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			// Do not change the code above. It is for signal wires positioning
 
 			// Construct the cell around the signal wires created above top
-			double px_0 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId);
-			double py_0 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId);
-			double px_1 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
-			double py_1 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
-			double px_2 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2);
-			double py_2 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2);
-			double px_3 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId);
-			double py_3 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId);
-			double px_4 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
-			double py_4 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
-			double px_5 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2);
-			double py_5 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2);
+			double px_0 = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex);
+			double py_0 = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex);
+			double px_1 = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex + alphaW_layer / 2);
+			double py_1 = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex + alphaW_layer / 2);
+			double px_2 = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex + alphaW_layer / 2);
+			double py_2 = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex + alphaW_layer / 2);
+			double px_3 = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex);
+			double py_3 = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex);
+			double px_4 = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex - alphaW_layer / 2);
+			double py_4 = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex - alphaW_layer / 2);
+			double px_5 = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex - alphaW_layer / 2);
+			double py_5 = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex - alphaW_layer / 2);
 			// bottom (do not forget to add the +20 deg. twist respect to the "straight" version)
-			double px_6  = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double py_6  = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double px_7  = -(R_layer + 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_7  = -(R_layer + 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_8  = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_8  = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_9  = -(R_layer - 2) * Math.sin(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double py_9  = -(R_layer - 2) * Math.cos(alphaW_layer * wireId + thster * (Math.pow(-1, superlayerId)));
-			double px_10 = -(R_layer - 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_10 = -(R_layer - 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double px_11 = -(R_layer + 2) * Math.sin(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
-			double py_11 = -(R_layer + 2) * Math.cos(alphaW_layer * wireId - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_6  = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
+			double py_6  = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
+			double px_7  = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_7  = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_8  = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_8  = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex + alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_9  = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
+			double py_9  = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
+			double px_10 = (R_layer - 2) * Math.cos(alphaW_layer * wirePhiIndex - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_10 = (R_layer - 2) * Math.sin(alphaW_layer * wirePhiIndex - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double px_11 = (R_layer + 2) * Math.cos(alphaW_layer * wirePhiIndex - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
+			double py_11 = (R_layer + 2) * Math.sin(alphaW_layer * wirePhiIndex - alphaW_layer / 2 + thster * (Math.pow(-1, superlayerId)));
 
 			// Group into points with (x,y,z) coordinates
 			List<Point3D> firstF  = new ArrayList<>();
@@ -195,25 +200,25 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			Point3D p_11 = new Point3D(px_11, py_11, zl);
 			// defining a cell around a wireLine, must be counter-clockwise!
 			firstF.add(p_0);
-			firstF.add(p_1);
-			firstF.add(p_2);
-			firstF.add(p_3);
-			firstF.add(p_4);
 			firstF.add(p_5);
+			firstF.add(p_4);
+			firstF.add(p_3);
+			firstF.add(p_2);
+			firstF.add(p_1);
 
 			secondF.add(p_6);
-			secondF.add(p_7);
-			secondF.add(p_8);
-			secondF.add(p_9);
-			secondF.add(p_10);
 			secondF.add(p_11);
+			secondF.add(p_10);
+			secondF.add(p_9);
+			secondF.add(p_8);
+			secondF.add(p_7);
 
 			// Create the cell and signal wire inside
 			// PrismaticComponent(int componentId, List<Point3D> firstFace, List<Point3D> secondFace)
 			// not possible to add directly PrismaticComponent class because it is an ABSTRACT
 			// a new class should be created: public class NewClassWire extends PrismaticComponent {...}
 			// 5 top points & 5 bottom points with convexe shape. Concave shape is not supported.
-			AlertDCWire wire = new AlertDCWire(wireId+1, wireLine, firstF, secondF);
+			AlertDCWire wire = new AlertDCWire(wireId, wireLine, firstF, secondF);
 			// Add wire object to the list
 			layer.addComponent(wire);
 		}

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -86,8 +86,8 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 		double R_layer  = 32.0d;
 		double DR_layer = 4.0d;
 
-		double   zoff1 = 0.0d;
-		double   zoff2 = 300.0d;
+		double   zoff1 = -150.0d;
+		double   zoff2 =  150.0d;
 		Point3D  p1    = new Point3D(R_layer, 0, zoff1);
 		Vector3D n1    = new Vector3D(0, 0, 1);
 
@@ -131,10 +131,12 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 		// Create AHDC sense wires
 		for (int iw = 0; iw < numWires; iw++) {
 
-                        int wireId = iw + 1 + (int) (numWires/2);
-                        if(wireId>numWires) wireId -= numWires;
+                        // start at phi=180
+                        double wirePhiIndex = (numWires/2) + iw - 0.5*(layerId-1); 
 
-                        double wirePhiIndex = (numWires/2) + iw - 0.5*(layerId-1); // start at phi=180
+                        // the wire id is such that the wire number = (wireId+1) is the first wqual or greater than numWires/2
+                        int wireId = iw + (int) (numWires/2);
+                        if(wireId>numWires-1) wireId -= numWires;
 
                         // The point given by (wx, wy, wz) is the origin of the current wire.
 			double wx = R_layer * Math.cos(alphaW_layer * wirePhiIndex);
@@ -144,7 +146,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			// planes by construciting a long line that passes through the midpoint
 			double wx_end = R_layer * Math.cos(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
 			double wy_end = R_layer * Math.sin(alphaW_layer * wirePhiIndex + thster * (Math.pow(-1, superlayerId)));
-			Line3D line   = new Line3D(wx, wy, 0, wx_end, wy_end, zl);
+			Line3D line   = new Line3D(wx, wy, -zl/2, wx_end, wy_end, zl/2);
 
 			Point3D lPoint = new Point3D();
 			Point3D rPoint = new Point3D();
@@ -185,19 +187,19 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			List<Point3D> firstF  = new ArrayList<>();
 			List<Point3D> secondF = new ArrayList<>();
 			// first Face
-			Point3D p_0 = new Point3D(px_0, py_0, 0.0d);
-			Point3D p_1 = new Point3D(px_1, py_1, 0.0d);
-			Point3D p_2 = new Point3D(px_2, py_2, 0.0d);
-			Point3D p_3 = new Point3D(px_3, py_3, 0.0d);
-			Point3D p_4 = new Point3D(px_4, py_4, 0.0d);
-			Point3D p_5 = new Point3D(px_5, py_5, 0.0d);
+			Point3D p_0 = new Point3D(px_0, py_0, -zl/2);
+			Point3D p_1 = new Point3D(px_1, py_1, -zl/2);
+			Point3D p_2 = new Point3D(px_2, py_2, -zl/2);
+			Point3D p_3 = new Point3D(px_3, py_3, -zl/2);
+			Point3D p_4 = new Point3D(px_4, py_4, -zl/2);
+			Point3D p_5 = new Point3D(px_5, py_5, -zl/2);
 			// second Face
-			Point3D p_6  = new Point3D(px_6, py_6, zl);
-			Point3D p_7  = new Point3D(px_7, py_7, zl);
-			Point3D p_8  = new Point3D(px_8, py_8, zl);
-			Point3D p_9  = new Point3D(px_9, py_9, zl);
-			Point3D p_10 = new Point3D(px_10, py_10, zl);
-			Point3D p_11 = new Point3D(px_11, py_11, zl);
+			Point3D p_6  = new Point3D(px_6, py_6, zl/2);
+			Point3D p_7  = new Point3D(px_7, py_7, zl/2);
+			Point3D p_8  = new Point3D(px_8, py_8, zl/2);
+			Point3D p_9  = new Point3D(px_9, py_9, zl/2);
+			Point3D p_10 = new Point3D(px_10, py_10, zl/2);
+			Point3D p_11 = new Point3D(px_11, py_11, zl/2);
 			// defining a cell around a wireLine, must be counter-clockwise!
 			firstF.add(p_0);
 			firstF.add(p_5);
@@ -218,7 +220,7 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			// not possible to add directly PrismaticComponent class because it is an ABSTRACT
 			// a new class should be created: public class NewClassWire extends PrismaticComponent {...}
 			// 5 top points & 5 bottom points with convexe shape. Concave shape is not supported.
-			AlertDCWire wire = new AlertDCWire(wireId, wireLine, firstF, secondF);
+			AlertDCWire wire = new AlertDCWire(wireId+1, wireLine, firstF, secondF);
 			// Add wire object to the list
 			layer.addComponent(wire);
 		}

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
@@ -195,19 +195,18 @@ public class AlertDCFactory implements Factory<AlertDCDetector, AlertDCSector, A
 			Point3D p_11 = new Point3D(px_11, py_11, zl);
 			// defining a cell around a wireLine, must be counter-clockwise!
 			firstF.add(p_0);
-			firstF.add(p_5);
-			firstF.add(p_4);
-			firstF.add(p_3);
-			firstF.add(p_2);
 			firstF.add(p_1);
+			firstF.add(p_2);
+			firstF.add(p_3);
+			firstF.add(p_4);
+			firstF.add(p_5);
 
 			secondF.add(p_6);
-			secondF.add(p_11);
-			secondF.add(p_10);
-			secondF.add(p_9);
-			secondF.add(p_8);
 			secondF.add(p_7);
-			
+			secondF.add(p_8);
+			secondF.add(p_9);
+			secondF.add(p_10);
+			secondF.add(p_11);
 
 			// Create the cell and signal wire inside
 			// PrismaticComponent(int componentId, List<Point3D> firstFace, List<Point3D> secondFace)

--- a/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/ConcaveComponent.java
+++ b/common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/ConcaveComponent.java
@@ -60,7 +60,7 @@ public abstract class ConcaveComponent extends AbstractComponent {
 		if (n.dot(direction) > 0.001) {
 			// System.err.println("PrismaticComponent: #" + componentId + " " + n.dot(direction) + " > 0");
 			// for (Point3D point : firstFace) System.err.println("\t" + point);
-            throw new IllegalArgumentException("the first face is not counter-clockwise: componentId=" + componentId);
+			throw new IllegalArgumentException("the first face is not counter-clockwise: componentId=" + componentId);
 		}
 		u = secondFace.get(1).vectorFrom(secondFace.get(0));
 		v = secondFace.get(2).vectorFrom(secondFace.get(0));

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/Hit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/Hit.java
@@ -1,5 +1,8 @@
 package org.jlab.rec.ahdc.Hit;
 
+import org.jlab.geom.detector.alert.AHDC.AlertDCDetector;
+import org.jlab.geom.prim.Line3D;
+import org.jlab.geom.prim.Point3D;
 
 public class Hit implements Comparable<Hit> {
 
@@ -12,6 +15,7 @@ public class Hit implements Comparable<Hit> {
 	private final double adc;
 	private final double time;
 
+        private Line3D wireLine;
 	private double  phi;
 	private double  radius;
 	private int     nbOfWires;
@@ -31,55 +35,21 @@ public class Hit implements Comparable<Hit> {
 		this.doca         = _Doca;
 		this.adc          = _ADC;
 		this.time 	  = _Time;
-		wirePosition();
 		this.residual_prefit = 0.0;
 		this.residual        = 0.0;
 		this.trackId	     = -1; // not defined yet
 	}
 
-	private void wirePosition() {
-		final double DR_layer = 4.0;
-		final double round    = 360.0;
-
-		double numWires = 32.0;
-		double R_layer  = 47.0;
-		
-		switch (this.superLayerId) {
-			case 1:
-				numWires = 47.0;
-				R_layer = 32.0;
-				break;
-			case 2:
-				numWires = 56.0;
-				R_layer = 38.0;
-				break;
-			case 3:
-				numWires = 72.0;
-				R_layer = 48.0;
-				break;
-			case 4:
-				numWires = 87.0;
-				R_layer = 58.0;
-				break;
-			case 5:
-				numWires = 99.0;
-				R_layer = 68.0;
-				break;
-		}
-
-		R_layer = R_layer + DR_layer * (this.layerId-1);
-		double alphaW_layer = Math.toRadians(round / (numWires));
-		//should it be at z = 0? in which case, we need to account for the positive or negative stereo angle...
-		double wx           = -R_layer * Math.sin(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
-		double wy           = -R_layer * Math.cos(alphaW_layer * (this.wireId-1) + 0.5*thster * (Math.pow(-1, this.superLayerId-1)));
-		
+	public void setWirePosition(AlertDCDetector factory) {
+	
 		//System.out.println(" superlayer " + this.superLayerId + " layer " + this.layerId + " wire " + this.wireId + " R_layer " + R_layer + " wx " + wx + " wy " + wy);
-		
-		this.nbOfWires = (int) numWires;
-		this.phi       = Math.atan2(wy, wx);
-		this.radius    = R_layer;
-		this.x         = wx;
-		this.y         = wy;
+		wireLine = factory.getSector(1).getSuperlayer(superLayerId).getLayer(layerId).getComponent(wireId).getLine();
+		Point3D end = wireLine.end();
+                this.nbOfWires = factory.getSector(1).getSuperlayer(superLayerId).getLayer(layerId).getNumComponents();
+		this.phi       = end.vectorFrom(0, 0, 0).phi();
+		this.radius    = end.distance(0, 0, end.z());
+		this.x         = end.x();
+		this.y         = end.y();
 	}
 
 	@Override
@@ -99,7 +69,7 @@ public class Hit implements Comparable<Hit> {
 	public int getId() {
 		return id;
 	}
-
+        
 	public int getSuperLayerId() {
 		return superLayerId;
 	}
@@ -116,7 +86,11 @@ public class Hit implements Comparable<Hit> {
 		return doca;
 	}
 
-	public double getRadius() {
+        public Line3D getLine() {
+            return wireLine;
+        }
+        
+        public double getRadius() {
 		return radius;
 	}
 

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
@@ -12,7 +12,7 @@ public class HitReader {
 	private ArrayList<Hit>     _AHDCHits;
 	private ArrayList<TrueHit> _TrueAHDCHits;
 
-	public HitReader(DataEvent event, boolean simulation) {
+        public HitReader(DataEvent event, boolean simulation) {
 		fetch_AHDCHits(event);
 		if (simulation) fetch_TrueAHDCHits(event);
 	}

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
@@ -88,11 +88,11 @@ public class Hit implements Comparable<Hit> {
 		
 		R_layer = R_layer + DR_layer * (this.layer-1);//OK
 		double alphaW_layer = Math.toRadians(round / (numWires));//OK
-		double wx           = R_layer * Math.cos(alphaW_layer * (this.wire-1));//OK
-		double wy           = R_layer * Math.sin(alphaW_layer * (this.wire-1));//OK
+		double wx           = -R_layer * Math.sin(alphaW_layer * (this.wire-1));//OK
+		double wy           = -R_layer * Math.cos(alphaW_layer * (this.wire-1));//OK
 
-		double wx_end = R_layer * Math.cos(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
-		double wy_end = R_layer * Math.sin(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
+		double wx_end = -R_layer * Math.sin(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
+		double wy_end = -R_layer * Math.cos(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
 
 		this.phi = Math.atan2( (wy+wy_end)*0.5, (wx+wx_end)*0.5 );
 		//System.out.println(" superlayer " + this.superLayer + " layer " + this.layer + " wire " + this.wire + " wx " + wx + " wy " + wy + " wx_end " + wx_end + " wy_end " + wy_end + " phi " + this.phi);
@@ -113,11 +113,11 @@ public class Hit implements Comparable<Hit> {
 
 		//calculate the "virtual" left and right wires accounting for the DOCA 
 		double deltaphi = Math.asin(this.doca/R_layer);
-		double wx_plus     = R_layer * Math.cos( alphaW_layer * (this.wire-1) - deltaphi );//OK
-		double wy_plus     = R_layer * Math.sin( alphaW_layer * (this.wire-1) - deltaphi );//OK
+		double wx_plus     = -R_layer * Math.sin( alphaW_layer * (this.wire-1) - deltaphi );//OK
+		double wy_plus     = -R_layer * Math.cos( alphaW_layer * (this.wire-1) - deltaphi );//OK
 
-		double wx_plus_end = R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
-		double wy_plus_end = R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
+		double wx_plus_end = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
+		double wy_plus_end = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
 
 		line = new Line3D(wx_plus, wy_plus, -zl/2, wx_plus_end, wy_plus_end, zl/2);
 		lPoint = new Point3D();
@@ -128,11 +128,11 @@ public class Hit implements Comparable<Hit> {
 		wireLine = new Line3D(lPoint, rPoint);
 		this.line3D_plus = wireLine;
 
-		double wx_minus     = R_layer * Math.cos( alphaW_layer * (this.wire-1) + deltaphi );//OK
-		double wy_minus     = R_layer * Math.sin( alphaW_layer * (this.wire-1) + deltaphi );//OK
+		double wx_minus     = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + deltaphi );//OK
+		double wy_minus     = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + deltaphi );//OK
 
-		double wx_minus_end = R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
-		double wy_minus_end = R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
+		double wx_minus_end = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
+		double wy_minus_end = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
 
 		line = new Line3D(wx_minus, wy_minus, -zl/2, wx_minus_end, wy_minus_end, zl/2);
 		lPoint = new Point3D();

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit.java
@@ -11,8 +11,6 @@ import org.jlab.geom.prim.Vector3D;
 
 public class Hit implements Comparable<Hit> {
 
-	private final double thster = Math.toRadians(20.0);
-        private final double zl     = 300.0;//OK
 	private final int    superLayer;
 	private final int    layer;
 	private final int    wire;
@@ -30,118 +28,31 @@ public class Hit implements Comparable<Hit> {
 	// Comparison with:  common-tools/clas-geometry/src/main/java/org/jlab/geom/detector/alert/AHDC/AlertDCFactory.java
 	// here, SuperLayer, Layer, Wire, start from 1
 	// in AlertDCFactory, same variables start from 1
-	public Hit(int superLayer, int layer, int wire, int numWire, double r, double doca) {
+	public Hit(int superLayer, int layer, int wire, int numWire, Line3D line, double doca) {
 		this.superLayer = superLayer;
 		this.layer      = layer;
 		this.wire       = wire;
-		this.r          = r;
+		this.r          = line.end().distance(0, 0, line.end().z());
 		this.doca       = doca;
 		this.numWires = numWire;
 		this.adc = 0;//placeholder
 		this.hitidx = -1;
 		this.hitsign = 0;
 		
-		final double DR_layer = 4.0;//OK
-		final double round    = 360.0;//OK
-		final double thster   = Math.toRadians(20.0);//OK
-
-		double numWires = 32.0;
-		double R_layer  = 47.0;
-
-		double zoff1 = -zl/2;//OK
-		double zoff2 = +zl/2;//OK
-		Point3D  p1 = new Point3D(R_layer, 0, zoff1);
-		Vector3D n1 = new Vector3D(0, 0, 1);
-		//n1.rotateY(-thopen);
-		//n1.rotateZ(thtilt);
-		Plane3D lPlane = new Plane3D(p1, n1);//OK
-
-		Point3D  p2 = new Point3D(R_layer, 0, zoff2);
-		Vector3D n2 = new Vector3D(0, 0, 1);
-		//n2.rotateY(thopen);
-		//n2.rotateZ(thtilt);
-		Plane3D rPlane = new Plane3D(p2, n2);//OK
-
-		switch (this.superLayer) {//OK
-			case 1:
-				numWires = 47.0;
-				R_layer = 32.0;
-				break;
-			case 2:
-				numWires = 56.0;
-				R_layer = 38.0;
-				break;
-			case 3:
-				numWires = 72.0;
-				R_layer = 48.0;
-				break;
-			case 4:
-				numWires = 87.0;
-				R_layer = 58.0;
-				break;
-			case 5:
-				numWires = 99.0;
-				R_layer = 68.0;
-				break;
-		}
-
-		
-		R_layer = R_layer + DR_layer * (this.layer-1);//OK
-		double alphaW_layer = Math.toRadians(round / (numWires));//OK
-		double wx           = -R_layer * Math.sin(alphaW_layer * (this.wire-1));//OK
-		double wy           = -R_layer * Math.cos(alphaW_layer * (this.wire-1));//OK
-
-		double wx_end = -R_layer * Math.sin(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
-		double wy_end = -R_layer * Math.cos(alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)));//OK
-
-		this.phi = Math.atan2( (wy+wy_end)*0.5, (wx+wx_end)*0.5 );
+		this.phi = line.midpoint().vectorFrom(0,0,0).phi();
 		//System.out.println(" superlayer " + this.superLayer + " layer " + this.layer + " wire " + this.wire + " wx " + wx + " wy " + wy + " wx_end " + wx_end + " wy_end " + wy_end + " phi " + this.phi);
 		
-		Line3D line = new Line3D(wx, wy, -zl/2, wx_end, wy_end, zl/2);
-		Point3D lPoint = new Point3D();
-		Point3D rPoint = new Point3D();
-		lPlane.intersection(line, lPoint);
-		rPlane.intersection(line, rPoint);
-		//lPoint.setZ(-zl/2);
-		//rPoint.setZ(zl/2);
-		//lPoint.show();
-		//rPoint.show();
-		// All wire go from left to right
-		Line3D wireLine = new Line3D(lPoint, rPoint);
-		//wireLine.show();
-		this.line3D = wireLine;
+		this.line3D = line;
 
 		//calculate the "virtual" left and right wires accounting for the DOCA 
-		double deltaphi = Math.asin(this.doca/R_layer);
-		double wx_plus     = -R_layer * Math.sin( alphaW_layer * (this.wire-1) - deltaphi );//OK
-		double wy_plus     = -R_layer * Math.cos( alphaW_layer * (this.wire-1) - deltaphi );//OK
-
-		double wx_plus_end = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
-		double wy_plus_end = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) - deltaphi );//OK
-
-		line = new Line3D(wx_plus, wy_plus, -zl/2, wx_plus_end, wy_plus_end, zl/2);
-		lPoint = new Point3D();
-		rPoint = new Point3D();
-		lPlane.intersection(line, lPoint);
-		rPlane.intersection(line, rPoint);
-
-		wireLine = new Line3D(lPoint, rPoint);
-		this.line3D_plus = wireLine;
-
-		double wx_minus     = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + deltaphi );//OK
-		double wy_minus     = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + deltaphi );//OK
-
-		double wx_minus_end = -R_layer * Math.sin( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
-		double wy_minus_end = -R_layer * Math.cos( alphaW_layer * (this.wire-1) + thster * (Math.pow(-1, this.superLayer-1)) + deltaphi );//OK
-
-		line = new Line3D(wx_minus, wy_minus, -zl/2, wx_minus_end, wy_minus_end, zl/2);
-		lPoint = new Point3D();
-		rPoint = new Point3D();
-		lPlane.intersection(line, lPoint);
-		rPlane.intersection(line, rPoint);
-		
-		wireLine = new Line3D(lPoint, rPoint);
-		this.line3D_minus = wireLine;
+		double deltaphi = Math.asin(this.doca/r);
+		this.line3D_plus = new Line3D();
+                this.line3D_plus.copy(line);
+                this.line3D_plus.rotateZ(deltaphi);
+                
+		this.line3D_minus = new Line3D();
+                this.line3D_minus.copy(line);
+                this.line3D_minus.rotateZ(deltaphi);
 		
 	}
 
@@ -180,9 +91,7 @@ public class Hit implements Comparable<Hit> {
         public double phi()    {return phi;}//at z = 0;
     
         public double phi(double z)    {
-	    double x_z = r*Math.sin( phi + thster * z/(zl*0.5) * (Math.pow(-1, this.superLayer-1)) );
-	    double y_z = r*Math.cos( phi + thster * z/(zl*0.5) * (Math.pow(-1, this.superLayer-1)) );
-	    return Math.atan2(x_z, y_z);
+	    return this.line3D.lerpPoint((z-line3D.origin().z())/line3D.length()).vectorFrom(0,0,0).phi();
 	}
 
 	public Line3D line() {return line3D;}
@@ -214,10 +123,6 @@ public class Hit implements Comparable<Hit> {
 
 	public RealVector get_Vector_beam() {
 		return null;
-	}
-
-	public double getThster() {
-		return thster;
 	}
 
 	public int getSuperLayer() {

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit_beam.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/Hit_beam.java
@@ -2,6 +2,7 @@ package org.jlab.rec.ahdc.KalmanFilter;
 
 import org.apache.commons.math3.linear.ArrayRealVector;
 import org.apache.commons.math3.linear.RealVector;
+import org.jlab.geom.prim.Line3D;
 
 public class Hit_beam extends Hit {
 
@@ -9,7 +10,7 @@ public class Hit_beam extends Hit {
 	double r,phi;
 
 	public Hit_beam(int superLayer, int layer, int wire, int numWire, double doca, double x, double y , double z) {
-	    super(0, 0, 0, 0, Math.hypot(x,y), 0);
+	    super(0, 0, 0, 0, new Line3D(x,y,0,x,y,1), 0);
 		this.x = x;
 		this.y = y;
 		this.z = z;

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/KalmanFilter.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/KalmanFilter/KalmanFilter.java
@@ -97,7 +97,7 @@ public class KalmanFilter {
 			    //System.out.println(" px " +  y[3] + " py " + y[4]  +" pz " +  y[5] +" vz " + y[2] + " number of hits: " + AHDC_hits.size() + " MC hits? " + sim_hits.size());
 			    track.set_n_hits(AHDC_hits.size());
 			    for (org.jlab.rec.ahdc.Hit.Hit AHDC_hit : AHDC_hits) {
-				Hit hit = new Hit(AHDC_hit.getSuperLayerId(), AHDC_hit.getLayerId(), AHDC_hit.getWireId(), AHDC_hit.getNbOfWires(), AHDC_hit.getRadius(), AHDC_hit.getDoca());
+				Hit hit = new Hit(AHDC_hit.getSuperLayerId(), AHDC_hit.getLayerId(), AHDC_hit.getWireId(), AHDC_hit.getNbOfWires(), AHDC_hit.getLine(), AHDC_hit.getDoca());
 				hit.setADC(AHDC_hit.getADC());
 				hit.setHitIdx(AHDC_hit.getId());
 				hit.setSign(0);

--- a/reconstruction/alert/src/main/java/org/jlab/service/ahdc/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/service/ahdc/AHDCEngine.java
@@ -27,6 +27,7 @@ import org.jlab.rec.alert.constants.CalibrationConstantsLoader;
 import java.io.File;
 import java.util.*;
 import org.jlab.detector.calib.utils.DatabaseConstantProvider;
+import org.jlab.geom.base.Detector;
 import org.jlab.geom.detector.alert.AHDC.AlertDCFactory;
 
 /** AHDCEngine reconstruction service.
@@ -60,6 +61,8 @@ public class AHDCEngine extends ReconstructionEngine {
     /// \todo better name... mode for what?
     private Mode mode = Mode.CV_Track_Finding;
 
+    private Detector factory = null;
+    
     public AHDCEngine() {
         super("ALERT", "ouillon", "1.0.1");
     }
@@ -67,7 +70,7 @@ public class AHDCEngine extends ReconstructionEngine {
     @Override
     public boolean init() {
 
-        (new AlertDCFactory()).createDetectorCLAS(new DatabaseConstantProvider());
+        factory = (new AlertDCFactory()).createDetectorCLAS(new DatabaseConstantProvider());
         
         simulation    = false;
         findingMethod = "distance";


### PR DESCRIPTION
- Revert previous modification
- Correct AHDC wire positions to match real data with wire 1 in each layer at phi = 0 and wire number increasing with phi
- Shift AHDC center at z = 0
- Set the hit geometry info based on the geometry service (to be checked)

Geometry tested via elastic analysis of run 21342
![Plot_04-14-2025_11 08 59_PM](https://github.com/user-attachments/assets/57f16ea0-5a69-4bbc-a941-5d3a8e855bc8)
