### PR TITLE
fix: Timer needs daemon mode (might be post-java8)

### DIFF
--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/Benchmark.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/Benchmark.java
@@ -25,10 +25,10 @@ public class Benchmark {
     
     public void printTimer(int seconds){
         TimerTask timerTask = new TimerTask() { 
-                @Override
-                public void run() { System.out.println(getInstance()); }
+            @Override
+            public void run() { System.out.println(benchmarkInstance); }
         };
-        updateTimer = new Timer("Benchmark");
+        updateTimer = new Timer("Benchmark", true);
         updateTimer.scheduleAtFixedRate(timerTask, 0, 1000*seconds);
     }
     
@@ -62,7 +62,7 @@ public class Benchmark {
     }
 
     public BenchmarkTimer getTotal(String name) {
-        BenchmarkTimer total = new BenchmarkTimer(name);
+        BenchmarkTimerTotal total = new BenchmarkTimerTotal(name);
         for (BenchmarkTimer b : timerStore.values())
             total.add(b);
         return total;

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/BenchmarkTimer.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/BenchmarkTimer.java
@@ -5,16 +5,17 @@ package org.jlab.utils.benchmark;
  * @author gavalian
  */
 public class BenchmarkTimer {
-    
+
     private String timerName = "generic";
-    private long   totalTime = 0;
-    private long   timeAtResume = 0;
-    private int    numberOfCalls = 0;
+    private long timeAtResume = 0;
     private Boolean isPaused = true;
-    
-    public BenchmarkTimer(){}
-    
-    public BenchmarkTimer(String name){
+
+    protected int numberOfCalls = 0;
+    protected long totalTime = 0;
+
+    public BenchmarkTimer() {}
+
+    public BenchmarkTimer(String name) {
         timerName = name;
     }
     
@@ -38,11 +39,6 @@ public class BenchmarkTimer {
         }
     }
 
-    public void add(BenchmarkTimer b) {
-        totalTime += b.totalTime;
-        numberOfCalls += b.numberOfCalls;
-    }
-
     public void reset(){
         totalTime = 0;
         timeAtResume = 0;
@@ -59,12 +55,10 @@ public class BenchmarkTimer {
     }
     
     @Override
-    public String toString(){
-        StringBuilder str = new StringBuilder();
+    public String toString() {
         double timePerCall = 0.0;
-        if(numberOfCalls!=0) timePerCall = this.getMiliseconds()/numberOfCalls;
-        str.append(String.format("TIMER (%-12s) : N Calls %12d,  Total Time  = %12.2f sec,  Unit Time = %12.3f msec",
-                this.getName(),numberOfCalls,this.getSeconds(),timePerCall));
-        return str.toString();
+        if (numberOfCalls != 0) timePerCall = getMiliseconds() / numberOfCalls;
+        return String.format("TIMER (%-12s) : N Calls %12d,  Total Time  = %12.2f sec,  Unit Time = %12.3f msec",
+            getName(), numberOfCalls, getSeconds(), timePerCall);
     }
 }

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/BenchmarkTimerTotal.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/benchmark/BenchmarkTimerTotal.java
@@ -1,0 +1,30 @@
+package org.jlab.utils.benchmark;
+
+import java.util.ArrayList;
+
+/**
+ *
+ * @author baltzell
+ */
+public class BenchmarkTimerTotal extends BenchmarkTimer {
+
+    ArrayList<BenchmarkTimer> benchmarks = new ArrayList<>();
+
+    public BenchmarkTimerTotal(String name) {
+        super(name);
+    }
+
+    @Override
+    public String toString() {
+        double timePerCall = 0.0;
+        if (numberOfCalls != 0) timePerCall = getMiliseconds() / numberOfCalls * benchmarks.size();
+        return String.format("TIMER (%-12s) : N Calls %12d,  Total Time  = %12.2f sec,  Unit Time = %12.3f msec",
+            getName(), numberOfCalls, getSeconds(), timePerCall);
+    }
+
+    public void add(BenchmarkTimer b) {
+        benchmarks.add(b);
+        totalTime += b.totalTime;
+        numberOfCalls += b.numberOfCalls;
+    }
+}


### PR DESCRIPTION
The additional, true argument for the Timer constructor enables daemon mode, otherwise it's blocking.

Also adds a benchmark totals class, just for display.