### PR TITLE
build(deps): group `org.openjfx:javafx` for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,10 @@ updates:
     ignore:
       - dependency-name: "org.jlab:groot" # since version numbers are not in order
       - dependency-name: "org.ejml:ejml-simple" # keep version the same as `j4ml:j4ml-clas12:jar:0.9-SNAPSHOT`; see pull requests #636 and #632
+    groups:
+      javafx:
+        patterns:
+          - "org.openjfx:javafx-*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I suspect these updates have been failing CI checks since they need to be updated _together_.