### PR TITLE
create REC::FTrack in EBTBEngine only

### DIFF
--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -47,6 +47,7 @@ public class EBEngine extends ReconstructionEngine {
     
     // inputs banks:
     String trackType        = null;
+    String ftrackType       = null;
     String ftofHitsType     = null;
     String trajectoryType   = null;
     String covMatrixType    = null;
@@ -135,7 +136,7 @@ public class EBEngine extends ReconstructionEngine {
         List<DetectorTrack>  tracks = DetectorData.readDetectorTracks(de, trackType, trajectoryType, covMatrixType);
         eb.addTracks(tracks);      
         
-        List<DetectorTrack> ftracks = DetectorData.readFDetectorTracks(de, "FMT::Tracks");
+        List<DetectorTrack> ftracks = DetectorData.readFDetectorTracks(de, ftrackType);
 
         List<DetectorTrack> ctracks = DetectorData.readCentralDetectorTracks(de, cvtTrackType, cvtTrajType);
         eb.addTracks(ctracks);
@@ -315,6 +316,10 @@ public class EBEngine extends ReconstructionEngine {
     
     public void setTrackType(String name) {
         this.trackType = name;
+    }
+
+    public void setFTrackType(String name) {
+        this.ftrackType = name;
     }
     
     public void setFTOFHitsType(String name) {

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBTBEngine.java
@@ -70,6 +70,7 @@ public class EBTBEngine extends EBEngine {
 
         this.setFTOFHitsType("FTOF::clusters");
         this.setTrackType("TimeBasedTrkg::TBTracks");
+        this.setFTrackType("FMT::Tracks");
         this.setTrajectoryType("TimeBasedTrkg::Trajectory");
         this.setCovMatrixType("TimeBasedTrkg::TBCovMat");
         this.setCvtTrackType("CVTRec::Tracks");


### PR DESCRIPTION
Consistent with FMT reconstruction being run on the output of the regular TBT engine, i.e. on TimeBasedTrkg:TBTracks and not on TimeBasedTrkg:TBAITracks. Addresses issue when running aicv yamls.