### PR TITLE
doc: add documentation for each bank

### DIFF
--- a/docs/mkdocs/docs/index.md
+++ b/docs/mkdocs/docs/index.md
@@ -5,7 +5,7 @@
 | | |
 | --- | --- |
 | [**API Documentation**](javadoc/index.html) | Documentation for classes and methods |
-| [**HIPO Bank**](banks.md) | Bank descriptions |
+| [**HIPO Banks**](banks.md) | Bank descriptions |
 | [**Source code**](https://github.com/JeffersonLab/coatjava) | The source code `git` repository |
 
 ---

--- a/docs/mkdocs/generate.sh
+++ b/docs/mkdocs/generate.sh
@@ -25,7 +25,7 @@ top_dir=$src_dir/../..
 # generate build files
 cp $src_dir/mkdocs.yaml $build_dir/
 cp -r $src_dir/docs $build_dir/
-$src_dir/src/banks.rb $top_dir/etc/bankdefs/hipo4 > $build_dir/docs/banks.md
+$src_dir/src/banks.rb $top_dir/etc/bankdefs/hipo4 $build_dir/docs
 tree $build_dir
 
 # build

--- a/docs/mkdocs/mkdocs.yaml
+++ b/docs/mkdocs/mkdocs.yaml
@@ -8,3 +8,4 @@ extra:
 theme:
   name: mkdocs
   user_color_mode_toggle: auto
+  color_mode: auto

--- a/docs/mkdocs/src/banks.rb
+++ b/docs/mkdocs/src/banks.rb
@@ -6,14 +6,49 @@
 require 'json'
 require 'fileutils'
 
+# iguana-created banks have claimed this group ID
 IguanaGroupNum = 30000
-CommonBanks = [
-  'REC::Particle',
-  'RUN::config',
-  'REC::Calorimeter',
-  'REC::Traj',
-] # FIXME: add more, or take inspiration from DST schema
 
+# list of banks to put at the top
+# FIXME: adapted from <https://clasweb.jlab.org/wiki/index.php/CLAS12_DSTs>, but maybe we can use schema dirs to automate
+CommonBanks = {
+  'Event banks' => [
+    'RUN::config',
+    'REC::Event',
+  ],
+  'Physics Banks' => [
+    'REC::Particle',
+    'RECFT::Particle',
+    'REC::Calorimeter',
+    'REC::Scintillator',
+    'REC::Cherenkov',
+    'REC::Track',
+    'REC::Traj',
+    'REC::CovMat',
+    'REC::ScintExtras',
+  ],
+  'Special & Tagged Banks' => [
+    'HEL::flip',
+    'RAW::scaler',
+    'RUN::scaler',
+    'HEL::scaler',
+    'RAW::epics',
+    'HEL::online',
+    'HEL::decoder',
+  ],
+  'Simulation Banks' => [
+    'MC::Header',
+    'MC::Event',
+    'MC::Lund',
+    'MC::Particle',
+    'MC::True',
+    'MC::GenMatch',
+    'MC::RecMatch',
+    'MC::User',
+  ],
+}
+
+# usage and args
 unless ARGV.size == 2
   puts """
   USAGE: #{$0} [INPUT_JSON_DIR] [OUTPUT_DIR]
@@ -79,31 +114,46 @@ TypeHash = {
   'S' => 'short',
 }
 
-# output tables
-FileUtils.mkdir_p OutputDir
-outMain = File.open File.join(OutputDir, "banks.md"), 'w'
-outMain.puts """# HIPO Banks
-
-## Common Banks
-
-"""
-CommonBanks.each do |name|
-  outMain.puts "- #{bank_md_link name}"
-end
-
-outMain.puts """
-## Full List of Banks
-
-Organized by group and item ID
-
-> **NOTE:**  Iguana banks, which are defined in the Iguana repository, use group number #{IguanaGroupNum}.
-"""
-
+# make a table row
 def table_row(out, cols)
   out.puts "| #{cols.join ' | '} |"
 end
+
+# start output markdown
+FileUtils.mkdir_p OutputDir
+FileUtils.mkdir_p File.join(OutputDir, BanksSubDir)
+outMain = File.open File.join(OutputDir, "banks.md"), 'w'
+outMain.puts """# HIPO Banks
+
+The banks are listed in tables below, organized by group and item ID. Click on a bank name for its details.
+"""
+
+# common banks table
+outMain.puts """
+## Common DST Banks
+
+For convenience, here are commonly used DST banks:
+
+"""
+table_row outMain, ['Group', 'Banks']
+table_row outMain, ['---', '---']
+CommonBanks.each do |group_name, bank_list|
+  table_row outMain, [
+    group_name,
+    bank_list.map{ |bank_name| bank_md_link bank_name }.join(', ')
+  ]
+end
+
+# all other bank tables
 specs_fully_sorted.each do |group_id, spec_list|
-  outMain.puts "\n## Group #{group_id}\n\n"
+
+  # get list of unique bank-name prefixes
+  uniq_prefixes = spec_list.map do |spec|
+    "`#{spec['name'].gsub /::.*/, ''}`"
+  end.uniq
+
+  outMain.puts "\n## #{uniq_prefixes.join ', '} Banks"
+  outMain.puts "**Group ID:** #{group_id}\n\n"
   table_row outMain, ['Item ID', 'Name', 'Description']
   table_row outMain, ['---', '---', '---']
   spec_list.each do |spec|

--- a/docs/mkdocs/src/banks.rb
+++ b/docs/mkdocs/src/banks.rb
@@ -4,19 +4,30 @@
 #
 
 require 'json'
+require 'fileutils'
 
-if ARGV.empty?
+IguanaGroupNum = 30000
+CommonBanks = [
+  'REC::Particle',
+  'RUN::config',
+  'REC::Calorimeter',
+  'REC::Traj',
+] # FIXME: add more, or take inspiration from DST schema
+
+unless ARGV.size == 2
   puts """
-  USAGE: #{$0} [DIRECTORY]
+  USAGE: #{$0} [INPUT_JSON_DIR] [OUTPUT_DIR]
 
-  Dumps the bank names and ID information for all JSON files in [DIRECTORY]
+  Dumps the bank names and ID information for all JSON files in [INPUT_JSON_DIR]
+  Output files will appear in [OUTPUT_DIR]
   """
   exit 2
 end
-SpecDir = ARGV[0]
+InputJsonDir = ARGV[0]
+OutputDir    = ARGV[1]
 
 # parse the JSON files
-specs = Dir.glob(File.join SpecDir, '*.json').map do |spec_file_name|
+specs = Dir.glob(File.join InputJsonDir, '*.json').map do |spec_file_name|
   JSON.parse File.read(spec_file_name)
 end.flatten
 
@@ -43,26 +54,61 @@ specs_grouped_sorted = specs_grouped.sort_by{|k,v|k}.to_h
 # then sort each group's item IDs
 specs_fully_sorted = Hash.new
 specs_grouped_sorted.each do |group_id, spec_list|
+  raise "do not define a bank with group ID #{IguanaGroupNum}, since that is reserved for Iguana" if group_id==IguanaGroupNum
   specs_fully_sorted[group_id] = spec_list.sort do |spec_a, spec_b|
     spec_a['item'].to_i <=> spec_b['item'].to_i
   end
 end
 
-# dump a table
-puts """# Bank Group and Item IDs
+# functions to give bank details markdown file name and link
+BanksSubDir = 'banks'
+def bank_md_name(name)
+  File.join(BanksSubDir, name.gsub(/::/,'_')) + '.md'
+end
+def bank_md_link(name)
+  "[`#{name}`](#{bank_md_name name})"
+end
 
-> **NOTE:**  Iguana banks, which are defined in the Iguana repository, use group number 30000.
+# data type hash
+TypeHash = {
+  'B' => 'byte',
+  'D' => 'double',
+  'F' => 'float',
+  'I' => 'int',
+  'L' => 'long',
+  'S' => 'short',
+}
+
+# output tables
+FileUtils.mkdir_p OutputDir
+outMain = File.open File.join(OutputDir, "banks.md"), 'w'
+outMain.puts """# HIPO Banks
+
+## Common Banks
 
 """
+CommonBanks.each do |name|
+  outMain.puts "- #{bank_md_link name}"
+end
 
-def row(cols)
-  puts "| #{cols.join ' | '} |"
+outMain.puts """
+## Full List of Banks
+
+Organized by group and item ID
+
+> **NOTE:**  Iguana banks, which are defined in the Iguana repository, use group number #{IguanaGroupNum}.
+"""
+
+def table_row(out, cols)
+  out.puts "| #{cols.join ' | '} |"
 end
 specs_fully_sorted.each do |group_id, spec_list|
-  puts "\n## Group #{group_id}\n\n"
-  row ['Item ID', 'Name', 'Description']
-  row ['---', '---', '---']
+  outMain.puts "\n## Group #{group_id}\n\n"
+  table_row outMain, ['Item ID', 'Name', 'Description']
+  table_row outMain, ['---', '---', '---']
   spec_list.each do |spec|
+
+    # clean up description
     desc = spec['info'].split.map do |word|
       if word.include? '::'
         "`#{word}`"
@@ -72,10 +118,37 @@ specs_fully_sorted.each do |group_id, spec_list|
         word
       end
     end.join(' ')
-    row [
+
+    # output main table row
+    table_row outMain, [
       spec['item'],
-      '`' + spec['name'] + '`',
+      bank_md_link(spec['name']),
       desc,
     ]
+
+    # generate detailed table
+    outBank = File.open File.join(OutputDir, bank_md_name(spec['name'])), 'w'
+    outBank.puts """# `#{spec['name']}` Bank Details
+
+#{desc}
+
+[Return to main tables](../banks.md)
+
+"""
+    table_row outBank, ['Item Name', 'Type', 'Description']
+    table_row outBank, ['---', '---', '---']
+    spec['entries'].each do |entry|
+      datatype = TypeHash[entry['type']]
+      raise "unknown datatype '#{datatype}'" if datatype.nil?
+      table_row outBank, [
+        "`#{entry['name']}`",
+        "`#{datatype}`",
+        entry['info']
+      ]
+    end
+    outBank.close
   end
 end
+outMain.close
+
+puts "OUTPUT FILES WRITTEN TO #{OutputDir}"


### PR DESCRIPTION
- add a web-table for _every_ bank, showing the item names, types, and their descriptions
- fix: make sure no bank overlaps with Iguana's
- fix: default color scheme set to match system's, so dark-mode users aren't blinded

---

<img width="1305" height="1259" alt="image" src="https://github.com/user-attachments/assets/0e6144b6-94d7-44d7-9106-49deff7be6f5" />

---

<img width="1322" height="792" alt="image" src="https://github.com/user-attachments/assets/531ca559-2d0c-48c9-acf7-947cbcfdbb82" />
