### PR TITLE
feat:  add TranslationTable, for appending CCDB translation tables with DetectorType

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -1,0 +1,34 @@
+package org.jlab.detector.decode;
+
+import org.jlab.detector.base.DetectorType;
+import org.jlab.utils.groups.IndexedTable;
+
+/**
+ *
+ * @author baltzell
+ */
+public class TranslationTable extends IndexedTable {
+
+    public TranslationTable() {
+        super(3,new String[]{"sector/I","layer/I","component/I","order/I","type/I"});
+    };
+
+    public void add(DetectorType dt, IndexedTable it) {
+        for (Object key : it.getList().getMap().keySet()) {
+            int crate = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 0);
+            int slot = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 1);
+            int channel = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 2);
+            long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(crate, slot, channel);
+            // add row to the new table:
+            addEntry(crate, slot, channel);
+            // add all entries to the new row:
+            int column;
+            for (column=0; column<it.getEntryMap().values().size(); column++) {
+                int value = it.getIntValueByHash(column, hash);
+                setIntValueByHash(value, column, hash);
+            }
+            // add the new detector type:
+            setIntValueByHash(dt.getDetectorId(), column, hash);
+        }
+    }
+}

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -1,7 +1,9 @@
 package org.jlab.detector.decode;
 
 import org.jlab.detector.base.DetectorType;
+import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.utils.groups.IndexedTable;
+
 
 /**
  *
@@ -14,21 +16,59 @@ public class TranslationTable extends IndexedTable {
     };
 
     public void add(DetectorType dt, IndexedTable it) {
+
         for (Object key : it.getList().getMap().keySet()) {
-            int crate = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 0);
-            int slot = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 1);
-            int channel = IndexedTable.DEFAULT_GENERATOR.getIndex((long) key, 2);
-            long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(crate, slot, channel);
+
+            // get the indices:
+            long hash = (long)key;
+            int crate = IndexedTable.DEFAULT_GENERATOR.getIndex(hash, 0);
+            int slot = IndexedTable.DEFAULT_GENERATOR.getIndex(hash, 1);
+            int channel = IndexedTable.DEFAULT_GENERATOR.getIndex(hash, 2);
+
+            if (hasEntryByHash(hash)) {
+                System.err.print("TranslationTable:  found CCDB overlap for ");
+                System.err.println(String.format("%d/%d/%d %s",crate,slot,channel,dt));
+            }
+
             // add row to the new table:
             addEntry(crate, slot, channel);
-            // add all entries to the new row:
-            int column;
-            for (column=0; column<it.getEntryMap().values().size(); column++) {
+
+            // add each column's entry to the new row:
+            for (int column=0; column<it.getEntryMap().values().size(); column++) {
                 int value = it.getIntValueByHash(column, hash);
                 setIntValueByHash(value, column, hash);
             }
-            // add the new detector type:
-            setIntValueByHash(dt.getDetectorId(), column, hash);
+
+            // add the new detector type, as the last column:
+            setIntValueByHash(dt.getDetectorId(), it.getEntryMap().values().size(), hash);
         }
+    }
+
+    
+    public static final DetectorType[] TYPES = new DetectorType[]{
+        DetectorType.FTCAL,DetectorType.FTHODO,DetectorType.FTTRK,
+        DetectorType.LTCC,DetectorType.ECAL,DetectorType.FTOF,
+        DetectorType.HTCC,DetectorType.DC,DetectorType.CTOF,
+        DetectorType.CND,DetectorType.BST,DetectorType.RF,
+        DetectorType.BMT,DetectorType.FMT,DetectorType.RICH,
+        DetectorType.HEL,DetectorType.BAND,DetectorType.RTPC,
+        DetectorType.RASTER,DetectorType.ATOF,DetectorType.AHDC};
+   
+    public static final String[] STYPES = new String[]{
+        "/daq/tt/ftcal","/daq/tt/fthodo","/daq/tt/fttrk",
+        "/daq/tt/ltcc","/daq/tt/ec","/daq/tt/ftof",
+        "/daq/tt/htcc","/daq/tt/dc","/daq/tt/ctof",
+        "/daq/tt/cnd","/daq/tt/svt","/daq/tt/rf",
+        "/daq/tt/bmt","/daq/tt/fmt","/daq/tt/rich2",
+        "/daq/tt/hel","/daq/tt/band","/daq/tt/rtpc",
+        "/daq/tt/raster","/daq/tt/atof","/daq/tt/ahdc"};
+
+    public static void main(String[] args) {
+        ConstantsManager conman = new ConstantsManager();
+        conman.init(STYPES);
+        TranslationTable tt = new TranslationTable();
+        for (int i=0; i<STYPES.length; i++)
+            tt.add(TYPES[i],conman.getConstants(18779,STYPES[i]));
+        tt.show();
     }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -29,18 +29,19 @@ public class TranslationTable extends IndexedTable {
                 System.err.print("TranslationTable:  found CCDB overlap for ");
                 System.err.println(String.format("%d/%d/%d %s",crate,slot,channel,dt));
             }
+            else {
+                // add row to the new table:
+                addEntry(crate, slot, channel);
 
-            // add row to the new table:
-            addEntry(crate, slot, channel);
+                // add each column's entry to the new row:
+                for (int column=0; column<it.getEntryMap().values().size(); column++) {
+                    int value = it.getIntValueByHash(column, hash);
+                    setIntValueByHash(value, column, hash);
+                }
 
-            // add each column's entry to the new row:
-            for (int column=0; column<it.getEntryMap().values().size(); column++) {
-                int value = it.getIntValueByHash(column, hash);
-                setIntValueByHash(value, column, hash);
+                // add the new detector type, as the last column:
+                setIntValueByHash(dt.getDetectorId(), it.getEntryMap().values().size(), hash);
             }
-
-            // add the new detector type, as the last column:
-            setIntValueByHash(dt.getDetectorId(), it.getEntryMap().values().size(), hash);
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -4,7 +4,6 @@ import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.utils.groups.IndexedTable;
 
-
 /**
  *
  * @author baltzell
@@ -27,7 +26,10 @@ public class TranslationTable extends IndexedTable {
 
             if (hasEntryByHash(hash)) {
                 System.err.print("TranslationTable:  found CCDB overlap for ");
-                System.err.println(String.format("%d/%d/%d %s",crate,slot,channel,dt));
+                System.err.println(String.format("type %d/%s versus %s and c/s/c=%d/%d/%d",
+                    getIntValueByHash("type",hash),
+                    DetectorType.getType(getIntValueByHash("type",hash)),
+                    dt,crate,slot,channel));
             }
             else {
                 // add row to the new table:

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -9,6 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
@@ -120,7 +121,11 @@ public class IndexedTable extends DefaultTableModel {
             }
         }
     }
-    
+
+    public void setIntValueByHash(Integer value, int column, long hash) {
+        this.entries.getItemByHash(hash).setValue(column, value);
+    }
+
     public  void setDoubleValue(Double value, String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");
@@ -164,6 +169,18 @@ public class IndexedTable extends DefaultTableModel {
             }
         }
         return 0;
+    }
+
+    public List<Number> getValuesByHash(long hash) {
+        return this.entries.getItemByHash(hash).entryValues;
+    }
+
+    public List<Integer> getIntegersByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.intValue()).collect(Collectors.toList());
+    }
+
+    public List<Double> getDoublesByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.doubleValue()).collect(Collectors.toList());
     }
 
     public int  getIntValue(String item, int... index){

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -122,10 +122,6 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
 
-    public void setIntValueByHash(Integer value, int column, long hash) {
-        this.entries.getItemByHash(hash).setValue(column, value);
-    }
-
     public  void setDoubleValue(Double value, String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");
@@ -139,50 +135,6 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
     
-    public int getIntValueByHash(int index, long hash) {
-        if (this.entries.hasItemByHash(hash))
-            return this.entries.getItemByHash(hash).getValue(index).intValue();
-        return 0;
-    }
-    
-    public double getDoubleValueByHash(int index, long hash) {
-        if (this.entries.hasItemByHash(hash))
-            return this.entries.getItemByHash(hash).getValue(index).doubleValue();
-        return 0;
-    }
-
-    public int getIntValueByHash(String item, long hash) {
-        if (this.entries.hasItemByHash(hash)) {
-            if (this.entryMap.containsKey(item)) {
-                int index = this.entryMap.get(item);
-                return this.entries.getItemByHash(hash).getValue(index).intValue();
-            }
-        }
-        return 0;
-    }
-    
-    public double getDoubleValueByHash(String item, long hash) {
-        if (this.entries.hasItemByHash(hash)) {
-            if (this.entryMap.containsKey(item)) {
-                int index = this.entryMap.get(item);
-                return this.entries.getItemByHash(hash).getValue(index).doubleValue();
-            }
-        }
-        return 0;
-    }
-
-    public List<Number> getValuesByHash(long hash) {
-        return this.entries.getItemByHash(hash).entryValues;
-    }
-
-    public List<Integer> getIntegersByHash(long hash) {
-        return getValuesByHash(hash).stream().map(x -> x.intValue()).collect(Collectors.toList());
-    }
-
-    public List<Double> getDoublesByHash(long hash) {
-        return getValuesByHash(hash).stream().map(x -> x.doubleValue()).collect(Collectors.toList());
-    }
-
     public int  getIntValue(String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");
@@ -209,6 +161,38 @@ public class IndexedTable extends DefaultTableModel {
             }
         }
         return 0;
+    }
+
+    public void setIntValueByHash(Integer value, int column, long hash) {
+        this.entries.getItemByHash(hash).setValue(column, value);
+    }
+
+    public int getIntValueByHash(int index, long hash) {
+        return entries.getItemByHash(hash).getValue(index).intValue();
+    }
+    
+    public double getDoubleValueByHash(int index, long hash) {
+        return entries.getItemByHash(hash).getValue(index).doubleValue();
+    }
+
+    public int getIntValueByHash(String item, long hash) {
+        return entries.getItemByHash(hash).getValue(entryMap.get(item)).intValue();
+    }
+    
+    public double getDoubleValueByHash(String item, long hash) {
+        return entries.getItemByHash(hash).getValue(entryMap.get(item)).doubleValue();
+    }
+
+    public List<Number> getValuesByHash(long hash) {
+        return this.entries.getItemByHash(hash).entryValues;
+    }
+
+    public List<Integer> getIntegersByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.intValue()).collect(Collectors.toList());
+    }
+
+    public List<Double> getDoublesByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.doubleValue()).collect(Collectors.toList());
     }
 
     public NamedEntry getNamedEntry(int... index) {

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -22,9 +22,10 @@ public class IndexedTable extends DefaultTableModel {
     
     public static final IndexGenerator DEFAULT_GENERATOR = new IndexGenerator();
         
+    protected Map<String,Integer>       entryMap   = new LinkedHashMap<>();
+    protected Map<String,String>        entryTypes = new LinkedHashMap<>();
+    
     private IndexedList<IndexedEntry> entries    = null;
-    private Map<String,Integer>       entryMap   = new LinkedHashMap<>();
-    private Map<String,String>        entryTypes = new LinkedHashMap<>();
     private List<String>              entryNames = new ArrayList<>();
     private List<String>              indexNames = new ArrayList<>();
     private String                    precisionFormat = "%.6f";

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -201,7 +201,11 @@ public class IndexedTable extends DefaultTableModel {
     public IndexedList getList(){
         return this.entries;
     }
-    
+
+    public Map<String,Integer> getEntryMap(){
+        return this.entryMap;
+    }
+
     private void parseFormat(String format){
         String[] tokens = format.split(":");
         entryMap.clear();


### PR DESCRIPTION
Plus some IndexedTable hash-based accessor additions and cleanup, and more no-error-checking in hash-based accessors.

Needed for decoder speedups a'la #1008 