### PR TITLE
Default to retrieving field scales from RCDB

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -22,11 +22,14 @@ public class RCDBProvider {
             if (!cache.containsKey(run)) cache.put(run, provider.getConstants(run));
             return cache.get(run);
         }
+        public Double getDouble(int run, String key) {
+            return getConstants(run).getDouble(key);
+        }
         public Double getTorusScale(int run) {
-            return getConstants(run).getDouble("torus_scale");
+            return getDouble(run, "torus_scale");
         }
         public Double getSolenoidScale(int run) {
-            return getConstants(run).getDouble("solenoid_scale");
+            return getDouble(run, "solenoid_scale");
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -141,6 +141,8 @@ public class RCDBProvider {
     }
 
     public static void main(String[] args){
+        RCDBManager m = new RCDBManager();
+        System.out.println(m.getTorusScale(4013));
         RCDBProvider a=new RCDBProvider();
         RCDBConstants data=a.getConstants(4014);
         data.show();

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -16,11 +16,10 @@ public class RCDBProvider {
 
     public static class RCDBManager {
         HashMap<Integer,RCDBConstants> cache = new HashMap<>();
-        RCDBProvider provider = new RCDBProvider();
+        RCDBProvider provider = null;
         public synchronized RCDBConstants getConstants(int run) {
-            if (!cache.containsKey(run)) {
-                cache.put(run, provider.getConstants(run));
-            }
+            if (provider == null) provider = new RCDBProvider();
+            if (!cache.containsKey(run)) cache.put(run, provider.getConstants(run));
             return cache.get(run);
         }
         public Double getTorusScale(int run) {

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -13,6 +13,24 @@ import org.rcdb.ConditionType;
  * @author baltzell
  */
 public class RCDBProvider {
+
+    public static class RCDBManager {
+        HashMap<Integer,RCDBConstants> cache = new HashMap<>();
+        RCDBProvider provider = new RCDBProvider();
+        public synchronized RCDBConstants getConstants(int run) {
+            if (!cache.containsKey(run)) {
+                cache.put(run, provider.getConstants(run));
+            }
+            return cache.get(run);
+        }
+        public Double getTorusScale(int run) {
+            return getConstants(run).getDouble("torus_scale");
+        }
+        public Double getSolenoidScale(int run) {
+            return getConstants(run).getDouble("solenoid_scale");
+        }
+    }
+
     public static Logger LOGGER = Logger.getLogger(RCDBProvider.class.getName());
 
     public static final String DEFAULTADDRESS = "mysql://rcdb@clasdb.jlab.org/rcdb";

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -10,6 +10,7 @@ import java.util.TreeSet;
 import org.jlab.detector.base.DetectorDescriptor;
 
 import org.jlab.detector.base.DetectorType;
+import org.jlab.detector.calib.utils.RCDBProvider.RCDBManager;
 import org.jlab.detector.decode.DetectorDataDgtz.HelicityDecoderData;
 import org.jlab.detector.helicity.HelicityBit;
 import org.jlab.detector.helicity.HelicitySequence;
@@ -47,8 +48,9 @@ public class CLASDecoder4 {
     private HipoDataEvent               hipoEvent = null;
     private boolean              isRunNumberFixed = false;
     private int                  decoderDebugMode = 0;
-    private SchemaFactory        schemaFactory    = new SchemaFactory();
-    private ModeAHDC ahdcExtractor                = new ModeAHDC();
+    private SchemaFactory           schemaFactory = new SchemaFactory();
+    private ModeAHDC                ahdcExtractor = new ModeAHDC();
+    private RCDBManager               rcdbManager = new RCDBManager();
 
     public CLASDecoder4(boolean development){
         codaDecoder = new CodaEventDecoder();
@@ -439,11 +441,11 @@ public class CLASDecoder4 {
         return scalerBANK;
     }
 
-    public Event getDecodedEvent(EvioDataEvent rawEvent, int run, int counter, double torus, double solenoid) {
+    public Event getDecodedEvent(EvioDataEvent rawEvent, int run, int counter, Double torus, Double solenoid) {
 
         Event  decodedEvent = this.getDataEvent(rawEvent);        
 
-        Bank   header = this.createHeaderBank(run, counter, (float) torus, (float) solenoid);
+        Bank   header = this.createHeaderBank(run, counter, torus, solenoid);
         if(header!=null) decodedEvent.write(header);
 
         Bank   trigger = this.createTriggerBank();
@@ -614,7 +616,7 @@ public class CLASDecoder4 {
         return ((timestamp%6)+phase_offset)%6; // TI derived phase correction due to TDC and FADC clock differences
     }
 
-    public Bank createHeaderBank( int nrun, int nevent, float torus, float solenoid){
+    public Bank createHeaderBank( int nrun, int nevent, Double torus, Double solenoid){
 
         if(schemaFactory.hasSchema("RUN::config")==false) return null;
 
@@ -631,24 +633,31 @@ public class CLASDecoder4 {
             localEvent = nevent;
         }
 
-        /*
-        // example of getting torus/solenoid from RCDB:
-        if (Math.abs(solenoid)>10) {
-            solenoid = this.detectorDecoder.getRcdbSolenoidScale();
-        }
-        if (Math.abs(torus)>10) {
-            torus = this.detectorDecoder.getRcdbTorusScale();
-        }
-        */
-
         bank.putInt("run",        0, localRun);
         bank.putInt("event",      0, localEvent);
         bank.putInt("unixtime",   0, localTime);
         bank.putLong("trigger",   0, triggerBits);
-        bank.putFloat("torus",    0, torus);
-        bank.putFloat("solenoid", 0, solenoid);
         bank.putLong("timestamp", 0, timeStamp);
 
+        if (torus != null) {
+            bank.putFloat("torus", 0, torus.floatValue());
+        }
+        else if (rcdbManager.getTorusScale(localRun) == null) {
+            if (localRun > 100) throw new RuntimeException("Error retrieving torus scale from RCDB.");
+        }
+        else { 
+            bank.putFloat("torus", 0, rcdbManager.getTorusScale(localRun).floatValue());
+        }
+        if (solenoid != null) {
+            bank.putFloat("solenoid", 0, solenoid.floatValue());
+        }
+        else if (rcdbManager.getSolenoidScale(localRun) == null) {
+            if (localRun > 100) throw new RuntimeException("Error retrieving solenoid scale from RCDB.");
+        }
+        else { 
+            bank.putFloat("solenoid", 0, rcdbManager.getSolenoidScale(localRun).floatValue());
+        }
+        
         return bank;
     }
 
@@ -774,8 +783,7 @@ public class CLASDecoder4 {
         else 
             return null;
     }
-    
-    
+
     public static void main(String[] args){
 
         OptionParser parser = new OptionParser("decoder");
@@ -786,8 +794,8 @@ public class CLASDecoder4 {
         parser.addOption("-m", "run","translation tables source (use -m devel for development tables)");
         parser.addOption("-b", "16","record buffer size in MB");
         parser.addOption("-r", "-1","run number in the header bank (-1 means use CODA run)");
-        parser.addOption("-t", "-0.5","torus current in the header bank");
-        parser.addOption("-s", "0.5","solenoid current in the header bank");
+        parser.addOption("-t", null,"torus current in the header bank (null means use RCDB)");
+        parser.addOption("-s", null,"solenoid current in the header bank (null means use RCDB)");
         parser.addOption("-x", null,"CCDB timestamp (MM/DD/YYYY-HH:MM:SS)");
         parser.addOption("-v","default","CCDB variation");
         parser.addRequired("-o","output.hipo");
@@ -833,8 +841,8 @@ public class CLASDecoder4 {
         Event scalerEvent = new Event();
 
         int nrun = parser.getOption("-r").intValue();
-        double torus = parser.getOption("-t").doubleValue();
-        double solenoid = parser.getOption("-s").doubleValue();
+        Double torus = parser.getOption("-t").getValue() == null ? null : parser.getOption("-t").doubleValue();
+        Double solenoid = parser.getOption("-s").getValue() == null ? null : parser.getOption("-s").doubleValue();
 
         writer.open(outputFile);
         ProgressPrintout progress = new ProgressPrintout();

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -779,22 +779,18 @@ public class CLASDecoder4 {
     public static void main(String[] args){
 
         OptionParser parser = new OptionParser("decoder");
-
         parser.setDescription("CLAS12 Data Decoder");
         parser.addOption("-n", "-1", "maximum number of events to process");
         parser.addOption("-c", "2", "compression type (0-NONE, 1-LZ4 Fast, 2-LZ4 Best, 3-GZIP)");
         parser.addOption("-d", "0","debug mode, set >0 for more verbose output");
         parser.addOption("-m", "run","translation tables source (use -m devel for development tables)");
         parser.addOption("-b", "16","record buffer size in MB");
-        parser.addRequired("-o","output.hipo");
-
-
         parser.addOption("-r", "-1","run number in the header bank (-1 means use CODA run)");
         parser.addOption("-t", "-0.5","torus current in the header bank");
         parser.addOption("-s", "0.5","solenoid current in the header bank");
         parser.addOption("-x", null,"CCDB timestamp (MM/DD/YYYY-HH:MM:SS)");
         parser.addOption("-v","default","CCDB variation");
-
+        parser.addRequired("-o","output.hipo");
         parser.parse(args);
 
         List<String> inputList = parser.getInputList();
@@ -802,7 +798,7 @@ public class CLASDecoder4 {
         if(inputList.isEmpty()==true){
             parser.printUsage();
             System.out.println("\n >>>> error : no input file is specified....\n");
-            System.exit(0);
+            System.exit(1);
         }
 
         String modeDevel = parser.getOption("-m").stringValue();
@@ -811,7 +807,7 @@ public class CLASDecoder4 {
         if(modeDevel.compareTo("run")!=0&&modeDevel.compareTo("devel")!=0){
             parser.printUsage();
             System.out.println("\n >>>> error : mode has to be set to \"run\" or \"devel\" ");
-            System.exit(0);
+            System.exit(1);
         }
 
         if(modeDevel.compareTo("devel")==0){

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder4.java
@@ -101,7 +101,7 @@ public class CLASDecoder4 {
     }
 
     public CodaEventDecoder getCodaEventDecoder() {
-	return codaDecoder;
+        return codaDecoder;
     }
 
     public void initEvent(DataEvent event){


### PR DESCRIPTION
The defaults for torus/solenoid field scales in decoding will now be `null`, which means "try to get it from RCDB".  If one isn't available from RCDB, it will crash unless the user specifies the old `-s` and/or `-t` command-line arguments.  The internal passing of these scales is now via non-primitive types, to allow null as a valid value.

Previously the torus/solenoid scales had arbitrary default values of +/- 0.5, and the correct values had to be supplied by the user on the decoder's command line.  Our chef python clas12-workflow tools were long doing this automatically via RCDB's python interface.  In this pull request we move that into the decoder's Java.