### PR TITLE
fix(groovy): allow for user's custom classpath (`$JYPATH`)

### DIFF
--- a/libexec/env.sh
+++ b/libexec/env.sh
@@ -39,7 +39,7 @@ if [ $# -ge 1 ]; then
     if [ "$1" = "groovy" ]; then
       export JAVA_OPTS="-Dsun.java2d.pmoffscreen=false -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/debug.properties -Xms1024m -Xmx2048m -XX:+UseSerialGC ${JAVA_OPTS-}"
     fi
-    export JYPATH=$COATJAVA_CLASSPATH
+    export JYPATH=${JYPATH:+${JYPATH}:}$COATJAVA_CLASSPATH
   fi
 fi
 


### PR DESCRIPTION
The `$JYPATH` variable is used by some consumers (_e.g._, `j2root`) to set the class path for `run-groovy`. We lost the ability to customize this variable in https://github.com/JeffersonLab/coatjava/pull/632. This PR restores the desired functionality.