### PR TITLE
fix: increase heap max for `rebuild-scalers`

### DIFF
--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -2,9 +2,11 @@
 
 . `dirname $0`/../libexec/env.sh
 
+split_cli $@
+
 export MALLOC_ARENA_MAX=1
 
-java -Xms768m -Xmx1536m -XX:+UseSerialGC \
+java -Xmx768m -Xms768m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.postprocess.RebuildScalers \
-    $*
+    ${class_options[@]}

--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -6,7 +6,7 @@ split_cli $@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx768m -Xms768m -XX:+UseSerialGC ${jvm_options[@]} \
+java -Xms768m -Xmx1536m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.postprocess.RebuildScalers \
     ${class_options[@]}

--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx768m -Xms768m -XX:+UseSerialGC \
+java -Xms768m -Xmx1536m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.postprocess.RebuildScalers \
     $*


### PR DESCRIPTION
RG-A runs 4282 and 4293 require a bit more heap space for `org.jlab.analysis.postprocess.RebuildScalers`