### PR TITLE
fix: upload the `reconstruction` JARs to Maven repo

### DIFF
--- a/deploy-coatjava.sh
+++ b/deploy-coatjava.sh
@@ -168,6 +168,7 @@ print_deployment
 if ! $dry_run; then
   log "now deploying..."
   scp -r $deploy_dir/org/jlab/coat/coat-libs/* $deployment_user@$deployment_host:/group/clas/www/clasweb/html/clas12maven/org/jlab/coat/coat-libs/.
+  scp -r $deploy_dir/org/jlab/clas12/detector/* $deployment_user@$deployment_host:/group/clas/www/clasweb/html/clas12maven/org/jlab/clas12/detector/.
   scp $deploy_tarball $deployment_user@$deployment_host:/group/clas/www/clasweb/html/clas12offline/distribution/coatjava/.
   log "...done"
 else


### PR DESCRIPTION
I forgot the `scp` command in https://github.com/JeffersonLab/coatjava/pull/688

We could probably just `scp` the whole local repo (`myLocalMvnRepo/`), but I'd rather not accidentally clobber something unrelated; I prefer targeted `scp` commands for safety (but also we have snapshots anyway).