### PR TITLE
feat: `SplitLogManager` for treewide logging control

### DIFF
--- a/bin/bg-merger
+++ b/bin/bg-merger
@@ -6,7 +6,7 @@ export MALLOC_ARENA_MAX=1
 
 split_cli $@
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.eventmerger.EventMerger \
     ${class_options[@]}

--- a/bin/bos2hipo
+++ b/bin/bos2hipo
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.io.utils.Bos2HipoEventBank \
     $*

--- a/bin/cvt-compare
+++ b/bin/cvt-compare
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.rec.cvt.Geometry \
     $*

--- a/bin/daqEventViewer
+++ b/bin/daqEventViewer
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Xms1024m \
+java ${JAVA_OPTS-} -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.detector.examples.RawEventViewer \
     $*

--- a/bin/dclayereffs-ana
+++ b/bin/dclayereffs-ana
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m \
+java ${JAVA_OPTS-} -Dsun.java2d.pmoffscreen=false -Xmx2048m -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.service.dc.LayerEfficiencyAnalyzer \
     $*

--- a/bin/decoder
+++ b/bin/decoder
@@ -6,7 +6,7 @@ split_cli $@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.detector.decode.CLASDecoder4 \
     ${class_options[@]}

--- a/bin/dict-generator
+++ b/bin/dict-generator
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.roads.DictionaryGenerator \
     $*

--- a/bin/dict-maker
+++ b/bin/dict-maker
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.roads.DictionaryCreator \
     $*

--- a/bin/dict-merger
+++ b/bin/dict-merger
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.roads.DictionaryMerger \
     $*

--- a/bin/dict-validator
+++ b/bin/dict-validator
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.roads.DictionaryValidator \
     $*

--- a/bin/evio-viewer
+++ b/bin/evio-viewer
@@ -2,4 +2,4 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -cp ${COATJAVA_CLASSPATH:-''} org.jlab.coda.eventViewer.EventTreeFrame $*
+java ${JAVA_OPTS-} -cp ${COATJAVA_CLASSPATH:-''} org.jlab.coda.eventViewer.EventTreeFrame $*

--- a/bin/evio2hipo
+++ b/bin/evio2hipo
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.clas.reco.io.EvioHipoEvent4 \
     $*

--- a/bin/eviocure
+++ b/bin/eviocure
@@ -4,6 +4,6 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.io.utils.EvioCure $*

--- a/bin/eviodump
+++ b/bin/eviodump
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Xms1024m \
+java ${JAVA_OPTS-} -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.io.utils.DataSourceDump \
     $*

--- a/bin/hipo-browser
+++ b/bin/hipo-browser
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Xms1024m \
+java ${JAVA_OPTS-} -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.groot.ui.TBrowser \
     $*

--- a/bin/hipo-diff
+++ b/bin/hipo-diff
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.utils.HipoDiff \
     $*

--- a/bin/hipo-json
+++ b/bin/hipo-json
@@ -2,7 +2,7 @@
 
 . `dirname $0`/../libexec/env.sh
 
-java -Xms1024m \
+java ${JAVA_OPTS-} -Xms1024m \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.utils.JsonUtils \
     $*

--- a/bin/hipo-merge-histograms
+++ b/bin/hipo-merge-histograms
@@ -4,7 +4,7 @@
 
 split_cli $@
 
-cmd="java -Xms1024m ${jvm_options[@]} -cp ${COATJAVA_CLASSPATH:-''} org.jlab.groot.data.TDirectory"
+cmd="java ${JAVA_OPTS-} -Xms1024m ${jvm_options[@]} -cp ${COATJAVA_CLASSPATH:-''} org.jlab.groot.data.TDirectory"
 
 if [ $# -eq 0 ]; then
   echo """

--- a/bin/hipo-utils
+++ b/bin/hipo-utils
@@ -6,7 +6,7 @@ split_cli $@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx2048m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
+java ${JAVA_OPTS-} -Xmx2048m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.io.hipo.HipoUtilities \
     ${class_options[@]}

--- a/bin/postprocess
+++ b/bin/postprocess
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx768m -Xms768m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx768m -Xms768m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.postprocess.Tag1ToEvent \
     $*

--- a/bin/rebuild-scalers
+++ b/bin/rebuild-scalers
@@ -6,7 +6,7 @@ split_cli $@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xms768m -Xmx1536m -XX:+UseSerialGC ${jvm_options[@]} \
+java ${JAVA_OPTS-} -Xms768m -Xmx1536m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.postprocess.RebuildScalers \
     ${class_options[@]}

--- a/bin/recon-util
+++ b/bin/recon-util
@@ -6,7 +6,7 @@ split_cli $@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.clas.reco.EngineProcessor \
     ${class_options[@]}

--- a/bin/run-clara
+++ b/bin/run-clara
@@ -91,12 +91,8 @@ JAVA_OPTS="$java_opts $JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="$JAVA_OPTS -Djava.io.tmpdir=$CLARA_USER_DATA -Dorg.sqlite.tmpdir=$CLARA_USER_DATA"
 
 # Set verbosity:
-#
-# FIXME:
-# - use SplitLogManager
-# - allow verbosity control
-#
-[ -z ${quiet+x} ] && stub=fine || stub=info
+[ -z ${quiet+x} ] && stub=logging || stub=debug
+JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.jlab.logging.SplitLogManager"
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/$stub.properties"
 
 export JAVA_OPTS

--- a/bin/run-clara
+++ b/bin/run-clara
@@ -91,6 +91,11 @@ JAVA_OPTS="$java_opts $JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="$JAVA_OPTS -Djava.io.tmpdir=$CLARA_USER_DATA -Dorg.sqlite.tmpdir=$CLARA_USER_DATA"
 
 # Set verbosity:
+#
+# FIXME:
+# - use SplitLogManager
+# - allow verbosity control
+#
 [ -z ${quiet+x} ] && stub=fine || stub=info
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/$stub.properties"
 

--- a/bin/run-clara
+++ b/bin/run-clara
@@ -29,7 +29,7 @@ function error() {
 threads=2
 prefix=rec_
 java_quiet=false
-java_log_level=warning
+java_log_level=info
 CLARA_USER_DATA=.
 while getopts y:o:p:c:t:n:lL:qmvh opt
 do

--- a/bin/run-clara
+++ b/bin/run-clara
@@ -15,19 +15,23 @@ Options:\n
 \t-n   number of events (default=-1)\n
 \t-m   merge output files (see dependencies below)\n
 \t-l   larger JVM memory requests\n
-\t-v   verbose output\n
+\t-L   set Java log level (e.g., info, fine, etc.)\n
+\t-q   quiet output (overrides -L)\n
+\t-v   verbose output (xtrace)\n
 \t-h   print this help and exit\n\n
 Merging outputs (-m) requires hipo-utils and yq (https://github.com/mikefarah/yq).'
 
 function error() {
-    echo -e "\n$usage\n\nERROR:  $@." && exit 1
+    echo -e "\n$usage\n\nERROR:  $@." >&2 && exit 1
 }
 
 # Interpret command line:
 threads=2
 prefix=rec_
+java_quiet=false
+java_log_level=warning
 CLARA_USER_DATA=.
-while getopts y:o:p:c:t:n:lqmvh opt
+while getopts y:o:p:c:t:n:lL:qmvh opt
 do
     case $opt in
         y) yaml=$OPTARG ;;
@@ -37,8 +41,9 @@ do
         t) threads=$OPTARG && echo $threads | grep -q -E '^[0-9]+$' || error "-t must be an integer, threads" ;;
         n) nevents="-e $OPTARG" && echo "$nevents" | grep -q -E '^-e [0-9]+$' || error "-n must be an integer, events" ;;
         l) large=1 ;;
+        L) java_log_level=$OPTARG ;;
         m) merge=1 ;;
-        q) quiet=1 ;;
+        q) java_quiet=true ;;
         v) set -o xtrace ;;
         h) echo -e "\n$usage" && echo -e $info && exit 0 ;;
     esac
@@ -68,7 +73,7 @@ java_opts="-Xms${gb_init}g -Xmx${gb_max}g"
 yaml=$(cd $(dirname $yaml) && pwd)/$(basename $yaml)
 
 # Create the environment variables and directories required by CLARA:
-[ -e $CLARA_USER_DATA ] && echo "WARNING:  Using existing directory:  $CLARA_USER_DATA"
+[ -e $CLARA_USER_DATA ] && echo "WARNING:  Using existing directory:  $CLARA_USER_DATA" >&2
 mkdir -p $CLARA_USER_DATA || error "Cannot create -o output directory: $CLARA_USER_DATA"
 mkdir -p $CLARA_USER_DATA/log $CLARA_USER_DATA/config $CLARA_USER_DATA/data/output
 export CLARA_USER_DATA=$(cd $CLARA_USER_DATA && pwd)
@@ -90,11 +95,20 @@ done
 JAVA_OPTS="$java_opts $JAVA_OPTS -XX:+IgnoreUnrecognizedVMOptions"
 JAVA_OPTS="$JAVA_OPTS -Djava.io.tmpdir=$CLARA_USER_DATA -Dorg.sqlite.tmpdir=$CLARA_USER_DATA"
 
-# Set verbosity:
-[ -z ${quiet+x} ] && stub=logging || stub=debug
+# Set logger and verbosity
 JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.manager=org.jlab.logging.SplitLogManager"
-JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/$stub.properties"
-
+if $java_quiet; then
+  JAVA_OPTS="$JAVA_OPTS -Djava.util.logging.config.file=$CLAS12DIR/etc/logging/logging.properties"
+else
+  case ${java_log_level^^} in
+    SEVERE|WARNING|INFO|CONFIG|FINE|FINER|FINEST|ALL|OFF)
+      JAVA_OPTS="$JAVA_OPTS -D.level=${java_log_level^^}"
+      ;;
+    *)
+      error "unknown Java log level '$java_log_level'"
+      ;;
+  esac
+fi
 export JAVA_OPTS
 
 function get_host_ip() {

--- a/bin/run-coatjava
+++ b/bin/run-coatjava
@@ -24,7 +24,7 @@ shift
 
 split_cli $@
 
-exec java -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
+exec java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC ${jvm_options[@]} \
   -cp ${COATJAVA_CLASSPATH:-''} \
   $class_name \
   ${class_options[@]}

--- a/bin/trigger-filter
+++ b/bin/trigger-filter
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.eventmerger.RandomTriggerFilter \
     $*

--- a/bin/trigger-splitter
+++ b/bin/trigger-splitter
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.eventmerger.RandomTriggerSplit \
     $*

--- a/bin/trutheff
+++ b/bin/trutheff
@@ -4,7 +4,7 @@
 
 export MALLOC_ARENA_MAX=1
 
-java -Xmx1536m -Xms1024m -XX:+UseSerialGC \
+java ${JAVA_OPTS-} -Xmx1536m -Xms1024m -XX:+UseSerialGC \
     -cp ${COATJAVA_CLASSPATH:-''} \
     org.jlab.analysis.efficiency.Truth \
     $*

--- a/common-tools/clas-analysis/pom.xml
+++ b/common-tools/clas-analysis/pom.xml
@@ -79,12 +79,6 @@
 
     <dependency>
       <groupId>org.jlab.clas</groupId>
-      <artifactId>clas-logging</artifactId>
-      <version>13.5.0-SNAPSHOT</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jlab.clas</groupId>
       <artifactId>swim-tools</artifactId>
       <version>13.5.0-SNAPSHOT</version>
     </dependency>

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Tag1ToEvent.java
@@ -13,7 +13,6 @@ import org.jlab.detector.scalers.DaqScalersSequence;
 import org.jlab.detector.helicity.HelicityBit;
 import org.jlab.detector.helicity.HelicitySequenceDelayed;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
-import org.jlab.logging.SplitLogger;
 import org.jlab.utils.groups.IndexedTable;
 import org.jlab.utils.options.OptionParser;
 
@@ -31,7 +30,7 @@ import org.jlab.utils.options.OptionParser;
 
 public class Tag1ToEvent {
 
-    static final Logger LOGGER = SplitLogger.create(Tag1ToEvent.class.getName());
+    static final Logger LOGGER = Logger.getLogger(Tag1ToEvent.class.getName());
 
     public static void main(String[] args) {
 

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Util.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/postprocess/Util.java
@@ -22,15 +22,13 @@ import org.jlab.detector.helicity.HelicitySequence;
 import org.jlab.detector.helicity.HelicitySequenceDelayed;
 import org.jlab.detector.helicity.HelicitySequenceManager;
 
-import org.jlab.logging.SplitLogger;
-
 /**
  * Static utility methods for postprocessing.
  * @author baltzell
  */
 class Util {
 
-    static final Logger logger = SplitLogger.create(Util.class.getName());
+    static final Logger logger = Logger.getLogger(Util.class.getName());
 
     /**
      * Assign the delay-corrected helicity to the HEL::scaler bank's rows

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/ConstantsManager.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/ConstantsManager.java
@@ -13,7 +13,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.jlab.utils.groups.IndexedTable;
-import org.jlab.logging.SplitLogger;
+import org.jlab.logging.SplitLogManager;
 
 /**
  *
@@ -23,7 +23,10 @@ public class ConstantsManager {
 
     public static final int DBERROR_SLEEP_SECONDS=3;
 
-    private static Logger LOGGER = SplitLogger.create(ConstantsManager.class.getName(), false);
+    private static Logger LOGGER = Logger.getLogger(ConstantsManager.class.getName());
+    static {
+        SplitLogManager.configureHandlers(LOGGER, false);
+    }
 
     private DatabaseConstantsDescriptor defaultDescriptor = new DatabaseConstantsDescriptor();
     private volatile Map<Integer, DatabaseConstantsDescriptor> runConstants = new LinkedHashMap<Integer, DatabaseConstantsDescriptor>();
@@ -182,7 +185,10 @@ public class ConstantsManager {
      */
     public static class DatabaseConstantsDescriptor {
         
-        Logger LOGGER = SplitLogger.create(DatabaseConstantsDescriptor.class.getName(), false);
+        private static Logger LOGGER = Logger.getLogger(DatabaseConstantsDescriptor.class.getName());
+        static {
+          SplitLogManager.configureHandlers(LOGGER, false);
+        }
 
         private String  descName   = "descriptor";
         private int     runNumber  = 10;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/DatabaseConstantProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/DatabaseConstantProvider.java
@@ -22,7 +22,7 @@ import org.jlab.geom.base.ConstantProvider;
 import org.jlab.utils.groups.IndexedTable;
 import org.jlab.utils.groups.IndexedTableViewer;
 import org.jlab.utils.system.FileSystemExecScan;
-import org.jlab.logging.SplitLogger;
+import org.jlab.logging.SplitLogManager;
 
 /**
  *
@@ -30,7 +30,10 @@ import org.jlab.logging.SplitLogger;
  */
 public class DatabaseConstantProvider implements ConstantProvider {
 
-    static final Logger LOGGER = SplitLogger.create(DatabaseConstantProvider.class.getName(), false);
+    static final Logger LOGGER = Logger.getLogger(DatabaseConstantProvider.class.getName());
+    static {
+        SplitLogManager.configureHandlers(LOGGER, false);
+    }
     
     private final HashMap<String,String[]> constantContainer = new HashMap<>();
     private final boolean PRINT_ALL = true;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -3,7 +3,7 @@ package org.jlab.detector.calib.utils;
 import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jlab.logging.SplitLogger;
+import org.jlab.logging.SplitLogManager;
 
 import org.rcdb.RCDB;
 import org.rcdb.Condition;
@@ -34,7 +34,10 @@ public class RCDBProvider {
         }
     }
 
-    public static Logger LOGGER = SplitLogger.create(RCDBProvider.class.getName(), false);
+    public static Logger LOGGER = Logger.getLogger(RCDBProvider.class.getName());
+    static {
+        SplitLogManager.configureHandlers(LOGGER, false);
+    }
 
     public static final String DEFAULTADDRESS = "mysql://rcdb@clasdb.jlab.org/rcdb";
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicityGenerator.java
@@ -6,7 +6,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jlab.logging.SplitLogger;
 
 /**
  * Helicity Pseudo-Random Sequence.
@@ -30,7 +29,7 @@ import org.jlab.logging.SplitLogger;
  */
 public final class HelicityGenerator implements Comparable<HelicityGenerator>, Comparator<HelicityGenerator> {
 
-    static final Logger LOGGER = SplitLogger.create(HelicityGenerator.class.getName());
+    static final Logger LOGGER = Logger.getLogger(HelicityGenerator.class.getName());
     public static final int REGISTER_SIZE=30;
     private final List<Integer> states=new ArrayList<>();
     private int offset=0;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequence.java
@@ -10,7 +10,6 @@ import java.util.TreeSet;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jlab.detector.calib.utils.ConstantsManager;
-import org.jlab.logging.SplitLogger;
 
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.Event;
@@ -53,7 +52,7 @@ import org.jlab.jnp.hipo4.io.HipoWriterSorted;
  */
 public class HelicitySequence {
 
-    static final Logger LOGGER = SplitLogger.create(HelicitySequence.class.getName());
+    static final Logger LOGGER = Logger.getLogger(HelicitySequence.class.getName());
     public static final double TIMESTAMP_CLOCK=250.0e6; // Hz
     protected double helicityClock=29.56; // Hz
     protected HelicityPattern pattern=HelicityPattern.QUARTET;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceManager.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/helicity/HelicitySequenceManager.java
@@ -12,7 +12,6 @@ import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.jlab.jnp.hipo4.io.HipoReader;
-import org.jlab.logging.SplitLogger;
 
 /**
  * Manage helicity sequences for multiple run numbers simultaneously.
@@ -22,7 +21,7 @@ import org.jlab.logging.SplitLogger;
  */
 public final class HelicitySequenceManager {
 
-    static final Logger LOGGER = SplitLogger.create(HelicitySequence.class.getName());
+    static final Logger LOGGER = Logger.getLogger(HelicitySequence.class.getName());
     SchemaFactory schema=null;
     private final int delay;
     private boolean flip=false;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -10,7 +10,6 @@ import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.jlab.utils.groups.IndexedTable;
 import java.util.logging.Logger;
-import org.jlab.logging.SplitLogger;
 
 /**
  *
@@ -53,7 +52,7 @@ public class DaqScalers {
     private long timestamp=0;
     private int evnum=0;
 
-    private static final Logger logger = SplitLogger.create(DaqScalers.class.getName());
+    private static final Logger logger = Logger.getLogger(DaqScalers.class.getName());
 
     public DaqScalers setTimestamp(long timestamp) {
         this.timestamp=timestamp;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -12,7 +12,6 @@ import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.jlab.detector.calib.utils.ConstantsManager;
-import org.jlab.logging.SplitLogger;
 
 /**
  * For easy access to most recent scaler readout for any given event.
@@ -31,7 +30,7 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
     private Bank runConfigBank=null;
     private Bank runScalerBank=null;
   
-    protected static final Logger logger = SplitLogger.create(DaqScalersSequence.class.getName());
+    protected static final Logger logger = Logger.getLogger(DaqScalersSequence.class.getName());
     
     protected DaqScalersSequence(){};
 

--- a/common-tools/clas-io/pom.xml
+++ b/common-tools/clas-io/pom.xml
@@ -53,13 +53,6 @@
       <version>13.5.0-SNAPSHOT</version>
     </dependency>
 
-    <dependency>
-        <groupId>org.jlab.clas</groupId>
-        <artifactId>clas-logging</artifactId>
-        <version>13.5.0-SNAPSHOT</version>
-        <scope>compile</scope>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSource.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/hipo/HipoDataSource.java
@@ -13,7 +13,6 @@ import org.jlab.io.base.DataSourceType;
 import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.jlab.jnp.hipo4.io.HipoReader;
-import org.jlab.logging.SplitLogger;
 
 /**
  *
@@ -21,7 +20,7 @@ import org.jlab.logging.SplitLogger;
  */
 public class HipoDataSource implements DataSource {
 
-    public static final Logger LOGGER = SplitLogger.create(HipoDataSource.class.getName());
+    public static final Logger LOGGER = Logger.getLogger(HipoDataSource.class.getName());
 
     HipoReader reader = null;
     int currentEventNumber = 0;

--- a/common-tools/clas-io/src/main/java/org/jlab/io/utils/EvioCure.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/utils/EvioCure.java
@@ -7,7 +7,6 @@ import java.util.logging.Logger;
 import org.jlab.coda.jevio.EventWriter;
 import org.jlab.coda.jevio.EvioException;
 import org.jlab.coda.jevio.EvioReader;
-import org.jlab.logging.SplitLogger;
 
 /**
  *
@@ -15,7 +14,7 @@ import org.jlab.logging.SplitLogger;
  */
 public class EvioCure {
 
-    private static final Logger LOGGER = SplitLogger.create(EvioCure.class.getName());
+    private static final Logger LOGGER = Logger.getLogger(EvioCure.class.getName());
 
     public static void main(String[] args) {
 

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
@@ -99,7 +99,12 @@ public class SplitLogManager extends LogManager {
       thisLevel = logger.getLevel();
     // if all else fails, try to use the parent's level
     if(thisLevel==null) {
-      thisLevel = logger.getParent().getLevel();
+      try {
+        thisLevel = logger.getParent().getLevel();
+      }
+      catch(NullPointerException e) {
+        System.err.println("WARNING: 'getParent()' of logger '" + logger.getName() + "' failed");
+      }
       if(thisLevel==null) { // should never happen, but just in case, fall back to default and complain directly to `stderr`
         thisLevel = Level.INFO;
         System.err.println("WARNING: trouble setting level of logger '" + logger.getName() + "'; defaulting to level '" + thisLevel + "'");

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
@@ -2,33 +2,39 @@ package org.jlab.logging;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.logging.LogManager;
 
 /**
- * Helper methods to create a {@code Logger} that sends errors to {@code stderr} and everything else to {@code stdout}
+ * {@code LogManager} that sends errors to {@code stderr} and everything else to {@code stdout}
  * @see TestSplitLogger {@code TestSplitLogger}: for guidance on how to use this class
  * @author dilks
  */
-public class SplitLogger {
+public class SplitLogManager extends LogManager {
 
   /**
-   * create a new {@link SplitLogger} instance, with formatted messages
-   * @return a new {@link SplitLogger} instance
+   * create a new {@link Logger} instance
    * @param name the name of the logger
+   * @return a new {@link Logger} instance
    */
-  public static Logger create(String name) {
-    return create(name, true);
+  @Override
+  public Logger getLogger(String name) {
+    Logger logger = super.getLogger(name);
+    if(logger != null)
+      configureHandlers(logger, true);
+    return logger;
   }
 
   /**
-   * create a new {@link SplitLogger} instance, with an optional message formatting including a prefix
-   * @return a new {@link SplitLogger} instance
+   * add a new {@link Logger} instance
    * @param name the name of the logger
-   * @param includePrefix whether or not to include a prefix in the formatting
+   * @return {@code true} if the argument logger was registered successfully, {@code false} if a logger of that name already exists
    */
-  public static Logger create(String name, boolean includePrefix) {
-    Logger logger = Logger.getLogger(name);
-    configureHandlers(logger, includePrefix);
-    return logger;
+  @Override
+  public synchronized boolean addLogger(Logger logger) {
+    boolean added = super.addLogger(logger);
+    if(added)
+      configureHandlers(logger, true);
+    return added;
   }
 
   /**

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
@@ -6,7 +6,6 @@ import java.util.logging.LogManager;
 
 /**
  * {@code LogManager} that sends errors to {@code stderr} and everything else to {@code stdout}
- * @see TestSplitLogger {@code TestSplitLogger}: for guidance on how to use this class
  * @author dilks
  */
 public class SplitLogManager extends LogManager {
@@ -92,9 +91,9 @@ public class SplitLogManager extends LogManager {
     String userLevelProperty = System.getProperty(logger.getName() + ".level");
     if(userLevelProperty != null)
       thisLevel = Level.parse(userLevelProperty);
-    // else if the `SplitLoggerConfig` default level was set, use that level
-    else if(SplitLoggerConfig.INSTANCE.defaultLevelWasSet())
-      thisLevel = SplitLoggerConfig.INSTANCE.getDefaultLevel();
+    // else if the `SplitLogManagerConfig` default level was set, use that level
+    else if(SplitLogManagerConfig.INSTANCE.defaultLevelWasSet())
+      thisLevel = SplitLogManagerConfig.INSTANCE.getDefaultLevel();
     // else fallback to the level of `logger` itself
     else
       thisLevel = logger.getLevel();

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManagerConfig.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManagerConfig.java
@@ -3,7 +3,7 @@ package org.jlab.logging;
 import java.util.logging.Level;
 
 /** Configuration singleton for {@code SplitLogManager} */
-public enum SplitLoggerConfig {
+public enum SplitLogManagerConfig {
 
   /** singleton instance */
   INSTANCE;

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLoggerConfig.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLoggerConfig.java
@@ -2,7 +2,7 @@ package org.jlab.logging;
 
 import java.util.logging.Level;
 
-/** Configuration singleton for {@code SplitLogger} */
+/** Configuration singleton for {@code SplitLogManager} */
 public enum SplitLoggerConfig {
 
   /** singleton instance */
@@ -12,8 +12,8 @@ public enum SplitLoggerConfig {
   private volatile boolean calledSetDefaultLevel = false;
 
   /**
-   * Set the default {@code logging.Level} for all new {@code SplitLogger} instances.
-   * Note: see {@code SplitLogger} details to check if other ways to set logging levels will take priority over this.
+   * Set the default {@code logging.Level} for all new {@code SplitLogManager}'s {@code Logger} instances.
+   * Note: see {@code SplitLogManager} details to check if other ways to set logging levels will take priority over this.
    * @param level the log level
    */
   public synchronized void setDefaultLevel(Level level) {
@@ -21,8 +21,8 @@ public enum SplitLoggerConfig {
     this.calledSetDefaultLevel = true;
   }
 
-  /** @return the default {@code logging.Level} for all new {@code SplitLogger} instances.
-   * Note: see {@code SplitLogger} details to check if other ways to set logging levels will take priority over this.
+  /** @return the default {@code logging.Level} for all new {@code SplitLogManager}'s {@code Logger} instances.
+   * Note: see {@code SplitLogManager} details to check if other ways to set logging levels will take priority over this.
    */
   public Level getDefaultLevel() {
     return this.defaultLevel;

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/TestLogManager.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/TestLogManager.java
@@ -4,38 +4,34 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 
 /**
- * A simple class demonstrating how to use {@link SplitLogManager}.
- * <p>
- * The {@link SplitLogManager} will create {@code Logger} instances that send {@code SEVERE} and {@code WARNING} log messages
- * to {@code stderr}, and all lower levels to {@code stdout}.
+ * A simple class for testing a custom {@code LogManager}, such as {@link SplitLogManager}.
  * <p>
  * <b>How to set the logging level:</b>
  * <p>
  * A {@code .properties} file is necessary, which has the class name and desired log level; for example,
  * <pre>
- * org.jlab.logging.TestSplitLogger.level = FINE
+ * org.jlab.logging.TestLogManager.level = FINE
  * </pre>
  * From high to low, the levels are: {@code SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST}.
  * <p>
  * There are some example {@code .properties} files you can use with this class, like so:
  * <pre>
  * java \
- *   -Djava.util.logging.config.file=common-tools/clas-logging/src/main/resources/org/jlab/logging/TestSplitLogger.finest.properties \
+ *   -Djava.util.logging.config.file=common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.finest.properties \
  *   -cp ... \
- *   org.jlab.logging.TestSplitLogger
+ *   org.jlab.logging.TestLogManager
  * </pre>
  * You may write your own {@code .properties} file, to control the logging level of all classes which use logging.
- * @see SplitLogManager {@code SplitLogManager}: for implementation details
  * @author dilks
  */
-public class TestSplitLogger {
+public class TestLogManager {
 
   /** logger instance for this class */
-  protected static final Logger LOGGER = Logger.getLogger(TestSplitLogger.class.getName());
+  protected static final Logger LOGGER = Logger.getLogger(TestLogManager.class.getName());
 
   /** constructor: prints some messages to {@code stdout}, but not using the logger yet */
-  public TestSplitLogger() {
-    System.out.println("Created 'TestSplitLogger' instance");
+  public TestLogManager() {
+    System.out.println("Created 'TestLogManager' instance");
     System.out.println("Log level = " + LOGGER.getLevel());
   }
 
@@ -122,7 +118,7 @@ public class TestSplitLogger {
    * @param args unused
    */
   public static void main(String[] args) {
-    var potato = new TestSplitLogger();
+    var potato = new TestLogManager();
     potato.test1();
     potato.test2();
     potato.test3();

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/TestSplitLogger.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/TestSplitLogger.java
@@ -4,9 +4,9 @@ import java.util.logging.Logger;
 import java.util.logging.Level;
 
 /**
- * A simple class demonstrating how to use {@link SplitLogger}.
+ * A simple class demonstrating how to use {@link SplitLogManager}.
  * <p>
- * The {@link SplitLogger} class will send {@code SEVERE} and {@code WARNING} log messages
+ * The {@link SplitLogManager} will create {@code Logger} instances that send {@code SEVERE} and {@code WARNING} log messages
  * to {@code stderr}, and all lower levels to {@code stdout}.
  * <p>
  * <b>How to set the logging level:</b>
@@ -25,13 +25,13 @@ import java.util.logging.Level;
  *   org.jlab.logging.TestSplitLogger
  * </pre>
  * You may write your own {@code .properties} file, to control the logging level of all classes which use logging.
- * @see SplitLogger {@code SplitLogger}: for implementation details
+ * @see SplitLogManager {@code SplitLogManager}: for implementation details
  * @author dilks
  */
 public class TestSplitLogger {
 
   /** logger instance for this class */
-  protected static final Logger LOGGER = SplitLogger.create(TestSplitLogger.class.getName());
+  protected static final Logger LOGGER = Logger.getLogger(TestSplitLogger.class.getName());
 
   /** constructor: prints some messages to {@code stdout}, but not using the logger yet */
   public TestSplitLogger() {

--- a/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.finest.properties
+++ b/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.finest.properties
@@ -1,0 +1,6 @@
+### the finest possible logging level
+org.jlab.logging.TestLogManager.level = FINEST
+
+### or less fine levels
+# org.jlab.logging.TestLogManager.level = FINER
+# org.jlab.logging.TestLogManager.level = FINE

--- a/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.info.properties
+++ b/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.info.properties
@@ -1,2 +1,2 @@
 ### info level; includes warning and severe levels (for errors)
-org.jlab.logging.TestSplitLogger.level = INFO
+org.jlab.logging.TestLogManager.level = INFO

--- a/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.quiet.properties
+++ b/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestLogManager.quiet.properties
@@ -1,0 +1,5 @@
+### warnings and severe errors only
+org.jlab.logging.TestLogManager.level = WARNING
+
+### or you can suppress warnings too
+# org.jlab.logging.TestLogManager.level = SEVERE

--- a/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestSplitLogger.finest.properties
+++ b/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestSplitLogger.finest.properties
@@ -1,6 +1,0 @@
-### the finest possible logging level
-org.jlab.logging.TestSplitLogger.level = FINEST
-
-### or less fine levels
-# org.jlab.logging.TestSplitLogger.level = FINER
-# org.jlab.logging.TestSplitLogger.level = FINE

--- a/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestSplitLogger.quiet.properties
+++ b/common-tools/clas-logging/src/main/resources/org/jlab/logging/TestSplitLogger.quiet.properties
@@ -1,5 +1,0 @@
-### warnings and severe errors only
-org.jlab.logging.TestSplitLogger.level = WARNING
-
-### or you can suppress warnings too
-# org.jlab.logging.TestSplitLogger.level = SEVERE

--- a/common-tools/clas-reco/pom.xml
+++ b/common-tools/clas-reco/pom.xml
@@ -84,12 +84,6 @@
       <version>13.5.0-SNAPSHOT</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.jlab.clas</groupId>
-      <artifactId>clas-logging</artifactId>
-      <version>13.5.0-SNAPSHOT</version>
-    </dependency>
-
   </dependencies>
 
 </project>

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
@@ -17,7 +17,6 @@ import org.jlab.clara.engine.EngineDataType;
 import java.util.Arrays;
 import org.jlab.jnp.hipo4.data.SchemaFactory;
 import org.json.JSONObject;
-import org.jlab.logging.SplitLogger;
 import org.jlab.utils.ClaraYaml;
 
 /**
@@ -30,7 +29,7 @@ public class EngineProcessor {
     public static final String ENGINE_CLASS_PP = "org.jlab.service.postproc.PostprocEngine";
     
     private final Map<String,ReconstructionEngine>  processorEngines = new LinkedHashMap<>();
-    private static final Logger LOGGER = SplitLogger.create(EngineProcessor.class.getPackage().getName());
+    private static final Logger LOGGER = Logger.getLogger(EngineProcessor.class.getPackage().getName());
     private boolean updateDictionary = true;
     private SchemaFactory banksToKeep = null;
     private final List<String> schemaExempt = Arrays.asList("RUN::config","DC::tdc");

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
@@ -11,7 +11,7 @@ import java.util.TreeMap;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 import org.jlab.logging.SplitLogManager;
-import org.jlab.logging.SplitLoggerConfig;
+import org.jlab.logging.SplitLogManagerConfig;
 
 /**
  *
@@ -192,7 +192,7 @@ public class OptionParser {
     private void setVerbosity(String level) {
         try {
             this.logLevel = Level.parse(level);
-            SplitLoggerConfig.INSTANCE.setDefaultLevel(this.logLevel);
+            SplitLogManagerConfig.INSTANCE.setDefaultLevel(this.logLevel);
         }
         catch (IllegalArgumentException e) {
             System.err.println("Invalid -l java.util.logging.Level:  "+level);

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
@@ -10,7 +10,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Logger;
 import java.util.logging.Level;
-import org.jlab.logging.SplitLogger;
+import org.jlab.logging.SplitLogManager;
 import org.jlab.logging.SplitLoggerConfig;
 
 /**
@@ -238,7 +238,7 @@ public class OptionParser {
      * @param externalLogger an external {@code Logger} instance, typically one owned by the owner of this {@code OptionParser} instance
      */
     public void syncLogLevel(Logger externalLogger) {
-        SplitLogger.configureLevel(externalLogger, this.logLevel);
+        SplitLogManager.configureLevel(externalLogger, this.logLevel);
     }
 
     public static void main(String[] args){

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/system/FileSystemExecScan.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/system/FileSystemExecScan.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.apache.commons.text.StringSubstitutor;
-import org.jlab.logging.SplitLogger;
 
 /**
  * Find a location for a usable temporary directory, on a filesystem mounted
@@ -22,7 +21,7 @@ import org.jlab.logging.SplitLogger;
  */
 public class FileSystemExecScan {
     
-    static final Logger LOGGER = SplitLogger.create(FileSystemExecScan.class.getName());
+    static final Logger LOGGER = Logger.getLogger(FileSystemExecScan.class.getName());
 
     static final StringSubstitutor SUBSTITUTOR = new StringSubstitutor(System.getenv());
 

--- a/common-tools/coat-libs/pom.xml
+++ b/common-tools/coat-libs/pom.xml
@@ -77,6 +77,12 @@
 
     <dependency>
       <groupId>org.jlab.clas</groupId>
+      <artifactId>clas-logging</artifactId>
+      <version>13.4.1-SNAPSHOT</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jlab.clas</groupId>
       <artifactId>clas-reco</artifactId>
       <version>13.5.0-SNAPSHOT</version>
     </dependency>

--- a/common-tools/coat-libs/pom.xml
+++ b/common-tools/coat-libs/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.jlab.clas</groupId>
       <artifactId>clas-logging</artifactId>
-      <version>13.4.1-SNAPSHOT</version>
+      <version>13.5.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -2,24 +2,32 @@
 
 ## Controlling Log Levels
 
-To control the log level of a class with a `Logger`, make a logging `.properties` file, and set the level of each of your classes for which you want to use a non-default level; use the property name `className.level`, for example:
+To control the log level of a class with a `Logger`, use properties. As CLI options, you may use, for example,
+```
+-Dorg.jlab.detector.helicity.HelicityGenerator.level=FINEST   # sets HelicityGenerator level to FINEST
+-D.level=FINE   # sets the level of all loggers to FINE
+```
+
+Alternatively, make a logging `.properties` file, and set the level of each of your classes for which you want to use a non-default level; use the property name `className.level`, for example:
 ```
 # my_levels.properties
 org.jlab.detector.helicity.HelicityGenerator.level = FINEST
 org.jlab.detector.calib.utils.RCDBProvider.level = FINER
 ```
-You can also control the _global_ log level for all classes with `.level`, for example, to set
-it to `FINE`:
+or use `.level` for the global level:
 ```
+# my_levels.properties
 .level = FINE
 ```
 To use this `.properties` file, run with the `java` option
 ```
 -Djava.util.logging.config.file=my_levels.properties
 ```
-For example, if using `run-coatjava`,
+Then, here are some examples for using it with `recon-util`:
 ```bash
-run-coatjava [CLASS_NAME] [CLASS_ARGS] -- -Djava.util.logging.config.file=my_levels.properties
+recon-util [ARGS] -- -Djava.util.logging.config.file=my_levels.properties   # use your .properties file
+recon-util [ARGS] -- -D.level=ALL   # set the global level to ALL (very verbose!)
+recon-util [ARGS] -- -D.level=OFF   # silence the loggers
 ```
 From high to low, the levels are `SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST` (see `java.util.logging.Level` documentation).
 You may also use levels `ALL` or `OFF`, for everything or nothing, respectively.

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -8,11 +8,16 @@ To control the log level of a class with a `Logger`, make a logging `.properties
 org.jlab.detector.helicity.HelicityGenerator.level = FINEST
 org.jlab.detector.calib.utils.RCDBProvider.level = FINER
 ```
-Then run as
-```bash
-java -Djava.util.logging.config.file=my_levels.properties ...
+You can also control the _global_ log level for all classes with `.level`, for example, to set
+it to `FINE`:
 ```
-or using `run-coatjava`,
+.level = FINE
+```
+To use this `.properties` file, run with the `java` option
+```
+-Djava.util.logging.config.file=my_levels.properties
+```
+For example, if using `run-coatjava`,
 ```bash
 run-coatjava [CLASS_NAME] [CLASS_ARGS] -- -Djava.util.logging.config.file=my_levels.properties
 ```
@@ -20,7 +25,7 @@ From high to low, the levels are `SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FI
 You may also use levels `ALL` or `OFF`, for everything or nothing, respectively.
 
 > [!NOTE]
-> These properties may compete with the log level set by `OptionParser`'s option `-l`, potentially overriding that level.
+> These properties may compete with the log level set by `OptionParser`'s option `-l`, potentially overriding that level. For example, `postprocess` and `decoder` use `OptionParser`.
 
 ## Bumping Version Number and Deploying
 

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -2,7 +2,7 @@
 
 ## Controlling Log Levels
 
-To control the log level of a class with a `Logger`, use properties. As CLI options, you may use, for example,
+To control the log level of a class with a `Logger`, use properties. For example, use `java` options:
 ```
 -Dorg.jlab.detector.helicity.HelicityGenerator.level=FINEST   # sets HelicityGenerator level to FINEST
 -D.level=FINE   # sets the level of all loggers to FINE

--- a/libexec/env.sh
+++ b/libexec/env.sh
@@ -32,6 +32,9 @@ if [ "${1-}" != '--no-classpath' ]; then
   export COATJAVA_CLASSPATH
 fi
 
+# set log manager
+export JAVA_OPTS="-Dorg.jlab.logging.SplitLogManager ${JAVA_OPTS-}"
+
 # additional environment variables for groovy or interactive use
 # - call as `source $0 groovy` or `source $0 jshell`
 if [ $# -ge 1 ]; then

--- a/libexec/env.sh
+++ b/libexec/env.sh
@@ -33,7 +33,7 @@ if [ "${1-}" != '--no-classpath' ]; then
 fi
 
 # set log manager
-export JAVA_OPTS="-Dorg.jlab.logging.SplitLogManager ${JAVA_OPTS-}"
+export JAVA_OPTS="-Djava.util.logging.manager=org.jlab.logging.SplitLogManager ${JAVA_OPTS-}"
 
 # additional environment variables for groovy or interactive use
 # - call as `source $0 groovy` or `source $0 jshell`

--- a/reconstruction/cvt/pom.xml
+++ b/reconstruction/cvt/pom.xml
@@ -46,11 +46,6 @@
     </dependency>
     <dependency>
       <groupId>org.jlab.clas</groupId>
-      <artifactId>clas-logging</artifactId>
-      <version>13.5.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jlab.clas</groupId>
       <artifactId>clas-reco</artifactId>
       <version>13.5.0-SNAPSHOT</version>
     </dependency>

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/Geometry.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/Geometry.java
@@ -30,7 +30,6 @@ import org.jlab.groot.base.GStyle;
 import org.jlab.groot.data.GraphErrors;
 import org.jlab.groot.graphics.EmbeddedCanvasTabbed;
 import org.jlab.groot.group.DataGroup;
-import org.jlab.logging.SplitLogger;
 import org.jlab.rec.cvt.bmt.BMTGeometry;
 import org.jlab.rec.cvt.bmt.BMTType;
 import org.jlab.rec.cvt.bmt.CCDBConstantsLoader;
@@ -94,7 +93,7 @@ public class Geometry {
     
     private static boolean LOADED;
     
-    private final static Logger LOGGER = SplitLogger.create(Geometry.class.getName());
+    private final static Logger LOGGER = Logger.getLogger(Geometry.class.getName());
     
     
     // private constructor for a singleton

--- a/reconstruction/dc/pom.xml
+++ b/reconstruction/dc/pom.xml
@@ -64,11 +64,6 @@
     </dependency>
     <dependency>
       <groupId>org.jlab.clas</groupId>
-      <artifactId>clas-logging</artifactId>
-      <version>13.5.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jlab.clas</groupId>
       <artifactId>clas-utils</artifactId>
       <version>13.5.0-SNAPSHOT</version>
     </dependency>

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.jlab.logging.SplitLogger;
 import org.jlab.clas.reco.ReconstructionEngine;
 import org.jlab.detector.banks.RawBank.OrderType;
 import org.jlab.io.base.DataBank;
@@ -40,7 +39,7 @@ public class DCEngine extends ReconstructionEngine {
     private String   dafChi2Cut     = null;
     private String   dafAnnealingFactorsTB = null;
     
-    public static final Logger LOGGER = SplitLogger.create(ReconstructionEngine.class.getName());
+    public static final Logger LOGGER = Logger.getLogger(ReconstructionEngine.class.getName());
 
 
     public DCEngine(String name) {

--- a/validation/advanced-tests/run-advanced-tests.sh
+++ b/validation/advanced-tests/run-advanced-tests.sh
@@ -4,7 +4,6 @@
 # and input data files at ./data
 
 # set up environment
-JAVA_OPTS="-Djava.util.logging.config.file=$PWD/../../etc/logging/debug.properties"
 CLARA_HOME=$PWD/../../clara/ ; export CLARA_HOME
 COAT=$CLARA_HOME/plugins/clas12/
 


### PR DESCRIPTION
## Description
Changes:
- convert `SplitLogger` into `SplitLogManager`
  - `SplitLogger.create` is replaced by `SplitLogManager` methods that override `LogManager`, such that `Logger.getLogger` and similar commands instantiate a logger that has the same properties as the old `SplitLogger`
  - it is now easy to swap to a different custom log manager

This is a much cleaner approach for controlling our logger; now all we need to do is:

1. Use system property to choose a log manager
   - in this case, the new `SplitLogManager`, via a `java` CLI option:
     ```bash
     -Djava.util.logging.manager=org.jlab.logging.SplitLogManager
     ```
   - all `bin/` scripts now use this option (via `$JAVA_OPTS`, see below)
1. In your Java class, instantiate a `Logger` like normal:
   - just use `Logger.getLogger`, which will use the manager set by the `java.util.logging.manager` property:
     ```java
     static final Logger logger = Logger.getLogger(MyClass.class.getName());
     ```

## Log Levels

- No changes in `coatjava` itself; see the 'Developer Notes', linked from the main `README.md`
- Added log-level control to `run-clara` with new option `-L`
  - default level is `INFO` (`-Linfo`)
  - for example, `-Loff` to silence (mostly) everything, or `-Lall` for _very_ verbose
  - option `-q` for quiet output is (mostly) unchanged

## About `$JAVA_OPTS`
The environment variable `$JAVA_OPTS` is not used by the `java` command; rather it is a convention for things which wrap `java`. I added a default `$JAVA_OPTS` setting in `libexec/env.sh` that:
- sets the log manager
- prioritizes user's `$JAVA_OPTS`, if they have any
- all `java`-calling `bin/*` scripts now use `$JAVA_OPTS`, but as the _lowest_ priority in the CLI option ordering

Therefore, for all `java`-calling `bin/*` scripts, we have the following priority order of `java` options (from lowest priority to highest, _i.e._, left-to-right):
1. `$JAVA_TOOL_OPTIONS` and `_JAVA_OPTIONS`: JVM options; we don't appear to use them here, but they are used by `java` at the _lowest_ priority
1. `$JAVA_OPTS`: includes the log manager choice (set in `env.sh`), followed by user's `$JAVA_OPTS`, if any
1. hard-coded options unique to each `bin/*` script, such as `-Xms` and `-Xmx`
1. some scripts allow for further override options, passed to the script as arguments to the right of `--` (see `env.sh`'s function `split_cli`); these will take the _highest_ priority, since they are meant to be overrides
