### PR TITLE
use the same ejml version used by j4ml

### DIFF
--- a/common-tools/clas-tracking/pom.xml
+++ b/common-tools/clas-tracking/pom.xml
@@ -16,8 +16,8 @@
   <dependencies>
     <dependency>
         <groupId>org.ejml</groupId>
-        <artifactId>ejml-all</artifactId>
-        <version>0.44.0</version>
+        <artifactId>ejml-simple</artifactId>
+        <version>0.40</version>
     </dependency>
     <dependency>
       <groupId>org.jlab.clas</groupId>


### PR DESCRIPTION
Starting from 0.41, ejml-simple implements a new class ConstMatrix. This is not found at run time because the coat-lib jar contains two versions of this dependency, the other one being version 0.40 pulled by j4ml.
It never surfaced before because it is used only by the CVTAlignment service