### PR TITLE
fix: specify code owner of all `pom.xml` files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -67,6 +67,7 @@ bin/ @baltzell @raffaelladevita @c-dilks
 docs/ @baltzell @raffaelladevita @c-dilks
 external-dependencies/ @baltzell @raffaelladevita @c-dilks
 libexec/ @baltzell @raffaelladevita @c-dilks
+**/pom.xml @baltzell @raffaelladevita @c-dilks
 
 # common-tools
 common-tools/clara-io/ @baltzell @raffaelladevita


### PR DESCRIPTION
Prevent _everyone_ from being review-requested on version bumps, Maven tree-wide PRs, etc.