### PR TITLE
feat:  add a little ROOT

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,9 +46,9 @@ hs_err_pid*
 .project
 .settings
 
-# no log files:
+# no log/data files:
 *.log
 *.evio 
 
-bin/evio2hipotest
-export.sh
+# scons litter:
+.sconsign.dblite

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -208,6 +208,10 @@ for pom in $(find common-tools -name pom.xml); do
   #   install_jars $pom $prefix_dir/lib/services
   fi
 done
+
+# install JNI stuff:
+$(cd common-tools/clas-io/target && cp *.so ../../../coatjava/lib >& /dev/null || cp *.dylib ../../../coatjava/lib)
+
 echo "installed coatjava to: $prefix_dir"
 
 echo "COATJAVA SUCCESSFULLY BUILT !"

--- a/common-tools/clas-io/pom.xml
+++ b/common-tools/clas-io/pom.xml
@@ -60,6 +60,43 @@
         <scope>compile</scope>
     </dependency>
 
+    <dependency>
+        <groupId>org.jlab</groupId>
+        <artifactId>groot</artifactId>
+        <version>4.0.5</version>
+    </dependency>
+
   </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>scons-1</id>
+                        <phase>install</phase>
+                        <goals><goal>exec</goal></goals>
+                        <configuration>
+                            <arguments><argument>target/native</argument></arguments>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>scons-2</id>
+                        <phase>install</phase>
+                        <goals><goal>exec</goal></goals>
+                        <configuration>
+                            <arguments><argument></argument></arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <executable>scons</executable>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/common-tools/clas-io/sconscript
+++ b/common-tools/clas-io/sconscript
@@ -1,0 +1,19 @@
+Import('env')
+
+javah = env.Command('native', 'src/main/java/org/jlab/io/root/HoistJNI.java', ['javac -h $TARGET $SOURCE', Delete('src/main/java/org/jlab/io/root/HoistJNI.class')])
+AlwaysBuild(javah)
+
+if 'JAVA_HOME' in env['ENV']:
+  env['JAVA_HOME'] = env['ENV']['JAVA_HOME']
+  env.Append(CPPPATH = ["$JAVA_HOME/include", "$JAVA_HOME/include/linux"])
+
+elif env['PLATFORM'] == 'darwin':
+  env.ParseConfig("echo -I`/usr/libexec/java_home`/include")
+  env.ParseConfig("echo -I`/usr/libexec/java_home`/include/darwin")
+
+if env['PLATFORM'] == 'darwin':
+  env.ParseConfig("echo -Wl,-rpath,`root-config --libdir`")
+
+env.Append(CPPPATH = ['native'])
+env.ParseConfig("root-config --libs --cflags")
+env.SharedLibrary('hoistJNI', Glob('*.cpp'))

--- a/common-tools/clas-io/sconstruct
+++ b/common-tools/clas-io/sconstruct
@@ -1,0 +1,5 @@
+import os
+
+env = Environment(ENV=os.environ)
+Export('env')
+env.SConscript('sconscript', variant_dir='target', duplicate=0)

--- a/common-tools/clas-io/src/main/cpp/hoistJNI.cpp
+++ b/common-tools/clas-io/src/main/cpp/hoistJNI.cpp
@@ -1,0 +1,132 @@
+#include <iostream>
+#include <unordered_map>
+#include <mutex>
+#include <jni.h>
+#include <stdio.h>
+#include <TROOT.h>
+#include <TSystem.h>
+#include <TString.h>
+#include <TFile.h>
+#include <TNtuple.h>
+#include <TString.h>
+#include <TH1F.h>
+#include <TH2F.h>
+#include <TMap.h>
+#include <TGraphErrors.h>
+#include "org_jlab_io_root_HoistJNI.h"
+
+class concurrentMap
+{
+  std::mutex m_;
+  std::unordered_map<std::string, TObject*> objs;
+
+public:
+    TObject* get(std::string k) {
+        std::unique_lock<decltype(m_)> lock(m_);
+        return objs[k];
+    }
+
+    void set(std::string k, TObject* v) {
+        std::unique_lock<decltype(m_)> lock(m_);
+        objs[k] = v;
+    }
+};
+
+concurrentMap objects;
+
+static __attribute__((constructor)) void init() {
+  gSystem->ResetSignals();
+  ROOT::EnableThreadSafety();
+  gROOT->SetBatch(true);
+}
+
+JNIEXPORT void JNICALL Java_org_jlab_io_root_HoistJNI_createFile (JNIEnv *env, jobject thisObj, jstring jfname) {
+  const char *fname = env->GetStringUTFChars(jfname, NULL);
+  TFile* ff = new TFile(fname, "RECREATE");
+  objects.set(fname, ff);
+  env->ReleaseStringUTFChars(jfname, fname);
+}
+
+JNIEXPORT void JNICALL Java_org_jlab_io_root_HoistJNI_closeFile (JNIEnv *env, jobject thisObj, jstring jfname) {
+  const char *fname = env->GetStringUTFChars(jfname, NULL);
+  ((TFile*) objects.get(fname))->Close();
+  env->ReleaseStringUTFChars(jfname, fname);
+}
+
+JNIEXPORT void JNICALL Java_org_jlab_io_root_HoistJNI_mkdir( JNIEnv *env, jobject thisObj, jstring jfname, jstring jpath) {
+  const char *fname = env->GetStringUTFChars(jfname, NULL);
+  const char *path = env->GetStringUTFChars(jpath, NULL);
+  ((TFile*) objects.get(fname))->mkdir(path);
+  env->ReleaseStringUTFChars(jfname, fname);
+  env->ReleaseStringUTFChars(jpath, path);
+}
+
+JNIEXPORT void JNICALL Java_org_jlab_io_root_HoistJNI_writeH1F (JNIEnv *env, jobject thisObj, jstring jfname, jstring jpath,
+	jstring jname, jstring jtitle, jint nbins, jdouble xmin, jdouble xmax, jfloatArray jdata) {
+
+  const char *fname = env->GetStringUTFChars(jfname, NULL);
+  const char *path = env->GetStringUTFChars(jpath, NULL);
+  const char *name = env->GetStringUTFChars(jname, NULL);
+  const char *title = env->GetStringUTFChars(jtitle, NULL);
+
+  float *cdata = env->GetFloatArrayElements(jdata, NULL);
+
+  TFile* ff = (TFile*) objects.get(fname);
+  if(!ff->Get(path))
+    ff->mkdir(path);
+  ff->cd(path);
+
+  TH1F* h1 = new TH1F(name, title, nbins, xmin, xmax);
+  jsize length = env->GetArrayLength(jdata);
+  double nentries = 0;
+
+  for(int ib=0;ib<length;ib++) {
+    h1->SetBinContent(ib+1, cdata[ib]);
+    nentries += cdata[ib];
+  }
+
+  h1->SetEntries(nentries);
+  h1->Write("",TObject::kOverwrite);
+
+  env->ReleaseFloatArrayElements(jdata, cdata, 0);
+  env->ReleaseStringUTFChars(jfname, fname);
+  env->ReleaseStringUTFChars(jpath, path);
+  env->ReleaseStringUTFChars(jname, name);
+  env->ReleaseStringUTFChars(jtitle, title);
+}
+
+JNIEXPORT void JNICALL Java_org_jlab_io_root_HoistJNI_writeH2F (JNIEnv *env, jobject thisObj, jstring jfname, jstring jpath,
+	jstring jname, jstring jtitle, jint nxbins, jdouble xmin, jdouble xmax, jint nybins, jdouble ymin, jdouble ymax, jfloatArray jdata) {
+
+  const char *fname = env->GetStringUTFChars(jfname, NULL);
+  const char *path = env->GetStringUTFChars(jpath, NULL);
+  const char *name = env->GetStringUTFChars(jname, NULL);
+  const char *title = env->GetStringUTFChars(jtitle, NULL);
+
+  float *cdata = env->GetFloatArrayElements(jdata, NULL);
+
+  TFile* ff = (TFile*) objects.get(fname);
+  if(!ff->Get(path))
+    ff->mkdir(path);
+  ff->cd(path);
+
+  TH2F* h2 = new TH2F(name, title, nxbins, xmin, xmax, nybins, ymin, ymax);
+  double nentries = 0;
+  int ii = 0;
+
+  for(int ix=0;ix<nxbins;ix++)
+  for(int iy=0;iy<nybins;iy++) {
+    h2->SetBinContent(ix+1, iy+1, cdata[ii]);
+    nentries += cdata[ii++];
+  }
+
+  h2->SetEntries(nentries);
+  h2->Write("",TObject::kOverwrite);
+
+  env->ReleaseFloatArrayElements(jdata, cdata, 0);
+  env->ReleaseStringUTFChars(jfname, fname);
+  env->ReleaseStringUTFChars(jpath, path);
+  env->ReleaseStringUTFChars(jname, name);
+  env->ReleaseStringUTFChars(jtitle, title);
+}
+

--- a/common-tools/clas-io/src/main/java/org/jlab/io/root/Hoist.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/root/Hoist.java
@@ -1,0 +1,62 @@
+package org.jlab.io.root;
+
+import org.jlab.groot.data.H1F;
+import org.jlab.groot.data.H2F;
+
+/**
+ * Copied from https://github.com/drewkenjo/j2root
+ */
+public class Hoist {
+    
+    HoistJNI hoist = new HoistJNI();
+
+    private String fname;
+    private String path = "";
+    
+    public Hoist(String fname) {
+        this.fname = fname;
+        hoist.createFile(fname);
+    }
+    
+    public void close() {
+        hoist.closeFile(fname);
+    }
+
+    public void mkdir(String path) {
+        path = path.replaceFirst("^/*","").replaceAll("/*\\$","");
+        hoist.mkdir(fname, path);
+        this.path = path;
+    }
+
+    public void cd(String path) {
+        this.path = path.replaceFirst("^/*","").replaceAll("/*\\$","");
+    }
+
+    public void write(H1F h1) {
+        String fullpath = path + "/" + h1.getName();
+        int ind = fullpath.lastIndexOf("/");
+        String relpath = fullpath.substring(0,ind);
+        relpath = relpath.replaceFirst("^/*","").replaceAll("/*\\$","");
+        String name = fullpath.substring(ind+1);
+        hoist.writeH1F(fname, relpath, name,
+            h1.getXaxis().getNBins(), h1.getXaxis().min(), h1.getXaxis().max(),
+            h1.getData());
+    }
+
+    public void write(H2F h2) {
+        String fullpath = path + "/" + h2.getName();
+        int ind = fullpath.lastIndexOf("/");
+        String relpath = fullpath.substring(0,ind);
+        relpath = relpath.replaceFirst("^/*","").replaceAll("/*\\$","");
+        String name = fullpath.substring(ind+1);
+        int xsize = h2.getDataSize(0), ysize = h2.getDataSize(1), ii = 0;
+        float[] data = new float[xsize*ysize];
+        for(int ix=0;ix<xsize;ix++)
+            for(int iy=0;iy<ysize;iy++)
+                data[ii++] = (float) h2.getData(ix,iy);
+        hoist.writeH2F(fname, relpath, name,
+            h2.getXAxis().getNBins(), h2.getXAxis().min(), h2.getXAxis().max(),
+            h2.getYAxis().getNBins(), h2.getYAxis().min(), h2.getYAxis().max(),
+            data);
+    }
+}

--- a/common-tools/clas-io/src/main/java/org/jlab/io/root/HoistJNI.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/root/HoistJNI.java
@@ -1,0 +1,13 @@
+package org.jlab.io.root;
+
+/**
+ * Copied from https://github.com/drewkenjo/j2root
+ */
+public class HoistJNI {
+    static { System.loadLibrary("hoistJNI"); }
+    public native void createFile(String fname);
+    public native void closeFile(String fname);
+    public native void mkdir(String fname,String path);
+    public native void writeH1F(String fname, String path, String hname, int nbins, double xmin, double xmax, float[] arr);
+    public native void writeH2F(String fname, String path, String hname, int nxbins, double xmin, double xmax, int nybins, double ymin, double ymax, float[] arr);
+}


### PR DESCRIPTION
Copied from Andrey's https://github.com/drewkenjo/j2root, just histograms for now.  Requires `root-config` and `scons` in path (hence the failing CI tests currently), should switch to `cmake`?  clas-io currently doesn't build from within netbeans.

To-Do:
* Required:
- [ ] automatically (and manually) disable C++/ROOT in maven build if support not found
- [ ] runtime must only require ROOT support if used
- [ ] add a dedicated CI test (github or gitlab)
* Desired:
- [ ] auto-detect C++/ROOT/scons/gcc support for a user-friendly error
- [ ] Netbeans integration (currently not runnable)
- [ ] consider replacing scons with cmake or other