### PR TITLE
fix issues for pseudo-segments in HB tracking

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/nn/PatternRec.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/nn/PatternRec.java
@@ -84,8 +84,10 @@ public class PatternRec {
                                     s.get_Region() == r.get(ri).get_Region() &&
                                     s.associatedCrossId == r.get(ri).associatedCrossId &&
                                     r.get(ri).associatedCrossId != -1) {
-                                if (s.get_Superlayer() % 2 == missingSL % 2)
+                                if (s.get_Superlayer() % 2 == missingSL % 2){
                                     Segs2Road.add(s);
+                                    break;
+                                }
                             }
                         }
                     }

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterAI.java
@@ -244,8 +244,10 @@ public class DCHBPostClusterAI extends DCEngine {
                             s.get_Region() == r.get(ri).get_Region() &&
                             s.associatedCrossId == r.get(ri).associatedCrossId &&
                             r.get(ri).associatedCrossId != -1) {
-                        if (s.get_Superlayer() % 2 == missingSL % 2)
+                        if (s.get_Superlayer() % 2 == missingSL % 2){
                             Segs2RoadConv.add(s); 
+                            break;
+                        }
                     }
                 }
             }
@@ -260,6 +262,11 @@ public class DCHBPostClusterAI extends DCEngine {
 
         segmentsConv.addAll(psegmentsConv);
         List<Cross> pcrossesConv = crossMake.find_Crosses(segmentsConv, Constants.getInstance().dcDetector);
+        List<Cross> fullPseudoCrossesConv = new ArrayList(); // Cross by two pseudo segments
+        for(Cross crs : pcrossesConv){
+            if(crs.get_Segment1().get_Id() == -1 && crs.get_Segment2().get_Id() == -1) fullPseudoCrossesConv.add(crs);
+        }
+        pcrossesConv.removeAll(fullPseudoCrossesConv);        
         CrossList pcrosslistConv = crossLister.candCrossLists(event, pcrossesConv,
                 false,
                 null,

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterConv.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBPostClusterConv.java
@@ -146,9 +146,9 @@ public class DCHBPostClusterConv extends DCEngine {
 
         for (Cross c : crosses) {
             if (!c.get_Segment1().isOnTrack)
-                crossSegsNotOnTrack.add(c.get_Segment1());
+                if(!crossSegsNotOnTrack.contains(c.get_Segment1())) crossSegsNotOnTrack.add(c.get_Segment1());
             if (!c.get_Segment2().isOnTrack)
-                crossSegsNotOnTrack.add(c.get_Segment2());
+                if(!crossSegsNotOnTrack.contains(c.get_Segment2())) crossSegsNotOnTrack.add(c.get_Segment2());
         }
 
         RoadFinder rf = new RoadFinder();
@@ -174,8 +174,10 @@ public class DCHBPostClusterConv extends DCEngine {
                             s.get_Region() == r.get(ri).get_Region() &&
                             s.associatedCrossId == r.get(ri).associatedCrossId &&
                             r.get(ri).associatedCrossId != -1) {
-                        if (s.get_Superlayer() % 2 == missingSL % 2)
+                        if (s.get_Superlayer() % 2 == missingSL % 2){
                             Segs2Road.add(s); 
+                            break;
+                        }
                     }
                 }
             }
@@ -190,7 +192,12 @@ public class DCHBPostClusterConv extends DCEngine {
 
         segments.addAll(psegments);
         List<Cross> pcrosses = crossMake.find_Crosses(segments, Constants.getInstance().dcDetector);
-
+        List<Cross> fullPseudoCrosses = new ArrayList(); // Cross by two pseudo segments
+        for(Cross crs : pcrosses){
+            if(crs.get_Segment1().get_Id() == -1 && crs.get_Segment2().get_Id() == -1) fullPseudoCrosses.add(crs);
+        }
+        pcrosses.removeAll(fullPseudoCrosses);
+        
         CrossList pcrosslist = crossLister.candCrossLists(event, pcrosses,
                 false,
                 null,


### PR DESCRIPTION
In conventional HB tracking, since a bug, some pseudo-segments are missed.
There are unexpected pseudo crosses, which are constructed by two pseudo-segments, where the two pseudo-segments are constructed by two different roads. Such cases are very rare.

Overall, the updates almost have no effect on AI tracking, while slight effects on conventional tracking.