### PR TITLE
Include vtx

### DIFF
--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
@@ -106,7 +106,7 @@ public class EngineProcessor {
         String[] names = new String[]{
             "MAGFIELDS",
             "DCCR","DCHB","FTOFHB","EC","HTCC","EBHB",
-            "DCTB","FTOFTB","EBTB"
+            "DCTB","FTOFTB","EBTB","VTX"
         };
 
         String[] services = new String[]{
@@ -119,7 +119,8 @@ public class EngineProcessor {
             "org.jlab.service.eb.EBHBEngine",
             "org.jlab.service.dc.DCTBEngine",
             "org.jlab.service.ftof.FTOFTBEngine",
-            "org.jlab.service.eb.EBTBEngine"
+            "org.jlab.service.eb.EBTBEngine",
+            "org.jlab.rec.service.vtx.VTXEngine"
         };
 
         for(int i = 0; i < names.length; i++){
@@ -135,7 +136,7 @@ public class EngineProcessor {
             "CVTFP","CTOF","CND","BAND",
             "HTCC","LTCC","EBHB",
             "DCTB","FMT","FTOFTB","CVT","EBTB",
-            "RICHEB","RTPC","MC"
+            "RICHEB","RTPC","AHDC","ATOF","ALERT", "MC","VTX"
         };
 
         String[] services = new String[]{
@@ -167,9 +168,11 @@ public class EngineProcessor {
             "org.jlab.service.ahdc.AHDCEngine",
             "org.jlab.service.atof.ATOFEngine",
             "org.jlab.service.alert.ALERTEngine",
-            "org.jlab.service.mc.TruthMatch"
+            "org.jlab.service.mc.TruthMatch",
+            "org.jlab.rec.service.vtx.VTXEngine"
         };
-
+        if(names.length!=services.length)
+            LOGGER.log(Level.SEVERE, "initAll : the list of services does not match the list of service names...  ");
         for(int i = 0; i < names.length; i++){
             this.addEngine(names[i], services[i]);
         }

--- a/etc/services/data-ai.yaml
+++ b/etc/services/data-ai.yaml
@@ -59,6 +59,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
   global:
     variation: rgb_spring2019

--- a/etc/services/data-aicv.yaml
+++ b/etc/services/data-aicv.yaml
@@ -70,6 +70,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
   global:
     variation: rgb_spring2019

--- a/etc/services/data-cv.yaml
+++ b/etc/services/data-cv.yaml
@@ -57,6 +57,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
   global:
     variation: rgb_spring2019

--- a/etc/services/mc-ai.yaml
+++ b/etc/services/mc-ai.yaml
@@ -59,6 +59,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
 #  global:
 #    variation: rga_fall2018_mc

--- a/etc/services/mc-aicv.yaml
+++ b/etc/services/mc-aicv.yaml
@@ -70,6 +70,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
 #  global:
 #    variation: rga_fall2018_mc

--- a/etc/services/mc-cv.yaml
+++ b/etc/services/mc-cv.yaml
@@ -57,6 +57,8 @@ services:
     name: RICH
   - class: org.jlab.service.rtpc.RTPCEngine
     name: RTPC
+  - class: org.jlab.rec.service.vtx.VTXEngine
+    name: VTX
 configuration:
 #  global:
 #    variation: rga_fall2018_mc

--- a/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXEngine.java
+++ b/reconstruction/vtx/src/main/java/org/jlab/rec/service/vtx/VTXEngine.java
@@ -90,16 +90,23 @@ public class VTXEngine extends ReconstructionEngine {
         return true;
    }
 
+    /**
+     *
+     * @return init status
+     */
     @Override
     public boolean init() {
     //    String variation = Optional.ofNullable(this.getEngineConfigString("variation")).orElse("default");
         //beam offset table
     //    DatabaseConstantProvider dbprovider = new DatabaseConstantProvider(11, variation);
     //    dbprovider.loadTable("/geometry/beam/position");
-      this.registerBanks();
-      this.loadConfiguration();
-      Constants.setDOCACUT(this.docaCut);
-      return true;
+        this.registerBanks();
+        this.loadConfiguration();
+        Constants.setDOCACUT(this.docaCut);
+        
+        System.out.println("["+this.getName()+"] run with doca setting set to "+Constants.getDOCACUT());    
+
+        return true;
     }
     private void registerBanks() {
         super.registerOutputBank("REC::VertDoca");    
@@ -107,7 +114,7 @@ public class VTXEngine extends ReconstructionEngine {
     
     public void loadConfiguration() {    
         if (this.getEngineConfigString("docaCut")!=null) 
-            this.docaCut = (double) Double.valueOf(this.getEngineConfigString("docaCut"));
+            this.docaCut = (double) Double.valueOf(this.getEngineConfigString("docaCut"));     
                    
     }
 


### PR DESCRIPTION
Includes the detached vertex finder at the end of the chain of services.  Included in services run when choosing the -c 2 option in recon-utils.  Also added to yaml files in etc/services.