### PR TITLE
Define a default startTime for simulation or ALERT-only reconstruction

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
@@ -22,11 +22,14 @@ public class HitReader {
 
 	public final void fetch_AHDCHits(DataEvent event, AlertDCDetector detector) {
 		ArrayList<Hit> hits = new ArrayList<>();
-		
-		if (event.hasBank("AHDC::adc") && event.hasBank("REC::Event")) {
 
-			DataBank bankRecEvent = event.getBank("REC::Event"); 
-			double startTime = bankRecEvent.getFloat("startTime", 0);
+		
+		if (event.hasBank("AHDC::adc")) {
+			double startTime = 0;
+			if (event.hasBank("REC::Event")) {
+				DataBank bankRecEvent = event.getBank("REC::Event"); 
+				startTime = bankRecEvent.getFloat("startTime", 0);
+			}
 			if (startTime < 0) { // reject bad events 
 				return;
 			}

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java
@@ -25,13 +25,13 @@ public class HitReader {
 
 		
 		if (event.hasBank("AHDC::adc")) {
+			// Useful if one does not run the full CLAS12 reconstrcution
+			// i.e only run the reconstruction of ALERT
+			// or use simulated data
 			double startTime = 0;
-			if (event.hasBank("REC::Event")) {
+			if (event.hasBank("REC::Event") && !sim) {
 				DataBank bankRecEvent = event.getBank("REC::Event"); 
 				startTime = bankRecEvent.getFloat("startTime", 0);
-			}
-			if (startTime < 0) { // reject bad events 
-				return;
 			}
 			
 			RawDataBank bankDGTZ = new RawDataBank("AHDC::adc");


### PR DESCRIPTION
It also fixes another issue : this kind of cuts should be done at the analysis level, not here.

```cpp
if (startTime < 0) { // reject bad events 
 return;
 }
```