### PR TITLE
fix: make `install-clara` independent from `libexec`

### DIFF
--- a/install-clara
+++ b/install-clara
@@ -5,7 +5,6 @@ set -e
 # Default versions:
 grapes=2.20
 clara=5.0.2
-coatjava=''
 
 function error() {
     echo -e "\n$usage\n\n  Use option '-h' for more usage guidance.\n\nERROR:  $@"
@@ -66,10 +65,11 @@ trap cleanup EXIT
 # Configure:
 debug=0
 args=()
-usage="Usage:  install-clara -c COATJAVA [-v] [-b] [-f CLARA] [-g GRAPES] PATH"
+usage="Usage:  install-clara [-v] [-b] [-c COATJAVA] [-f CLARA] [-g GRAPES] PATH"
 info="""
-- Option -c for COATJAVA version is required; it can also be specified as a local installation directory
 - The default CLARA / GRAPES versions are $clara / $grapes
+- COATJAVA can also be specified as a local installation directory
+- If the COATJAVA version is not specified, it will try to auto-detect it.
 - [-v adds verbosity and disables cleanup]
 - [-b builds clara from source]"""
 
@@ -95,8 +95,14 @@ clara_home="$args"
 mkdir -p $clara_home    || error "Cannot create installation PATH:  $clara_home"
 clara_home=$(cd $clara_home && pwd) && rmdir $clara_home
 
+# If the user didn't specify a coatjava version, try auto-detect the version:
+if [ -z ${coatjava+x} ]
+then
+    [ -e "$(dirname $0)/libexec/version.sh" ] || error "Failed to auto-detect.  COATJAVA version must be specified with '-c'"
+    coatjava=$($(dirname $0)/libexec/version.sh | sed 's/-SNAPSHOT//')
+fi
+
 # Detect local COATJAVA installation and convert into an absolute path:
-[ -z "$coatjava" ] && error "COATJAVA version must be specified with '-c'"
 if compgen -G "$coatjava/lib/clas/coat-libs-*.jar" > /dev/null
 then
     coatjava=$(cd $coatjava && pwd)

--- a/install-clara
+++ b/install-clara
@@ -5,10 +5,10 @@ set -e
 # Default versions:
 grapes=2.20
 clara=5.0.2
-coatjava=$($(dirname $0)/libexec/version.sh)
+coatjava=''
 
 function error() {
-    echo -e "\n$usage\n\nERROR:  $@"
+    echo -e "\n$usage\n\n  Use option '-h' for more usage guidance.\n\nERROR:  $@"
     exit 1
 }
 
@@ -66,17 +66,17 @@ trap cleanup EXIT
 # Configure:
 debug=0
 args=()
-usage="Usage:  install-clara [-v] [-b] [-f CLARA] [-c COATJAVA] [-g GRAPES] PATH"
-info="\
-- The default COATJAVA/CLARA/GRAPES versions are $coatjava/$clara/$grapes.\n\
-- COATJAVA can also be specified as a local installation directory.\n\
-- [-v adds verbosity and disables cleanup]\n\
-- [-b builds clara from source]"
+usage="Usage:  install-clara -c COATJAVA [-v] [-b] [-f CLARA] [-g GRAPES] PATH"
+info="""
+- Option -c for COATJAVA version is required; it can also be specified as a local installation directory
+- The default CLARA / GRAPES versions are $clara / $grapes
+- [-v adds verbosity and disables cleanup]
+- [-b builds clara from source]"""
 
 while [[ $# -gt 0 ]]
 do
     case $1 in
-        -h) echo -e "\n$usage" && echo -e "\n$info" && exit 1 ;;
+        -h|--help) echo -e "\n$usage" && echo -e "$info" && exit 1 ;;
         -f) clara="$2" && shift && shift ;;
         -c) coatjava="$2" && shift && shift ;;
         -g) grapes="$2" && shift && shift ;;
@@ -96,6 +96,7 @@ mkdir -p $clara_home    || error "Cannot create installation PATH:  $clara_home"
 clara_home=$(cd $clara_home && pwd) && rmdir $clara_home
 
 # Detect local COATJAVA installation and convert into an absolute path:
+[ -z "$coatjava" ] && error "COATJAVA version must be specified with '-c'"
 if compgen -G "$coatjava/lib/clas/coat-libs-*.jar" > /dev/null
 then
     coatjava=$(cd $coatjava && pwd)


### PR DESCRIPTION
Now `install-clara` requires `-c` to specify `coatjava` version, or it'll try to auto-detect.