### PR TITLE
fix: use `SplitLogger` for all loggers

### DIFF
--- a/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioDataDictionary.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioDataDictionary.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataDescriptor;
@@ -20,7 +21,7 @@ import org.jlab.utils.TablePrintout;
  */
 public class EvioDataDictionary implements DataDictionary {
 
-	static final Logger LOGGER = Logger.getLogger(EvioDataDictionary.class.getName());
+	static final Logger LOGGER = SplitLogger.create(EvioDataDictionary.class.getName());
 	private HashMap<String, EvioDataDescriptor> descriptors = new HashMap<>();
 
 	public EvioDataDictionary() {

--- a/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioSource.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/evio/EvioSource.java
@@ -6,6 +6,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.coda.jevio.EvioCompactReader;
 import org.jlab.coda.jevio.EvioException;
@@ -16,7 +17,7 @@ import org.jlab.io.base.DataSourceType;
 
 public final class EvioSource implements DataSource {
 
-    static final Logger LOGGER = Logger.getLogger(EvioSource.class.getName());
+    static final Logger LOGGER = SplitLogger.create(EvioSource.class.getName());
     private ByteOrder storeByteOrder = ByteOrder.BIG_ENDIAN;
     private EvioCompactReader evioReader = null;
     private int currentEvent;

--- a/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSync.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSync.java
@@ -3,6 +3,7 @@ package org.jlab.io.hipo;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.io.base.DataEvent;
 import org.jlab.io.base.DataSync;
 import org.jlab.io.base.DataBank;
@@ -17,7 +18,7 @@ import org.jlab.jnp.hipo4.io.HipoWriterSorted;
  */
 public class HipoDataSync implements DataSync {
 
-    public static final Logger LOGGER = Logger.getLogger(HipoDataSync.class.getName());
+    public static final Logger LOGGER = SplitLogger.create(HipoDataSync.class.getName());
     
     HipoWriterSorted writer = null;
     

--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/DCGeant4Factory.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/DCGeant4Factory.java
@@ -4,6 +4,7 @@ import eu.mihosoft.vrl.v3d.Vector3d;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.base.GeometryFactory;
 import org.jlab.detector.units.SystemOfUnits.Length;
@@ -573,7 +574,7 @@ final class Wire {
 ///////////////////////////////////////////////////
 public final class DCGeant4Factory extends Geant4Factory {
 
-    private static final Logger LOGGER = Logger.getLogger("DCGeant4Factory");
+    private static final Logger LOGGER = SplitLogger.create("DCGeant4Factory");
     DCdatabase dbref = null;
     
     private final HashMap<String, String> properties = new HashMap<>();

--- a/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/SVT/SVTConstants.java
+++ b/common-tools/clas-jcsg/src/main/java/org/jlab/detector/geant4/v2/SVT/SVTConstants.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.detector.calib.utils.DatabaseConstantProvider; // coatjava-3.0
 
@@ -33,7 +34,7 @@ import eu.mihosoft.vrl.v3d.Transform;
  */
 public class SVTConstants {
 
-	public static Logger LOGGER = Logger.getLogger(SVTConstants.class.getName());
+	public static Logger LOGGER = SplitLogger.create(SVTConstants.class.getName());
 
 	private static String ccdbPath = "/geometry/cvt/svt/";
 	private static boolean bLoadedConstants = false; // only load constants once

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/ReconstructionEngine.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clara.base.ClaraUtil;
 import org.jlab.clara.engine.Engine;
 import org.jlab.clara.engine.EngineData;
@@ -40,7 +41,7 @@ import org.json.JSONObject;
  */
 public abstract class ReconstructionEngine implements Engine {
 
-    Logger LOGGER = Logger.getLogger(ReconstructionEngine.class.getName());
+    Logger LOGGER = SplitLogger.create(ReconstructionEngine.class.getName());
 
     public static final String CONFIG_BANK_NAME = "COAT::config";
     

--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/Constants.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/Constants.java
@@ -1,6 +1,7 @@
 package org.jlab.clas.tracking.kalmanfilter.zReference;
 
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  * Constants used in forward tracking
@@ -14,7 +15,7 @@ public class Constants {
     }
     
     
-    public static Logger LOGGER = Logger.getLogger(Constants.class.getName());
+    public static Logger LOGGER = SplitLogger.create(Constants.class.getName());
     
     // CONSTATNS for TRANSFORMATION
     public static final double ITERSTOPXHB = 1.2e-2; 

--- a/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/MagneticField.java
+++ b/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/MagneticField.java
@@ -9,6 +9,7 @@ import java.nio.ByteBuffer;
 import java.nio.FloatBuffer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  * For magnetic fields stored in a specific format. This is low-level,
@@ -19,7 +20,7 @@ import java.util.logging.Logger;
  * @version 1.0
  */
 public abstract class MagneticField implements IMagField {
-	public static Logger LOGGER = Logger.getLogger(MagneticField.class.getName());
+	public static Logger LOGGER = SplitLogger.create(MagneticField.class.getName());
 
 	/** Magic number used to check if byteswapping is necessary. */
 	public static final int MAGICNUMBER = 0xced;

--- a/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/MagneticFields.java
+++ b/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/MagneticFields.java
@@ -13,6 +13,7 @@ import java.util.StringTokenizer;
 import java.util.TimeZone;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import javax.swing.ButtonGroup;
 import javax.swing.JFileChooser;
@@ -30,7 +31,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
  */
 public class MagneticFields {
 
-	public static Logger LOGGER = Logger.getLogger(MagneticField.class.getName());
+	public static Logger LOGGER = SplitLogger.create(MagneticField.class.getName());
 
 	// used for rotating to tilted sector coordinates
 	private static final double ROOT3OVER2 = Math.sqrt(3) / 2;

--- a/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/Torus.java
+++ b/common-tools/cnuphys/magfield/src/main/java/cnuphys/magfield/Torus.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.PrintStream;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  * The Class Torus.
@@ -15,7 +16,7 @@ import java.util.logging.Logger;
 
 public class Torus extends MagneticField {
 
-	public static Logger LOGGER = Logger.getLogger(Torus.class.getName());
+	public static Logger LOGGER = SplitLogger.create(Torus.class.getName());
 		
 	//has part of the solenoid been added in to remove the overlap?
 

--- a/common-tools/cnuphys/swimmer/src/main/java/cnuphys/swim/Swimmer.java
+++ b/common-tools/cnuphys/swimmer/src/main/java/cnuphys/swim/Swimmer.java
@@ -3,6 +3,7 @@ package cnuphys.swim;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import cnuphys.adaptiveSwim.AdaptiveSwimResult;
 import cnuphys.adaptiveSwim.geometry.Cylinder;
@@ -28,7 +29,7 @@ import cnuphys.swim.util.Plane;
  *
  */
 public final class Swimmer {
-	public static Logger LOGGER = Logger.getLogger(Swimmer.class.getName());
+	public static Logger LOGGER = SplitLogger.create(Swimmer.class.getName());
 
 	// Speed of light in m/s
 	public static final double C = 299792458.0; // m/s

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/MagFieldsEngine.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataBank;
@@ -14,7 +15,7 @@ import org.jlab.utils.groups.IndexedTable;
 
 public class MagFieldsEngine extends ReconstructionEngine {
 
-    public static Logger LOGGER = Logger.getLogger(MagFieldsEngine.class.getName());
+    public static Logger LOGGER = SplitLogger.create(MagFieldsEngine.class.getName());
 
     private String solShift = null;
 

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swimmer.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swimmer.java
@@ -4,6 +4,7 @@ import cnuphys.magfield.MagneticFields;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  *
@@ -13,7 +14,7 @@ import java.util.logging.Logger;
 
 public class Swimmer {
 
-    public static Logger LOGGER = Logger.getLogger(Swimmer.class.getName());
+    public static Logger LOGGER = SplitLogger.create(Swimmer.class.getName());
     
     private static HashMap<Thread, ProbeCollection> swimmers = new HashMap<>();
     

--- a/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/HelixFit/HelixFitJava.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/HelixFit/HelixFitJava.java
@@ -2,6 +2,7 @@ package org.jlab.rec.ahdc.HelixFit;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /** Helix Fit.
  *
@@ -9,7 +10,7 @@ import java.util.logging.Logger;
  */
 public class HelixFitJava {
 
-    static final Logger LOGGER = Logger.getLogger(HelixFitJava.class.getName());
+    static final Logger LOGGER = SplitLogger.create(HelixFitJava.class.getName());
 
     /** \todo What does this method do
      *  \what does its name even mean?

--- a/reconstruction/alert/src/main/java/org/jlab/rec/atof/hit/ATOFHit.java
+++ b/reconstruction/alert/src/main/java/org/jlab/rec/atof/hit/ATOFHit.java
@@ -4,6 +4,7 @@ import org.jlab.geom.base.*;
 import org.jlab.geom.prim.Point3D;
 import org.jlab.rec.atof.constants.Parameters;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.rec.alert.constants.CalibrationConstantsLoader;
 
 /**
@@ -17,7 +18,7 @@ import org.jlab.rec.alert.constants.CalibrationConstantsLoader;
  */
 public class ATOFHit {
 
-    static final Logger LOGGER = Logger.getLogger(ATOFHit.class.getName());
+    static final Logger LOGGER = SplitLogger.create(ATOFHit.class.getName());
     
     private int sector, layer, component, order;
     private int tdc, tot;

--- a/reconstruction/alert/src/main/java/org/jlab/service/atof/ATOFEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/service/atof/ATOFEngine.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataBank;
@@ -39,7 +40,7 @@ public class ATOFEngine extends ReconstructionEngine {
     private Detector ATOF;
     private double b; //Magnetic field
     private boolean useStartTime = true;
-    static final Logger LOGGER = Logger.getLogger(ATOFEngine.class.getName());
+    static final Logger LOGGER = SplitLogger.create(ATOFEngine.class.getName());
     
     public void setB(double B) {
         this.b = B;

--- a/reconstruction/bg/src/main/java/org/jlab/service/bg/BackgroundEngine.java
+++ b/reconstruction/bg/src/main/java/org/jlab/service/bg/BackgroundEngine.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.analysis.eventmerger.EventMerger;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataEvent;
@@ -24,7 +25,7 @@ public class BackgroundEngine extends ReconstructionEngine {
     public static final String CONF_REUSE_EVENTS = "reuseEvents";
     public static final String CONF_BG_SCALE = "bgScale";
 
-    static final Logger logger = Logger.getLogger(BackgroundEngine.class.getName());
+    static final Logger logger = SplitLogger.create(BackgroundEngine.class.getName());
 
     EventMerger bgmerger = null;
 //    LinkedList<String> bgfilenames = new LinkedList<>();

--- a/reconstruction/calib/src/main/java/org/jlab/calibration/service/CalibBanksEngine.java
+++ b/reconstruction/calib/src/main/java/org/jlab/calibration/service/CalibBanksEngine.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.calibration.detectors.CTOFBankBuilder;
 import org.jlab.calibration.detectors.DCBankBuilder;
 import org.jlab.calibration.detectors.CalibBankBuilder;
@@ -26,7 +27,7 @@ public class CalibBanksEngine extends ReconstructionEngine {
     public static final String CONF_DETECTORS = "detectors";
     private final List<DetectorType> detectors = new ArrayList<>();
     
-    static final Logger logger = Logger.getLogger(CalibBanksEngine.class.getName());
+    static final Logger logger = SplitLogger.create(CalibBanksEngine.class.getName());
 
     public CalibBanksEngine() {
         super("CALIB", "devita", "1.0");

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/Constants.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/Constants.java
@@ -4,6 +4,7 @@ import cnuphys.magfield.MagneticFields;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clas.pdg.PhysicsConstants;
 import org.jlab.clas.swimtools.Swim;
 
@@ -13,7 +14,7 @@ import org.jlab.rec.cvt.svt.SVTParameters;
 public class Constants {
    
 
-    public static Logger LOGGER = Logger.getLogger(Constants.class.getName());
+    public static Logger LOGGER = SplitLogger.create(Constants.class.getName());
     public static double CAANGLE1= 1.75;
     public static double CAANGLE2=0.551;
     public static double CAANGLE3=30.;

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/bmt/CCDBConstantsLoader.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/bmt/CCDBConstantsLoader.java
@@ -8,6 +8,7 @@ import org.jlab.geom.prim.Vector3D;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  *
@@ -16,7 +17,7 @@ import java.util.logging.Logger;
  */
 public class CCDBConstantsLoader {
 
-    public static Logger LOGGER = Logger.getLogger(CCDBConstantsLoader.class.getName());
+    public static Logger LOGGER = SplitLogger.create(CCDBConstantsLoader.class.getName());
 
     public CCDBConstantsLoader() {}
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/Constants.java
@@ -3,6 +3,7 @@ package org.jlab.rec.dc;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import cnuphys.snr.NoiseReductionParameters;
 import java.util.LinkedHashMap;
@@ -43,7 +44,7 @@ public class Constants {
     }
 
     
-    public static Logger LOGGER = Logger.getLogger(Constants.class.getName());
+    public static Logger LOGGER = SplitLogger.create(Constants.class.getName());
 
     private static boolean ConstantsLoaded = false;
     

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/banks/HitReader.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.io.base.DataBank;
 import org.jlab.io.base.DataEvent;
@@ -54,7 +55,7 @@ public class HitReader {
     private List<FittedHit> _HBHits; //hit-based tracking hit information
     private List<FittedHit> _TBHits; //time-based tracking hit information
 
-    private static final Logger LOGGER = Logger.getLogger(HitReader.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(HitReader.class.getName());
 
     public HitReader(Banks names, DCGeant4Factory detector) {
         this.bankNames= names;

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterCleanerUtilities.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterCleanerUtilities.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.io.base.DataEvent;
 
@@ -15,7 +16,7 @@ import org.jlab.utils.groups.IndexedTable;
 
 public class ClusterCleanerUtilities {
 
-    private static final Logger LOGGER = Logger.getLogger(ClusterCleanerUtilities.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(ClusterCleanerUtilities.class.getName());
 
     public ClusterCleanerUtilities() {
         List<ArrayList<Hit>> sortdHits = new ArrayList<>();

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cluster/ClusterFinder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.io.base.DataEvent;
 
@@ -40,7 +41,7 @@ public class ClusterFinder {
     public ClusterFinder() {
 
     }
-    private static final Logger LOGGER = Logger.getLogger(ClusterFinder.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(ClusterFinder.class.getName());
 
     // cluster finding algorithm
     // the loop is done over sector and superlayers

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/cross/Cross.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/cross/Cross.java
@@ -3,6 +3,7 @@ package org.jlab.rec.dc.cross;
 import java.util.ArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clas.clas.math.FastMath;
 
 //import org.apache.commons.math3.util.FastMath;
@@ -21,7 +22,7 @@ import org.jlab.rec.dc.Constants;
  */
 public class Cross extends ArrayList<Segment> implements Comparable<Cross> {
     
-    private static final Logger LOGGER = Logger.getLogger(Cross.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(Cross.class.getName());
 
     /**
      * serial id

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/nn/PatternRec.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/nn/PatternRec.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.rec.dc.Constants;
 import org.jlab.rec.dc.cluster.Cluster;
@@ -29,7 +30,7 @@ import org.jlab.rec.dc.trajectory.RoadFinder;
  */
 public class PatternRec {
     
-    private static final Logger LOGGER = Logger.getLogger(PatternRec.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(PatternRec.class.getName());
 
     private final ClusterFinder clf = new ClusterFinder();
     private final ClusterCleanerUtilities ct = new ClusterCleanerUtilities();

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/segment/Segment.java
@@ -3,6 +3,7 @@ package org.jlab.rec.dc.segment;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.geom.prim.Plane3D;
 import org.jlab.geom.prim.Point3D;
@@ -23,7 +24,7 @@ import org.jlab.rec.dc.trajectory.SegmentTrajectory;
 public class Segment extends ArrayList<FittedHit> implements Comparable<Segment>,
         Cloneable {
 
-    private static final Logger LOGGER = Logger.getLogger(Segment.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(Segment.class.getName());
 
     private static final long serialVersionUID = -997960312423538455L;
     private FittedCluster _fittedCluster;

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/timetodistance/TableLoader.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/timetodistance/TableLoader.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.base.GeometryFactory;
 import org.jlab.geom.base.ConstantProvider;
@@ -23,7 +24,7 @@ public class TableLoader {
     public TableLoader() {
     }
     
-    public static final Logger LOGGER = Logger.getLogger(TableLoader.class.getName());
+    public static final Logger LOGGER = SplitLogger.create(TableLoader.class.getName());
 
     private static boolean T2DLOADED = false;
     

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clas.clas.math.FastMath;
 import org.jlab.clas.swimtools.Swim;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
@@ -43,7 +44,7 @@ import org.jlab.clas.tracking.utilities.RungeKuttaDoca;
 
 public class TrackCandListFinder {
 
-    private static final Logger LOGGER = Logger.getLogger(TrackCandListFinder.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(TrackCandListFinder.class.getName());
 
     long startTime, startTime2 = 0;
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/KFitterDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/KFitterDoca.java
@@ -3,6 +3,7 @@ package org.jlab.rec.dc.track.fit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.swimtools.Swim;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
@@ -16,7 +17,7 @@ import org.jlab.jnp.matrix.*;
  */
 public class KFitterDoca {
 
-    private static final Logger LOGGER = Logger.getLogger(KFitterDoca.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(KFitterDoca.class.getName());
     
     public boolean setFitFailed = false;
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/MeasVecsDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/MeasVecsDoca.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.detector.geant4.v2.DCGeant4Factory;
 import org.jlab.geom.prim.Line3D;
 import org.jlab.geom.prim.Point3D;
@@ -13,7 +14,7 @@ import org.jlab.rec.dc.track.Track;
 
 public class MeasVecsDoca {
 
-    private static final Logger LOGGER = Logger.getLogger(MeasVecsDoca.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(MeasVecsDoca.class.getName());
     
     public List<MeasVec> measurements = new ArrayList<MeasVec>();
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/fit/StateVecsDoca.java
@@ -4,6 +4,7 @@ import org.jlab.jnp.matrix.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clas.clas.math.FastMath;
 import org.jlab.clas.pdg.PhysicsConstants;
 import org.jlab.clas.swimtools.Swim;
@@ -16,7 +17,7 @@ import org.jlab.geom.prim.Point3D;
  */
 public class StateVecsDoca {
 
-    private static final Logger LOGGER = Logger.getLogger(StateVecsDoca.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(StateVecsDoca.class.getName());
 
     private final double Bmax = 2.366498; // averaged
 

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/Trajectory.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/Trajectory.java
@@ -3,6 +3,7 @@ package org.jlab.rec.dc.trajectory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.clas.swimtools.Swim;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.geom.prim.Point3D;
@@ -23,7 +24,7 @@ public class Trajectory extends ArrayList<Cross> {
     public Trajectory() {
     }
 
-    private static final Logger LOGGER = Logger.getLogger(Trajectory.class.getName());
+    private static final Logger LOGGER = SplitLogger.create(Trajectory.class.getName());
     
     private int id;
     private int sector;

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/TrajectorySurfaces.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/trajectory/TrajectorySurfaces.java
@@ -17,6 +17,7 @@ import org.jlab.rec.dc.Constants;
 
 import java.io.PrintWriter;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.geom.detector.ec.ECLayer;
 import org.jlab.geom.detector.ec.ECSuperlayer;
 import org.jlab.geom.detector.fmt.FMTLayer;
@@ -33,7 +34,7 @@ import org.jlab.geom.prim.Triangle3D;
  */
 public class TrajectorySurfaces {
 
-    public static Logger LOGGER = Logger.getLogger(TrajectorySurfaces.class.getName());
+    public static Logger LOGGER = SplitLogger.create(TrajectorySurfaces.class.getName());
 
     private List<ArrayList<Surface>> detectorPlanes = new ArrayList<>();
 

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EBEngine.java
@@ -3,6 +3,7 @@ package org.jlab.service.eb;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataEvent;
@@ -23,7 +24,7 @@ import org.jlab.rec.eb.EBRadioFrequency;
  */
 public class EBEngine extends ReconstructionEngine {
 
-    public static final Logger LOGGER = Logger.getLogger(EBEngine.class.getName());
+    public static final Logger LOGGER = SplitLogger.create(EBEngine.class.getName());
 
     boolean usePOCA = false;
 

--- a/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
+++ b/reconstruction/ec/src/main/java/org/jlab/service/ec/ECEngine.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.detector.base.DetectorCollection;
@@ -23,7 +24,7 @@ import org.jlab.io.base.DataEvent;
 
 public class ECEngine extends ReconstructionEngine {
 
-    public static Logger LOGGER = Logger.getLogger(ECEngine.class.getName());
+    public static Logger LOGGER = SplitLogger.create(ECEngine.class.getName());
     
     public ECEngine(){
         super("EC","gavalian","1.0");

--- a/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
+++ b/reconstruction/htcc/src/main/java/org/jlab/service/htcc/HTCCReconstructionService.java
@@ -2,6 +2,7 @@ package org.jlab.service.htcc;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.rec.htcc.HTCCReconstruction;
@@ -13,7 +14,7 @@ import org.jlab.io.base.DataEvent;
  */
 public class HTCCReconstructionService extends ReconstructionEngine{
 
-    public static Logger LOGGER = Logger.getLogger(HTCCReconstructionService.class.getName());
+    public static Logger LOGGER = SplitLogger.create(HTCCReconstructionService.class.getName());
 
     public HTCCReconstructionService(){
         super("HTCC","henkins","1.0");

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/LTCCEngine.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 
 /**
  * LTCC Reconstruction Engine.
@@ -14,7 +15,7 @@ import java.util.logging.Logger;
  */
 public class LTCCEngine extends ReconstructionEngine {
 
-    public static Logger LOGGER = Logger.getLogger(LTCCEngine.class.getName());
+    public static Logger LOGGER = SplitLogger.create(LTCCEngine.class.getName());
 
     private static final boolean DEBUG = false;
     private static final List<String> CC_TABLES = 

--- a/reconstruction/postproc/src/main/java/org/jlab/service/postproc/PostprocEngine.java
+++ b/reconstruction/postproc/src/main/java/org/jlab/service/postproc/PostprocEngine.java
@@ -2,6 +2,7 @@ package org.jlab.service.postproc;
 
 import java.io.File;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import org.jlab.analysis.postprocess.Processor;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.io.base.DataEvent;
@@ -18,7 +19,7 @@ public class PostprocEngine extends ReconstructionEngine {
     public static final String CONF_RESTREAM_HELICITY = "restream";
     public static final String CONF_REBUILD_SCALERS = "rebuild";
 
-    static final Logger logger = Logger.getLogger(PostprocEngine.class.getName());
+    static final Logger logger = SplitLogger.create(PostprocEngine.class.getName());
 
     Processor processor = null;
 

--- a/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
+++ b/reconstruction/raster/src/main/java/org/jlab/service/raster/RasterEngine.java
@@ -3,6 +3,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import javax.swing.JFrame;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.groot.data.H2F;
@@ -28,7 +29,7 @@ public class RasterEngine extends ReconstructionEngine {
     private final int    xComponent = 1;
     private final int    yComponent = 2;
 
-    public static final Logger LOGGER = Logger.getLogger(RasterEngine.class.getName());
+    public static final Logger LOGGER = SplitLogger.create(RasterEngine.class.getName());
 
     public RasterEngine() {
         super("RasterEngine","devita","1.0");

--- a/reconstruction/recoil/src/main/java/org/jlab/service/recoil/RecoilEngine.java
+++ b/reconstruction/recoil/src/main/java/org/jlab/service/recoil/RecoilEngine.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import javax.swing.JFrame;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.detector.base.DetectorType;
@@ -27,7 +28,7 @@ import org.jlab.io.hipo.HipoDataSource;
  */
 public class RecoilEngine extends ReconstructionEngine {
 
-    public static Logger LOGGER = Logger.getLogger(RecoilEngine.class.getName());
+    public static Logger LOGGER = SplitLogger.create(RecoilEngine.class.getName());
 
     public static RecoilStripFactory factory = new RecoilStripFactory();
 

--- a/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
+++ b/reconstruction/urwell/src/main/java/org/jlab/service/urwell/URWellEngine.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.jlab.logging.SplitLogger;
 import javax.swing.JFrame;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.detector.base.DetectorType;
@@ -27,7 +28,7 @@ import org.jlab.io.hipo.HipoDataSource;
  */
 public class URWellEngine extends ReconstructionEngine {
 
-    public static Logger LOGGER = Logger.getLogger(URWellEngine.class.getName());
+    public static Logger LOGGER = SplitLogger.create(URWellEngine.class.getName());
 
     public static URWellStripFactory factory = new URWellStripFactory();
 


### PR DESCRIPTION
This PR extends #951 by replacing all `Logger.getLogger` patterns with `SplitLogger.create`.