### PR TITLE
fix: doubled log messages when `SplitLogManager.configureHandlers` is called twice

### DIFF
--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/SplitLogManager.java
@@ -45,13 +45,15 @@ public class SplitLogManager extends LogManager {
 
     // clear handlers
     logger.setUseParentHandlers(false);
+    for(var handler : logger.getHandlers())
+      logger.removeHandler(handler);
 
     // log message formatting
     if(includePrefix)
       // "[source] level: message throwable_backtrace\n"
       System.setProperty(
           "java.util.logging.SimpleFormatter.format",
-          "[" + logger.getName().replaceAll(".*\\.","") + "] %4$s: %5$s%6$s%n");
+          "%4$s: [" + logger.getName().replaceAll(".*\\.","") + "] %5$s%6$s%n");
     else
       // "level: message throwable_backtrace\n"
       System.setProperty(


### PR DESCRIPTION
Some classes call `SplitLogManager.configureHandlers` to make the prefix quieter, _e.g._, `DatabaseConstantProvider`; this was causing log messages to double. This PR fixes the issue, and adjusts the formatting a bit to be more consistent with the database classes' log messages.