### PR TITLE
ci: dependabot conventional commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "build(deps)"
     ignore:
       - dependency-name: "org.jlab:groot" # since version numbers are not in order
       - dependency-name: "org.ejml:ejml-simple" # keep version the same as `j4ml:j4ml-clas12:jar:0.9-SNAPSHOT`; see pull requests #636 and #632
@@ -30,6 +32,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:


### PR DESCRIPTION
specify conventional-commit convention, rather than guess it