### PR TITLE
refactor: common maven goal wrappers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,9 +214,9 @@ jobs:
       - name: untar build
         run: tar xzvf coatjava.tar.gz
       - name: print dependency tree
-        run: mvn dependency:tree -Ddetail=true --no-transfer-progress
-      - name: dependency analysis # note: skips `coat-libs`, since shaded JAR dependencies are "unused" according to `dependency:analyze`
-        run: mvn dependency:analyze -DfailOnWarning=true -pl '!org.jlab.coat:coat-libs' --no-transfer-progress
+        run: libexec/dependency-tree.sh
+      - name: dependency analysis
+        run: libexec/dependency-analysis.sh
 
   # documentation
   #############################################################################
@@ -245,7 +245,7 @@ jobs:
           distribution: ${{ env.java_distribution }}
       - name: build coatjava javadocs # javadoc:aggregate output dir cannot be controlled, so assume the latest "standard" path and `mv` it
         run: |
-          mvn javadoc:aggregate -pl '!org.jlab.coat:coat-libs' --no-transfer-progress
+          libexec/build-javadocs.sh
           mv target/reports/apidocs pages/javadoc
       ### upload artifacts
       - uses: actions/upload-pages-artifact@v4

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,8 +36,8 @@ depana:
   stage: test-stage
   dependencies: [build]
   script:
-    - mvn dependency:tree -Ddetail=true --no-transfer-progress
-    - mvn dependency:analyze -DfailOnWarning=true -pl '!org.jlab.coat:coat-libs' --no-transfer-progress
+    - libexec/dependency-tree.sh
+    - libexec/dependency-analysis.sh
 
 eb:
   stage: test-stage
@@ -72,7 +72,7 @@ docs:
   script:
     - python3 -m pip install -r docs/mkdocs/requirements.txt
     - ./docs/mkdocs/generate.sh pages
-    - mvn javadoc:aggregate -pl '!org.jlab.coat:coat-libs' --no-transfer-progress
+    - libexec/build-javadocs.sh
     - mv target/reports/apidocs pages/javadoc
     - mv publish pages/jacoco
   artifacts:

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -145,10 +145,11 @@ if [ $cleanBuild == "yes" ]; then
   exit
 fi
 
+# run dependency analysis and exit
 if [ $anaDepends == "yes" ]; then
-    mvn dependency:analyze -DfailOnWarning=true -pl '!org.jlab.coat:coat-libs' --no-transfer-progress
-    mvn dependency:tree -Ddetail=true --no-transfer-progress 
-    exit 0
+  libexec/dependency-analysis.sh
+  libexec/dependency-tree.sh
+  exit 0
 fi
 
 # start new installation tree

--- a/libexec/build-javadocs.sh
+++ b/libexec/build-javadocs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# analyze maven dependencies
+# NOTE: skips `coat-libs`, the shaded JAR module
+set -euo pipefail
+mvn javadoc:aggregate -pl '!org.jlab.coat:coat-libs' --no-transfer-progress

--- a/libexec/dependency-analysis.sh
+++ b/libexec/dependency-analysis.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# analyze maven dependencies
+# NOTE: skips `coat-libs`, since shaded JAR dependencies are "unused" according to `dependency:analyze`
+set -euo pipefail
+mvn dependency:analyze -DfailOnWarning=true -pl '!org.jlab.coat:coat-libs' --no-transfer-progress

--- a/libexec/dependency-tree.sh
+++ b/libexec/dependency-tree.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# print the maven dependency tree
+set -euo pipefail
+mvn dependency:tree -Ddetail=true --no-transfer-progress


### PR DESCRIPTION
wraps common goals with their preferred options:
- `libexec/build-javadocs.sh`: for building docs
- `libexec/dependency-analysis.sh`: for analyzing dependencies
- `libexec/dependency-tree.sh`: for printing dependency DAGs

purpose:
- reduce DRY violations between CI configs and `build-coatjava.sh`
- allow developers to run these goals, by calling `libexec/` scripts manually