### PR TITLE
fix an issue in the updated DCHBPostClusterAI.java by PR#543

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
@@ -311,7 +311,6 @@ public class DCHBPostClusterAI extends DCEngine {
         if (trkcands.isEmpty()) {
             event.appendBanks(
                     writer.fillHBHitsBank(event, fhits),  
-                    writer.fillHBClustersBank(event, clusters),
                     writer.fillHBSegmentsBank(event, segments),
                     writer.fillHBCrossesBank(event, crosses));
         }

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
@@ -30,7 +30,7 @@ import org.jlab.rec.dc.trajectory.RoadFinder;
 
 /**
  *
- * @author ziegler
+ * @author ziegler, tongtong
  */
 public class DCHBPostClusterAI extends DCEngine {
 
@@ -126,7 +126,6 @@ public class DCHBPostClusterAI extends DCEngine {
             dcSwim, true);
 
         // track found
-        clusters = new ArrayList<>();
         int trkId = 1;
         if (trkcands.size() > 0) {
             // remove overlaps
@@ -311,7 +310,8 @@ public class DCHBPostClusterAI extends DCEngine {
         // the clusters, the segments, the crosses
         if (trkcands.isEmpty()) {
             event.appendBanks(
-                    writer.fillHBHitsBank(event, fhits),    
+                    writer.fillHBHitsBank(event, fhits),  
+                    writer.fillHBClustersBank(event, clusters),
                     writer.fillHBSegmentsBank(event, segments),
                     writer.fillHBCrossesBank(event, crosses));
         }


### PR DESCRIPTION
In updated org.jlab.service.dc.DCHBPostClusterAI by PR#543, there is an issue, which causes clusters in HB AI-assisted tracks are not saved in HitBasedTrkg::AIClusters.