### PR TITLE
ci: comment details on dependabot submodule bump PRs

### DIFF
--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -18,7 +18,7 @@ jobs:
       - name: get changes
         id: changes
         run: |
-          git diff origin/${{ github.base_rev }} --submodule=log | tee changes.txt
+          git diff origin/${{ github.base_ref }} --submodule=log | tee changes.txt
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           cat changes.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -1,0 +1,34 @@
+name: Submodule Changes
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  changes:
+    name: Submodule Changes
+    if: github.actor == 'c-dilks' # FIXME
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          submodules: true
+      - name: get changes
+        id: changes
+        run: |
+          git diff origin/${{ github.base_rev }} --submodule=log | tee changes.txt
+          echo "changes<<EOF" >> $GITHUB_OUTPUT
+          cat changes.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+      - name: comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Submodule Changes\n\n\`\`\`\n${{ steps.changes.outputs.changes }}\n\`\`\``
+            })

--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -2,13 +2,13 @@ name: Submodule Changes
 
 on:
   pull_request:
-    # types:
-    #   - opened
+    types:
+      - opened
 
 jobs:
   changes:
     name: Submodule Changes
-    if: github.actor == 'c-dilks' # FIXME
+    if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -2,8 +2,8 @@ name: Submodule Changes
 
 on:
   pull_request:
-    types:
-      - opened
+    # types:
+    #   - opened
 
 jobs:
   changes:

--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -18,7 +18,11 @@ jobs:
       - name: get changes
         id: changes
         run: |
-          git diff origin/${{ github.base_ref }} --submodule=log | tee changes.txt
+          for sm in $(grep 'path = ' .gitmodules | awk '{print $3}'); do
+            echo "SUBMODULE $sm ===========" | tee changes.txt
+            git diff origin/${{ github.base_ref }} --submodule=log -- $sm | tee changes.txt
+            echo "" | tee changes.txt
+          done
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           cat changes.txt >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/submodule.yml
+++ b/.github/workflows/submodule.yml
@@ -19,9 +19,7 @@ jobs:
         id: changes
         run: |
           for sm in $(grep 'path = ' .gitmodules | awk '{print $3}'); do
-            echo "SUBMODULE $sm ===========" | tee changes.txt
-            git diff origin/${{ github.base_ref }} --submodule=log -- $sm | tee changes.txt
-            echo "" | tee changes.txt
+            git diff origin/${{ github.base_ref }} --submodule=log -- $sm | tee -a changes.txt
           done
           echo "changes<<EOF" >> $GITHUB_OUTPUT
           cat changes.txt >> $GITHUB_OUTPUT


### PR DESCRIPTION
Dependabot's PRs for submodules do not provide any info about what changed; there is no way to configure dependabot to provide more details.

This PR adds an action to automatically comment on dependabot PRs what has changed.

An example of such a comment is below, tested on #980.