### PR TITLE
ci: set dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ version: 2
 updates:
   - package-ecosystem: "maven"
     directory: "/"
+    cooldown:
+      default-days: 14
     schedule:
       interval: "weekly"
     commit-message:
@@ -30,6 +32,8 @@ updates:
           - "org.openjfx:javafx-*"
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 14
     schedule:
       interval: "weekly"
     commit-message:


### PR DESCRIPTION
It's a bit more secure to set a cooldown period for new dependencies, to allow time for patch releases.