### PR TITLE
fix(build): prioritize Maven central repository

### DIFF
--- a/common-tools/coat-libs/pom.xml
+++ b/common-tools/coat-libs/pom.xml
@@ -13,14 +13,6 @@
     <version>13.4.1-SNAPSHOT</version>
   </parent>
 
-  <repositories>
-    <repository>
-      <id>freehep-repo-public</id>
-      <url>https://clasweb.jlab.org/.clas12maven/</url>
-      <!--<url>https://srs.slac.stanford.edu/nexus/content/groups/freehep-maven2-public/</url>-->
-    </repository>
-  </repositories>
-
   <dependencies>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,10 @@
 
   <repositories>
     <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2</url>
+    </repository>
+    <repository>
       <id>clas12maven</id>
       <url>https://clasweb.jlab.org/.clas12maven</url>
     </repository>


### PR DESCRIPTION
Maven checks repositories in order, for dependencies. If a "404 not found" is returned, it moves on to the next repository until a dependency is found. Before this PR, Maven central is last in the priority list; this PR puts Maven central first, since most of our dependencies come from there.

This should greatly reduce the number of 404s seen on clasweb logs. We now have the following numbers of 404 responses, before and after this change:

```
For https://clasweb.jlab.org/.clas12maven:
- before change: 166
- after change:  28
For https://clasweb.jlab.org/.jhep/maven:
- before change: 165
- after change:  11
```

I confirmed that the 28 remaining 404s from clas12maven and the 11 from jhep/maven are coming from cases where Maven searches clas12maven first, then finds the dependency on jhep/maven, or vice versa. We may need a repository management solution (Nexus, Artifactory) to stop those.