### PR TITLE
feat: log level option `-l` is now case-insenstive

### DIFF
--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionParser.java
@@ -192,7 +192,7 @@ public class OptionParser {
 
     private void setVerbosity(String level) {
         try {
-            this.logLevel = Level.parse(level);
+            this.logLevel = Level.parse(level.toUpperCase());
             SplitLogManagerConfig.INSTANCE.setDefaultLevel(this.logLevel);
         }
         catch (IllegalArgumentException e) {
@@ -231,7 +231,7 @@ public class OptionParser {
      */
     public static void overrideLogLevel(String level, String... classList) {
         for(var className : classList)
-            System.setProperty(className + ".level", level);
+            System.setProperty(className + ".level", level.toUpperCase());
     }
 
     /**


### PR DESCRIPTION
All of these will now set the log level to `FINE`, no more need to type in all-caps:
```
-l FINE
-l fine
-l FiNe
```