### PR TITLE
feat(ALERTEngine): initialize ATOF detector and check that there are …

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/service/alert/ALERTEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/service/alert/ALERTEngine.java
@@ -46,6 +46,8 @@ public class ALERTEngine extends ReconstructionEngine {
      */
     private RecoBankWriter rbc;
 
+    Detector ATOF; // ALERT ATOF detector
+
     /**
      *  Current run number being processed.
      *  TODO: why atomic here and nowhere else? 
@@ -81,6 +83,10 @@ public class ALERTEngine extends ReconstructionEngine {
         rbc = new RecoBankWriter();
 
         modelTrackMatching = new ModelTrackMatching();
+
+        AlertTOFFactory factory = new AlertTOFFactory();
+        DatabaseConstantProvider cp = new DatabaseConstantProvider(11, "default");
+        ATOF = factory.createDetectorCLAS(cp);
 
         if(this.getEngineConfigString("Mode")!=null) {
             //if (Objects.equals(this.getEngineConfigString("Mode"), Mode.AI_Track_Finding.name()))
@@ -160,11 +166,9 @@ public class ALERTEngine extends ReconstructionEngine {
                     interClusters.add(new Pair<>(x, y));
                 }
             }
+            if (interClusters.size() != 5) continue;
 
             try {
-                AlertTOFFactory factory = new AlertTOFFactory();
-                DatabaseConstantProvider cp = new DatabaseConstantProvider(11, "default");
-                Detector ATOF = factory.createDetectorCLAS(cp);
 
                 float[] pred = modelTrackMatching.prediction(interClusters);
                 int sector_pred = (int) pred[0];


### PR DESCRIPTION
…5 interclusters for the prediction

Found a lot of text is spit out by the ALERT Engine: 
INFO: [DB] ---> open 11 | default | Thu Jan 08 08:56:42 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas12
Exception in ALERTEngine processDataEvent: java.lang.NullPointerException
INFO: [DB] ---> open 11 | default | Thu Jan 08 08:56:44 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas12
Exception in ALERTEngine processDataEvent: java.lang.IndexOutOfBoundsException: Index 4 out of bounds for length 4
INFO: [DB] ---> open 11 | default | Thu Jan 08 08:56:45 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas12
Exception in ALERTEngine processDataEvent: java.lang.NullPointerException
INFO: [DB] ---> open 11 | default | Thu Jan 08 08:56:45 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas12
Exception in ALERTEngine processDataEvent: java.lang.NullPointerException
>>>>> progress :  (         508) :  time :   129.19 (sec) =>>> average time =   254.303 msec
INFO: [DB] ---> open 11 | default | Thu Jan 08 08:56:49 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas1

Fix that by building the ATOF detector in the init method and by checking that there are 5 interclusters in the tracks (It means 4 clusters).