### PR TITLE
Iss1006 vtx speed3

### DIFF
--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
@@ -64,6 +64,15 @@ public class Swim {
     }
 
     /**
+     * Set max swimming path length
+     *
+     * @param maxPathLength
+     */
+    public void setMaxPathLength(double _maxPathLength) {
+        this._maxPathLength = _maxPathLength;
+    }
+
+    /**
      *
      * @param direction
      *            +1 for out -1 for in

--- a/etc/bankdefs/util/bankSplit.py
+++ b/etc/bankdefs/util/bankSplit.py
@@ -55,7 +55,7 @@ mc = ["MC::Event", "MC::GenMatch", "MC::Header", "MC::Lund", "MC::Particle", "MC
 tag1 = ["RUN::config", "RAW::epics", "RAW::scaler", "RUN::scaler", "HEL::scaler", "COAT::config", "HEL::flip", "HEL::online", "HEL::decoder"]
 
 # these are the output of the event builder:
-rectb   = ["REC::Event","REC::Particle","REC::Calorimeter","REC::CaloExtras","REC::Cherenkov","REC::CovMat","REC::ForwardTagger","REC::Scintillator","REC::ScintExtras","REC::Track","REC::UTrack","REC::FTrack","REC::Traj","RECFT::Event","RECFT::Particle"]
+rectb   = ["REC::Event","REC::Particle","REC::Calorimeter","REC::CaloExtras","REC::Cherenkov","REC::CovMat","REC::ForwardTagger","REC::Scintillator","REC::ScintExtras","REC::Track","REC::UTrack","REC::FTrack","REC::Traj","REC::VertDoca","RECFT::Event","RECFT::Particle"]
 rechb   = ["RECHB::Event","RECHB::Particle","RECHB::Calorimeter","RECHB::CaloExtras","RECHB::Cherenkov","RECHB::ForwardTagger","RECHB::Scintillator","RECHB::ScintExtras","RECHB::Track","RECHB::FTrack"]
 rectbai = ["RECAI::Event","RECAI::Particle","RECAI::Calorimeter","RECAI::CaloExtras","RECAI::Cherenkov","RECAI::CovMat","RECAI::ForwardTagger","RECAI::Scintillator","RECAI::ScintExtras","RECAI::Track","RECAI::Traj","RECAIFT::Event","RECAIFT::Particle"]
 rechbai = ["RECHBAI::Event","RECHBAI::Particle","RECHBAI::Calorimeter","RECHBAI::CaloExtras","RECHBAI::Cherenkov","RECHBAI::ForwardTagger","RECHBAI::Scintillator","RECHBAI::ScintExtras","RECHBAI::Track"]

--- a/reconstruction/vtx/src/main/java/org/jlab/rec/vtx/DoubleSwim.java
+++ b/reconstruction/vtx/src/main/java/org/jlab/rec/vtx/DoubleSwim.java
@@ -39,6 +39,8 @@ public class DoubleSwim  extends Swim {
         swim2.stepSize= 500.00* 1.e-6; // 500 microns
         swim1.distanceBetweenSaves=500.00 * 1.e-6; // 500 microns
         swim2.distanceBetweenSaves=500.00 * 1.e-6; // 500 microns
+        swim1.setMaxPathLength(0.5); // m
+        swim2.setMaxPathLength(0.5); // m
     }
     
     public void init(double x01, double y01, double z01, double px01, double py01, double pz01, int charge1,


### PR DESCRIPTION
Reduces the computing time of the overtaxing service by limiting the maximum swimming path length
Tests on RG-E data show a reduction by a factor > 4.