### PR TITLE
Decoding speedups

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/base/DetectorDescriptor.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/base/DetectorDescriptor.java
@@ -88,6 +88,14 @@ public class DetectorDescriptor implements Comparable<DetectorDescriptor> {
         this.dt_COMPONENT = comp;
     }
 
+    public final void setSectorLayerComponentOrderType(int sector, int layer, int comp, int order, int type) {
+        this.dt_SECTOR = sector;
+        this.dt_LAYER  = layer;
+        this.dt_COMPONENT = comp;
+        this.dt_ORDER = order;
+        this.detectorType = DetectorType.getType(type);
+    }
+
     public static int generateHashCode(int s, int l, int c){
         return  ((s<<24)&0xFF000000)|
                 ((l<<16)&0x00FF0000)|(c&0x0000FFFF);
@@ -99,7 +107,6 @@ public class DetectorDescriptor implements Comparable<DetectorDescriptor> {
                 (this.dt_COMPONENT&0x00000FFF);
         return hash;
     }
-   
     
     public void copy(DetectorDescriptor desc){
         this.hw_SLOT    = desc.hw_SLOT;
@@ -118,7 +125,6 @@ public class DetectorDescriptor implements Comparable<DetectorDescriptor> {
                 this.dt_COMPONENT.equals(desc.dt_COMPONENT)) return true;
         return false;
     }
-    
     
     public static String getName(String base, int... ids){
         StringBuilder str = new StringBuilder();

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
@@ -719,6 +719,8 @@ public class CLASDecoder {
             if(evioEvent.getHandler().getStructure()!=null){
                 try {
 
+                    codaDecoder.cacheBranches(evioEvent);
+
                     dataList = codaDecoder.getDataEntries( (EvioDataEvent) event);
                     
                     List<FADCData> fadcPacked = codaDecoder.getADCEntries((EvioDataEvent) event);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -39,15 +39,29 @@ public class CodaEventDecoder {
     private byte helicityLevel3 = HelicityBit.UDF.value();
     private final List<Integer> triggerWords = new ArrayList<>();
     JsonObject  epicsData = new JsonObject();
+    List<EvioTreeBranch> branchList = null;
 
     private int tiMaster = -1; 
 
     // FIXME:  move this to CCDB, e.g., meanwhile cannot reuse ROC id 
     private static final List<Integer> PCIE_ROCS = Arrays.asList(new Integer[]{78});
 
-    public CodaEventDecoder(){
+    public CodaEventDecoder(){}
 
+    /**
+     * Load map by crate(?). 
+     *
+     * @param event 
+     */
+    void cacheBranches(EvioDataEvent event) {
+        branchList = getEventBranches(event);
+        //branchMap = new TreeMap<>();
+        //for (EvioTreeBranch branch : branchList) {
+        //    if (!branchMap.containsKey(branch.getTag()))
+        //        branchMap.put(branch.getTag(), branch);
+        //}
     }
+
     /**
      * returns detector digitized data entries from the event.
      * all branches are analyzed and different types of digitized data
@@ -69,9 +83,8 @@ public class CodaEventDecoder {
         // from the previous event, in the case where there's no HEAD bank:
         this.setTriggerBits(0);
         List<DetectorDataDgtz>  rawEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
         this.setTimeStamp(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             List<DetectorDataDgtz>  list = this.getDataEntries(event,branch.getTag());
             if(list != null){
                 rawEntries.addAll(list);
@@ -186,8 +199,7 @@ public class CodaEventDecoder {
 
     public List<FADCData> getADCEntries(EvioDataEvent event){
         List<FADCData>  entries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             List<FADCData>  list = this.getADCEntries(event,branch.getTag());
             if(list != null){
                 entries.addAll(list);
@@ -198,29 +210,20 @@ public class CodaEventDecoder {
 
     public List<FADCData> getADCEntries(EvioDataEvent event, int crate){
         List<FADCData>  entries = new ArrayList<>();
-
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
-
+        EvioTreeBranch cbranch = this.getEventBranch(branchList, crate);
         if(cbranch == null ) return null;
-
         for(EvioNode node : cbranch.getNodes()){
             if(node.getTag()==57638){
                 return this.getDataEntries_57638(crate, node, event);
             }
         }
-
         return entries;
     }
 
     public List<FADCData> getADCEntries(EvioDataEvent event, int crate, int tagid){
-
         List<FADCData>  adc = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
+        EvioTreeBranch cbranch = this.getEventBranch(branchList, crate);
         if(cbranch == null ) return null;
-
         for(EvioNode node : cbranch.getNodes()){
            if(node.getTag()==tagid){
                 //  This is regular integrated pulse mode, used for FTOF
@@ -238,13 +241,9 @@ public class CodaEventDecoder {
      * @return
      */
     public List<DetectorDataDgtz> getDataEntries(EvioDataEvent event, int crate){
-
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
         List<DetectorDataDgtz>   bankEntries = new ArrayList<>();
-
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
+        EvioTreeBranch cbranch = this.getEventBranch(branchList, crate);
         if(cbranch == null ) return null;
-
         for (EvioNode node : cbranch.getNodes()) {
             if (node.getTag() == 57615) {
                 //  This is regular integrated pulse mode, used for FTOF
@@ -1233,8 +1232,7 @@ public class CodaEventDecoder {
 
     public void getDataEntries_EPICS(EvioDataEvent event){
         epicsData = new JsonObject();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57620) {
                     byte[] stringData =  ByteDataTransformer.toByteArray(node.getStructureBuffer(true));
@@ -1260,8 +1258,7 @@ public class CodaEventDecoder {
 
     public HelicityDecoderData getDataEntries_HelicityDecoder(EvioDataEvent event){
         HelicityDecoderData data = null;
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57651) {
                     
@@ -1341,8 +1338,7 @@ public class CodaEventDecoder {
     public List<DetectorDataDgtz> getDataEntries_Scalers(EvioDataEvent event){
 
         List<DetectorDataDgtz> scalerEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             int  crate = branch.getTag();
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57637 || node.getTag()==57621){
@@ -1421,8 +1417,7 @@ public class CodaEventDecoder {
     public List<DetectorDataDgtz> getDataEntries_VTP(EvioDataEvent event){
 
         List<DetectorDataDgtz> vtpEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             int  crate = branch.getTag();
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57634){
@@ -1447,11 +1442,10 @@ public class CodaEventDecoder {
     public List<DetectorDataDgtz>  getDataEntries_TDC(EvioDataEvent event){
 
         List<DetectorDataDgtz> tdcEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
 
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             int  crate = branch.getTag();
-            EvioTreeBranch cbranch = this.getEventBranch(branches, branch.getTag());
+            EvioTreeBranch cbranch = this.getEventBranch(branchList, branch.getTag());
             for(EvioNode node : cbranch.getNodes()){
                 if(node.getTag()==57607){
                     int[] intData = ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
@@ -1479,10 +1473,9 @@ public class CodaEventDecoder {
     public List<DetectorDataDgtz>  getDataEntries_TI(EvioDataEvent event){
 
         List<DetectorDataDgtz> tiEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchList){
             int  crate = branch.getTag();
-            EvioTreeBranch cbranch = this.getEventBranch(branches, branch.getTag());
+            EvioTreeBranch cbranch = this.getEventBranch(branchList, branch.getTag());
             for(EvioNode node : cbranch.getNodes()){
                 if(node.getTag()==57610){
                     long[] longData = ByteDataTransformer.toLongArray(node.getStructureBuffer(true));

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -35,6 +35,8 @@ public class DetectorEventDecoder {
     private ExtendedFADCFitter extendedFitter = new ExtendedFADCFitter();
     private MVTFitter mvtFitter = new MVTFitter();
 
+    private TranslationTable translator = new TranslationTable();
+
     public DetectorEventDecoder(boolean development){
         if(development==true){
             this.initDecoderDev();
@@ -56,6 +58,11 @@ public class DetectorEventDecoder {
     }
 
     public void setRunNumber(int run){
+        if (run != this.runNumber) {
+            translator = new TranslationTable();
+            for (int i=0; i<keysTrans.size(); i++)
+                translator.add(keysTrans.get(i), translationManager.getConstants(run, tablesTrans.get(i)));
+        }
         this.runNumber = run;
     }
 
@@ -143,44 +150,21 @@ public class DetectorEventDecoder {
      */
     public void translate(List<DetectorDataDgtz>  detectorData){
 
-        // Preload CCDB tables:
-        ArrayList<IndexedTable> tables = new ArrayList<>();
-        for (String name : tablesTrans) {
-            tables.add(translationManager.getConstants(runNumber, name));
-        }
+        for (DetectorDataDgtz d : detectorData) {
 
-        for (DetectorDataDgtz data : detectorData) {
+            // Get the hardware indexing for this detector data object:
+            long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(d.getDescriptor().getCrate(),
+                d.getDescriptor().getSlot(), d.getDescriptor().getChannel());
 
-            // Get the hardware indexing for this detector hit:
-            int crate    = data.getDescriptor().getCrate();
-            int slot     = data.getDescriptor().getSlot();
-            int channel  = data.getDescriptor().getChannel();
-            long hash    = IndexedTable.DEFAULT_GENERATOR.hashCode(crate,slot,channel);
-            
-            // Try to find it in the translation tables:
-            for (int j=0; j<tablesTrans.size(); ++j) {
+            if (translator.hasEntryByHash(hash)) {
 
-                IndexedTable t = tables.get(j);
+                // The tanslated detector indexing:
+                List<Integer> x = translator.getIntegersByHash(hash);
 
-                // Found it; now set the detector indexing for this hit:
-                if (t.hasEntryByHash(hash)) {
-
-                    int sector    = t.getIntValueByHash(0, hash);
-                    int layer     = t.getIntValueByHash(1, hash);
-                    int component = t.getIntValueByHash(2, hash);
-                    int order     = t.getIntValueByHash(3, hash);
-
-                    data.getDescriptor().setSectorLayerComponent(sector, layer, component);
-                    data.getDescriptor().setOrder(order);
-                    data.getDescriptor().setType(keysTrans.get(j));
-
-                    for(int i = 0; i < data.getADCSize(); i++) data.getADCData(i).setOrder(order);
-                    for(int i = 0; i < data.getTDCSize(); i++) data.getTDCData(i).setOrder(order);
-
-                    // Assume there's only one instance of this crate/slot/channel
-                    // in all translation tables, and we found it, so stop:
-                    break;
-                }
+                // Set the translated detector indexing:
+                d.getDescriptor().setSectorLayerComponentOrderType(x.get(0),x.get(1),x.get(2),x.get(3),x.get(4));
+                for (int i=0; i<d.getADCSize(); i++) d.getADCData(i).setOrder(x.get(3));
+                for (int i=0; i<d.getTDCSize(); i++) d.getTDCData(i).setOrder(x.get(3));
             }
         }
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -28,6 +28,7 @@ public class DetectorEventDecoder {
     List<DetectorType> keysTrans    = null;
     List<DetectorType> keysFitter   = null;
     List<DetectorType> keysFilter   = null;
+    List<DetectorType> keysMicromega= null;
 
     private int runNumber = 10;
 
@@ -121,7 +122,9 @@ public class DetectorEventDecoder {
 
         scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp",
                                                       "/runcontrol/helicity","/daq/config/scalers/dsc1"}));
-        
+       
+        keysMicromega = Arrays.asList(new DetectorType[]{DetectorType.BMT,DetectorType.FMT,DetectorType.FTTRK});
+
         checkTables();
     }
 
@@ -200,10 +203,7 @@ public class DetectorEventDecoder {
                 IndexedTable daq = tables.get(j);
                 DetectorType type = keysFitter.get(j);
                 //custom MM fitter
-            	if( ( (type == DetectorType.BMT)&&(data.getDescriptor().getType().getName().equals("BMT")) )
-                 || ( (type == DetectorType.FMT)&&(data.getDescriptor().getType().getName().equals("FMT")) )
-                 //|| ( (type == DetectorType.AHDC)&&(data.getDescriptor().getType().getName().equals("AHDC")) )
-                 || ( (type == DetectorType.FTTRK)&&(data.getDescriptor().getType().getName().equals("FTTRK")) ) ){
+                if (data.getDescriptor().getType() == type && keysMicromega.contains(keysFitter.get(j))) {
                     short adcOffset = (short) daq.getDoubleValueByHash("adc_offset", hash0);
                     double fineTimeStampResolution = (byte) daq.getDoubleValueByHash("dream_clock", hash0);
                     double samplingTime = (byte) daq.getDoubleValueByHash("sampling_time", hash0);
@@ -222,7 +222,7 @@ public class DetectorEventDecoder {
                         int nsb = daq.getIntValueByHash("nsb", hash);
                         int tet = daq.getIntValueByHash("tet", hash);
                         int ped = 0;
-                        if(type == DetectorType.RF&&data.getDescriptor().getType().getName().equals("RF")) {
+                        if(data.getDescriptor().getType() == DetectorType.RF && type == DetectorType.RF) {
                             ped = daq.getIntValueByHash("pedestal", hash);
                         }
                         if(data.getADCSize()>0){

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -4,6 +4,7 @@ import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.utils.groups.IndexedTable;
 
+
 /**
  *
  * @author baltzell

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -1,8 +1,8 @@
 package org.jlab.detector.decode;
 
+import org.jlab.utils.groups.IndexedTable;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
-import org.jlab.utils.groups.IndexedTable;
 
 /**
  *
@@ -24,6 +24,7 @@ public class TranslationTable extends IndexedTable {
             int slot = IndexedTable.DEFAULT_GENERATOR.getIndex(hash, 1);
             int channel = IndexedTable.DEFAULT_GENERATOR.getIndex(hash, 2);
 
+            // first one wins, print error message for loser:
             if (hasEntryByHash(hash)) {
                 System.err.print("TranslationTable:  found CCDB overlap for ");
                 System.err.println(String.format("type %d/%s versus %s and c/s/c=%d/%d/%d",
@@ -36,17 +37,14 @@ public class TranslationTable extends IndexedTable {
                 addEntry(crate, slot, channel);
 
                 // add each column's entry to the new row:
-                for (int column=0; column<it.getEntryMap().values().size(); column++) {
-                    int value = it.getIntValueByHash(column, hash);
-                    setIntValueByHash(value, column, hash);
-                }
+                for (int column=0; column<it.getEntryMap().values().size(); column++)
+                    setIntValueByHash(it.getIntValueByHash(column, hash), column, hash);
 
                 // add the new detector type, as the last column:
                 setIntValueByHash(dt.getDetectorId(), it.getEntryMap().values().size(), hash);
             }
         }
     }
-
     
     public static final DetectorType[] TYPES = new DetectorType[]{
         DetectorType.FTCAL,DetectorType.FTHODO,DetectorType.FTTRK,
@@ -70,7 +68,7 @@ public class TranslationTable extends IndexedTable {
         ConstantsManager conman = new ConstantsManager();
         conman.init(STYPES);
         TranslationTable tt = new TranslationTable();
-        for (int i=0; i<STYPES.length; i++)
+        for (int i=0; i<TYPES.length; i++)
             tt.add(TYPES[i],conman.getConstants(18779,STYPES[i]));
         tt.show();
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -4,7 +4,6 @@ import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.utils.groups.IndexedTable;
 
-
 /**
  *
  * @author baltzell

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/TranslationTable.java
@@ -1,5 +1,6 @@
 package org.jlab.detector.decode;
 
+import java.util.stream.Collectors;
 import org.jlab.utils.groups.IndexedTable;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
@@ -45,6 +46,16 @@ public class TranslationTable extends IndexedTable {
             }
         }
     }
+
+    public void dump() {
+        for (Object key : getList().getMap().keySet()) {
+            int[] idx = IndexedTable.DEFAULT_GENERATOR.getIndices((long)key, 0,1,2);
+            System.out.print(String.format("%d/%d/%d ", idx[0],idx[1],idx[2]));
+            System.out.print(getIntegersByHash((long)key).stream().
+                map(String::valueOf).collect(Collectors.joining("/")));
+            System.out.print("\n");
+        }
+    }
     
     public static final DetectorType[] TYPES = new DetectorType[]{
         DetectorType.FTCAL,DetectorType.FTHODO,DetectorType.FTTRK,
@@ -71,5 +82,6 @@ public class TranslationTable extends IndexedTable {
         for (int i=0; i<TYPES.length; i++)
             tt.add(TYPES[i],conman.getConstants(18779,STYPES[i]));
         tt.show();
+        tt.dump();
     }
 }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/pulse/HipoExtractor.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/pulse/HipoExtractor.java
@@ -92,35 +92,35 @@ public abstract class HipoExtractor implements IExtractor {
     }
 
     protected static void copyIndices(Bank src, Bank dest, int isrc, int idest) {
-        dest.putByte("sector", idest, src.getByte("sector",isrc));
-        dest.putByte("layer", idest, src.getByte("layer",isrc));
-        dest.putShort("component", idest, src.getShort("component",isrc));
-        dest.putByte("order", idest, src.getByte("order",isrc));
+        dest.putByte(0, idest, src.getByte(0,isrc));
+        dest.putByte(1, idest, src.getByte(1,isrc));
+        dest.putShort(2, idest, src.getShort(2,isrc));
+        dest.putByte(3, idest, src.getByte(3,isrc));
         dest.putShort("windex", idest, (short)isrc);
     }
 
     protected static void copyIndices(DataBank src, DataBank dest, int isrc, int idest) {
-        dest.setByte("sector", idest, src.getByte("sector",isrc));
-        dest.setByte("layer", idest, src.getByte("layer",isrc));
-        dest.setShort("component", idest, src.getShort("component",isrc));
-        dest.setByte("order", idest, src.getByte("order",isrc));
+        dest.setByte(0, idest, src.getByte(0,isrc));
+        dest.setByte(1, idest, src.getByte(1,isrc));
+        dest.setShort(2, idest, src.getShort(2,isrc));
+        dest.setByte(3, idest, src.getByte(3,isrc));
         dest.setShort("windex", idest, (short)isrc);
     }
 
     protected static int[] getIndices(Bank bank, int row) {
         return new int[] {
-            bank.getShort("sector", row),
-            bank.getShort("layer", row),
-            bank.getShort("component", row),
-            bank.getShort("order", row)};
+            bank.getShort(0, row),
+            bank.getShort(1, row),
+            bank.getShort(2, row),
+            bank.getShort(3, row)};
     }
 
     protected static int[] getIndices(DataBank bank, int row) {
         return new int[] {
-            bank.getShort("sector", row),
-            bank.getShort("layer", row),
-            bank.getShort("component", row),
-            bank.getShort("order", row)};
+            bank.getShort(0, row),
+            bank.getShort(1, row),
+            bank.getShort(2, row),
+            bank.getShort(3, row)};
     }
 
     protected List<Pulse> getPulses(int n, IndexedTable it, DataBank wfBank) {

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedList.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedList.java
@@ -327,10 +327,22 @@ public class IndexedList<T> {
         }
 
         /**
+         * Retrieves an array of the requested indices.
+         * 
+         * @param indices
+         * @return 
+         */
+        public int[] getIndices(long hashcode, int... indices) {
+            int[] ret = new int[indices.length];
+            for (int i=0; i<ret.length; i++)
+                ret[i] = getIndex(hashcode, i);
+            return ret;
+        }
+
+        /**
          * Returns a formatted string representing all indices in the hash key.
          *
          * @param hashcode the encoded long key
-         * @param length the number of indices to extract
          * @return a string representation of the indices
          */
         public String getString(long hashcode) {

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -122,10 +122,6 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
 
-    public void setIntValueByHash(Integer value, int column, long hash) {
-        this.entries.getItemByHash(hash).setValue(column, value);
-    }
-
     public  void setDoubleValue(Double value, String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");
@@ -139,50 +135,6 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
     
-    public int getIntValueByHash(int index, long hash) {
-        if (this.entries.hasItemByHash(hash))
-            return this.entries.getItemByHash(hash).getValue(index).intValue();
-        return 0;
-    }
-    
-    public double getDoubleValueByHash(int index, long hash) {
-        if (this.entries.hasItemByHash(hash))
-            return this.entries.getItemByHash(hash).getValue(index).doubleValue();
-        return 0;
-    }
-
-    public int getIntValueByHash(String item, long hash) {
-        if (this.entries.hasItemByHash(hash)) {
-            if (this.entryMap.containsKey(item)) {
-                int index = this.entryMap.get(item);
-                return this.entries.getItemByHash(hash).getValue(index).intValue();
-            }
-        }
-        return 0;
-    }
-    
-    public double getDoubleValueByHash(String item, long hash) {
-        if (this.entries.hasItemByHash(hash)) {
-            if (this.entryMap.containsKey(item)) {
-                int index = this.entryMap.get(item);
-                return this.entries.getItemByHash(hash).getValue(index).doubleValue();
-            }
-        }
-        return 0;
-    }
-
-    public List<Number> getValuesByHash(long hash) {
-        return this.entries.getItemByHash(hash).entryValues;
-    }
-
-    public List<Integer> getIntegersByHash(long hash) {
-        return getValuesByHash(hash).stream().map(x -> x.intValue()).collect(Collectors.toList());
-    }
-
-    public List<Double> getDoublesByHash(long hash) {
-        return getValuesByHash(hash).stream().map(x -> x.doubleValue()).collect(Collectors.toList());
-    }
-
     public int  getIntValue(String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");

--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/groups/IndexedTable.java
@@ -122,6 +122,10 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
 
+    public void setIntValueByHash(Integer value, int column, long hash) {
+        this.entries.getItemByHash(hash).setValue(column, value);
+    }
+
     public  void setDoubleValue(Double value, String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");
@@ -135,6 +139,50 @@ public class IndexedTable extends DefaultTableModel {
         }
     }
     
+    public int getIntValueByHash(int index, long hash) {
+        if (this.entries.hasItemByHash(hash))
+            return this.entries.getItemByHash(hash).getValue(index).intValue();
+        return 0;
+    }
+    
+    public double getDoubleValueByHash(int index, long hash) {
+        if (this.entries.hasItemByHash(hash))
+            return this.entries.getItemByHash(hash).getValue(index).doubleValue();
+        return 0;
+    }
+
+    public int getIntValueByHash(String item, long hash) {
+        if (this.entries.hasItemByHash(hash)) {
+            if (this.entryMap.containsKey(item)) {
+                int index = this.entryMap.get(item);
+                return this.entries.getItemByHash(hash).getValue(index).intValue();
+            }
+        }
+        return 0;
+    }
+    
+    public double getDoubleValueByHash(String item, long hash) {
+        if (this.entries.hasItemByHash(hash)) {
+            if (this.entryMap.containsKey(item)) {
+                int index = this.entryMap.get(item);
+                return this.entries.getItemByHash(hash).getValue(index).doubleValue();
+            }
+        }
+        return 0;
+    }
+
+    public List<Number> getValuesByHash(long hash) {
+        return this.entries.getItemByHash(hash).entryValues;
+    }
+
+    public List<Integer> getIntegersByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.intValue()).collect(Collectors.toList());
+    }
+
+    public List<Double> getDoublesByHash(long hash) {
+        return getValuesByHash(hash).stream().map(x -> x.doubleValue()).collect(Collectors.toList());
+    }
+
     public int  getIntValue(String item, int... index){
         if(this.entries.hasItem(index)==false){
             if(DEBUG_MODE>0) System.out.println( "[IndexedTable] ---> error.. entry does not exist");


### PR DESCRIPTION
* Less string comparisons;  more hash/index-based access for CCDB tables and banks
* Add global TranslationTable class with addition DetectorType field, and use it in decoding
* Cache EVIO branch list once per event

This is the completion of #1008, after breaking it into multiple pull requests.