### PR TITLE
Prefer pi+ over pi- for start time determination

### DIFF
--- a/reconstruction/eb/README.md
+++ b/reconstruction/eb/README.md
@@ -136,8 +136,8 @@ particle must have both
 1.  a track in the DC
 2.  an associated FTOF hit in panel 1B (preferred) or 1A
 
-Priority is then ordered as $e^-$, $e^+$, $\pi^+$,
-$\pi^-$. In each case, if multiple candidates exist, the one with
+Priority is then ordered as $e^-$, $e^+$, $\pi^-$,
+$\pi^+$. In each case, if multiple candidates exist, the one with
 the highest momentum is taken. For $e^+/e^-$ the
 ECAL/HTCC criteria discussed in the next section is required, but for
 pions there are no additional requirements (i.e. it's just assumed to be

--- a/reconstruction/eb/src/main/java/org/jlab/service/eb/EventBuilder.java
+++ b/reconstruction/eb/src/main/java/org/jlab/service/eb/EventBuilder.java
@@ -43,7 +43,7 @@ public class EventBuilder {
     
     private final IMatch cndMatcher;
 
-    private static final int[] TRIGGERLIST = new int[]{11,-11,211,-211,0};
+    private static final int[] TRIGGERLIST = new int[]{11,-11,-211,211,0};
 
     private boolean usePOCA=false;
     


### PR DESCRIPTION
New priority:
1. e<sup>-</sup>
1. e<sup>+</sup>
1. 𝜋<sup>-</sup>
1. 𝜋<sup>+</sup>

Also need to update documentation.
