### PR TITLE
ci: cache maven cache and separate spotbugs job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - name: install xrootd-client (linux)
         if: ${{ matrix.runner == 'ubuntu-latest' }}
         run: |
@@ -115,6 +116,7 @@ jobs:
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - name: install xrootd-client
         run: |
           sudo apt -y update
@@ -140,6 +142,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -161,6 +164,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -197,6 +201,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -252,6 +257,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -276,6 +282,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -298,6 +305,7 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -333,6 +341,7 @@ jobs:
       ### javadoc
       - name: set up JDK
         uses: actions/setup-java@v5
+        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,8 +122,8 @@ jobs:
       - uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
           cvmfs_repositories: 'oasis.opensciencegrid.org'
-      - name: unit tests and spotbugs
-        run: ./build-coatjava.sh --xrootd --spotbugs --unittests --no-progress -T${{ env.nthreads }}
+      - name: unit tests
+        run: ./build-coatjava.sh --xrootd --unittests --no-progress -T${{ env.nthreads }}
       - name: collect jacoco report
         run: validation/jacoco-aggregate.sh
       - name: publish jacoco report
@@ -132,6 +132,27 @@ jobs:
           name: jacoco_report
           path: publish/
           retention-days: 1
+
+  spotbugs:
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.java_version }}
+          distribution: ${{ env.java_distribution }}
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
+        with:
+          cvmfs_repositories: 'oasis.opensciencegrid.org'
+      - uses: actions/download-artifact@v6
+        with:
+          name: build_ubuntu-latest
+      - name: untar build
+        run: tar xzvf coatjava.tar.gz
+      - name: spotbugs
+        run: libexec/spotbugs.sh
 
   test_decoder:
     needs: [ build, download_test_data ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: untar build
         run: tar xzvf coatjava.tar.gz
       - name: spotbugs
-        run: ./build-coatjava.sh --xrootd --spotbugs --no-progress
+        run: ./build-coatjava.sh --spotbugs --nomaps --no-progress
 
   test_decoder:
     needs: [ build, download_test_data ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
       - name: untar build
         run: tar xzvf coatjava.tar.gz
       - name: spotbugs
-        run: libexec/spotbugs.sh
+        run: ./build-coatjava.sh --xrootd --spotbugs --no-progress
 
   test_decoder:
     needs: [ build, download_test_data ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,10 +142,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
           cvmfs_repositories: 'oasis.opensciencegrid.org'
@@ -164,10 +164,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
           cvmfs_repositories: 'oasis.opensciencegrid.org'
@@ -201,10 +201,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - name: setup cvmfs
         uses: cvmfs-contrib/github-action-cvmfs@v5
         with:
@@ -257,10 +257,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - uses: actions/download-artifact@v6
         with:
           name: build_${{ matrix.runner }}
@@ -282,10 +282,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - name: setup groovy
         uses: wtfjoke/setup-groovy@v3
         with:
@@ -305,10 +305,10 @@ jobs:
       - uses: actions/checkout@v5
       - name: Set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - uses: actions/download-artifact@v6
         with:
           name: build_ubuntu-latest
@@ -341,10 +341,10 @@ jobs:
       ### javadoc
       - name: set up JDK
         uses: actions/setup-java@v5
-        cache: maven
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
+          cache: maven
       - name: build coatjava javadocs # javadoc:aggregate output dir cannot be controlled, so assume the latest "standard" path and `mv` it
         run: |
           libexec/build-javadocs.sh


### PR DESCRIPTION
- separate `spotbugs` job, so it's clearer to the user if it fails
- cache the maven cache, for performance
  - 0.25 GB per runner type (Ubuntu and macOS)
  - here's a screenshot:
<img width="1697" height="242" alt="image" src="https://github.com/user-attachments/assets/3530500c-994e-419b-990e-66f5e254c1d0" />
