### PR TITLE
doc(deps): GSON version associated with DJL API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,9 @@
       </dependency>
 
       <!-- resolve conflict between `org.jlab.coda:jclara` and `ai.djl:api`
-           by choosing the later version of their `com.google.code.gson:gson` dependency -->
+           by choosing the later version of their `com.google.code.gson:gson` dependency
+           - `djl`'s `gson` version is here: https://github.com/deepjavalibrary/djl/blob/master/gradle/libs.versions.toml
+      -->
       <dependency>
         <groupId>com.google.code.gson</groupId>
         <artifactId>gson</artifactId>


### PR DESCRIPTION
We need a better way to deal with dependency convergence conflicts and keeping the conflicting versions up-to-date. This is a step in the right direction, at least...