### PR TITLE
apply AI model for HB tracking

### DIFF
--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
@@ -31,7 +31,7 @@ public class KFitter extends AKFitter {
     
     private static final double initialCMBlowupFactor = 70;
     
-    public StateVecs sv = new StateVecs();
+    private StateVecs sv = new StateVecs();
     private MeasVecs mv = new MeasVecs();
     private StateVec finalSmoothedStateVec = null;
     private StateVec finalTransportedStateVec = null;
@@ -45,7 +45,7 @@ public class KFitter extends AKFitter {
     private double chi2kf = 0;
     private double KFScale = 4;
 
-    public int svzLength;
+    private int svzLength;
 
     public int ConvStatus = 1;
 
@@ -60,7 +60,7 @@ public class KFitter extends AKFitter {
     Matrix result = new Matrix();
     Matrix result_inv = new Matrix();
     Matrix adj = new Matrix();
-
+    
     public KFitter(boolean filter, int iterations, int dir, Swim swim, double Z[], Libr mo) {
         super(filter, iterations, dir, swim, mo);
         this.Z = Z;
@@ -1156,6 +1156,14 @@ public class KFitter extends AKFitter {
     
     public double getNDFDAF(){
         return ndfDAF;
+    }
+        
+    public void setSvzLength(int svzlength){
+        this.svzLength = svzlength;
+    }
+    
+    public int getSvzLength(){
+        return svzLength;
     }
 
     public void printlnMeasVecs() {

--- a/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
+++ b/common-tools/clas-tracking/src/main/java/org/jlab/clas/tracking/kalmanfilter/zReference/KFitter.java
@@ -31,7 +31,7 @@ public class KFitter extends AKFitter {
     
     private static final double initialCMBlowupFactor = 70;
     
-    private StateVecs sv = new StateVecs();
+    public StateVecs sv = new StateVecs();
     private MeasVecs mv = new MeasVecs();
     private StateVec finalSmoothedStateVec = null;
     private StateVec finalTransportedStateVec = null;
@@ -45,7 +45,7 @@ public class KFitter extends AKFitter {
     private double chi2kf = 0;
     private double KFScale = 4;
 
-    private int svzLength;
+    public int svzLength;
 
     public int ConvStatus = 1;
 
@@ -861,7 +861,7 @@ public class KFitter extends AKFitter {
         
     // Since no vertex inforamtion, the starting point for path length is the final point at the last layer.
     // After vertex information is obtained, transition for the starting point from the final point to vertex will be taken.
-    private void calcFinalChisq(int sector, boolean nofilter) {
+    public void calcFinalChisq(int sector, boolean nofilter) {
         int k = svzLength - 1;
         this.chi2 = 0;
         double path = 0;

--- a/reconstruction/ai/src/main/java/org/jlab/rec/ai/dcHBTrackState/HBTrackStateEstimator.java
+++ b/reconstruction/ai/src/main/java/org/jlab/rec/ai/dcHBTrackState/HBTrackStateEstimator.java
@@ -1,0 +1,150 @@
+package org.jlab.rec.ai.dcHBTrackState;
+
+import ai.djl.MalformedModelException;
+import ai.djl.ModelException;
+import ai.djl.inference.Predictor;
+import ai.djl.ndarray.*;
+import ai.djl.ndarray.types.Shape;
+import ai.djl.repository.zoo.*;
+import ai.djl.training.util.ProgressBar;
+import ai.djl.translate.*;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.concurrent.*;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.jlab.clas.reco.ReconstructionEngine;
+import org.jlab.io.base.*;
+import org.jlab.utils.system.ClasUtilsFile;
+import org.jlab.service.ai.PredictorPool;
+
+
+public class HBTrackStateEstimator{
+    // ---------------- Configuration ----------------
+    private String modelFile;
+
+    ZooModel<float[][], float[]> model;
+    PredictorPool predictors;
+
+    // ---------------- Statistics for normalization of inputs and outputs of training samples ----------------
+    //// Note: Statistics of hits and track states depends on training samples, so need to be renewed when training samples change!!!
+    // Statistics of hits: doca, xm, xr, yr, z
+    private float[] HIT_MEAN;
+    private float[] HIT_STD;
+
+    // Statistics of track state: x, y, tx, ty, Q at z = 229 cm in the tilted sector frame
+    private float[] STATE_MEAN;
+    private float[] STATE_STD;
+    
+    public HBTrackStateEstimator(String modelFile){
+        this.modelFile = modelFile;
+        
+        if(modelFile.contains("inbending")){
+            HIT_MEAN = new float[]{0.52949071f, -45.771999f,  -45.744694f,  57.336819f, 373.046356f};
+            HIT_STD = new float[]{0.40272677f, 47.928203f, 48.379021f, 32.645191f, 111.54994f};
+            STATE_MEAN = new float[]{-33.564308f, 0.010787425f, -0.15567796f, 0.0017755219f, 0.317530721f};
+            STATE_STD = new float[]{28.667490f, 17.761129f, 0.11940812f, 0.074460238f, 0.74185127f};        
+        }
+        else if(modelFile.contains("outbending")){
+            HIT_MEAN = new float[]{0.53385729f, -59.236504f,  -59.200584f,  50.136387f, 372.057922f};
+            HIT_STD = new float[]{0.40085429f, 51.385536f, 51.840462f, 31.498201f, 111.50029f};
+            STATE_MEAN = new float[]{-39.446106f, 0.17583229f, -0.18047817f, 0.0014163271f, -0.082320645f};
+            STATE_STD = new float[]{33.733425f, 17.226780f, 0.14071095f, 0.072449364f, 0.72273886f};  
+        }
+        else{
+           Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Name of model file does not include inbending or outbending"); 
+        }
+        
+        System.setProperty("ai.djl.pytorch.num_interop_threads", "1");
+        System.setProperty("ai.djl.pytorch.num_threads", "1");
+        System.setProperty("ai.djl.pytorch.graph_optimizer", "false");                
+        try {
+            String modelPath = ClasUtilsFile.getResourceDir("CLAS12DIR", "etc/data/nnet/hbTSE/" + modelFile);
+
+            Criteria<float[][], float[]> criteria = Criteria.builder()
+                .setTypes(float[][].class, float[].class)
+                .optModelPath(Paths.get(modelPath))
+                .optEngine("PyTorch")
+                .optTranslator(getTranslator())
+                .optProgress(new ProgressBar())
+                .build();
+
+            model = criteria.loadModel();
+
+            int threads = 64;
+            predictors = new PredictorPool(threads, model);
+
+
+        } catch (IOException | ModelException e) {
+            Logger.getLogger(getClass().getName()).log(Level.SEVERE, null, e);
+        }                
+    }    
+    
+    // ---------------- Translator ----------------
+    private Translator<float[][], float[]> getTranslator() {
+        return new Translator<float[][], float[]>() {
+
+            @Override
+            public NDList processInput(TranslatorContext ctx, float[][] hits) {
+                NDManager manager = ctx.getNDManager();
+                int n = hits.length;
+
+                float[][] norm = new float[n][5];
+                for (int i = 0; i < n; i++)
+                    for (int j = 0; j < 5; j++)
+                        norm[i][j] = (hits[i][j] - HIT_MEAN[j]) / HIT_STD[j];
+
+                NDArray x = manager.create(norm);    
+                x = x.reshape(1, n, 5); 
+                return new NDList(x);
+            }
+
+            @Override
+            public float[] processOutput(TranslatorContext ctx, NDList list) {
+                NDArray out = list.get(0); // [1,5]
+                float[] y = out.toFloatArray();
+
+                for (int i = 0; i < 5; i++)
+                    y[i] = y[i] * STATE_STD[i] + STATE_MEAN[i];
+
+                return y;
+            }
+
+            @Override
+            public Batchifier getBatchifier() {
+                return null;
+            }
+        };
+    }
+    
+    
+    public float[] predict(float[][] hits) {
+        if (hits == null) return null;
+                
+        if (hits.length == 0) {
+            throw new IllegalArgumentException("HBInitialStateEstimator: empty hits");
+        }
+        
+        for (int i = 0; i < hits.length; i++) {
+            if (hits[i].length != 5) {
+                throw new IllegalArgumentException(
+                    "Expect 5 features per hit, got " + hits[i].length
+                );
+            }
+        }        
+
+        try {
+            Predictor<float[][], float[]> predictor = predictors.take();
+            try {
+                return predictor.predict(hits);
+            } finally {
+                predictors.put(predictor);
+            }
+        } catch (TranslateException | InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}
+

--- a/reconstruction/dc/pom.xml
+++ b/reconstruction/dc/pom.xml
@@ -42,6 +42,11 @@
       <version>13.5.2-SNAPSHOT</version>
     </dependency>
     <dependency>
+      <groupId>org.jlab.clas12.detector</groupId>
+      <artifactId>clas12detector-ai</artifactId>
+      <version>13.5.2-SNAPSHOT</version>
+    </dependency>    
+    <dependency>
       <groupId>org.jlab.clas</groupId>
       <artifactId>clas-jcsg</artifactId>
       <version>13.5.2-SNAPSHOT</version>

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -266,9 +266,9 @@ public class TrackCandListFinder {
 		
                 org.jlab.clas.tracking.kalmanfilter.AStateVecs.StateVec finalSV = svs.new StateVec(initSV);
                 rk.SwimToZ(sector, finalSV, dcSwim, measSurfaces.get(measSurfaces.size()-1).wireLine[0].end().z(), new float[3]);
-                kFZRef.sv.transported(true).put(measSurfaces.size()-1, finalSV);
+                kFZRef.getStateVecs().transported(true).put(measSurfaces.size()-1, finalSV);
                 
-                kFZRef.svzLength = measSurfaces.size();
+                kFZRef.setSvzLength(measSurfaces.size());
                 kFZRef.calcFinalChisq(sector, true);
                                 
                 StateVec stateVec = new StateVec(finalSV.x,

--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -34,6 +34,8 @@ import org.jlab.clas.tracking.kalmanfilter.zReference.StateVecs;
 import org.jlab.clas.tracking.utilities.MatrixOps.Libr;
 import org.jlab.clas.tracking.utilities.RungeKuttaDoca;
 
+import org.jlab.rec.ai.dcHBTrackState.HBTrackStateEstimator;
+
 /**
  * A class with a method implementing an algorithm that finds lists of track
  * candidates in the DC
@@ -203,6 +205,106 @@ public class TrackCandListFinder {
         q *= (int) -1 * Math.signum(TORSCALE); // flip the charge according to the field scale
 
         return q;
+    }
+    
+    public List<Track> getTrackCandsAI(CrossList crossList, DCGeant4Factory DcDetector, Swim dcSwim, HBTrackStateEstimator hbTSEstimator){
+        List<Track> cands = new ArrayList();
+        
+        for (List<Cross> aCrossList : crossList) {
+            Track cand = new Track();
+
+            if (aCrossList.size() == 3 && this.PassNSuperlayerTracking(aCrossList, cand)) {
+                cand.addAll(aCrossList);
+                cand.setSector(aCrossList.get(0).get_Sector());
+                int sector = cand.getSector();
+                
+                List<Surface> measSurfaces = getMeasSurfaces(cand, DcDetector);
+
+                int numHits = 0;
+                for(Surface surf : measSurfaces){
+                    numHits += surf.nMeas;
+                }
+                float[][] hits = new float[numHits][5];
+                int indexHit = 0;
+                for(int i = 0; i < measSurfaces.size(); i++){
+                    hits[indexHit][0] = (float)measSurfaces.get(i).doca[0];
+                    hits[indexHit][1] = (float)measSurfaces.get(i).wireLine[0].origin().x();
+                    hits[indexHit][2] = (float)measSurfaces.get(i).wireLine[0].end().x();
+                    hits[indexHit][3] = (float)measSurfaces.get(i).wireLine[0].end().y();
+                    hits[indexHit][4] = (float)measSurfaces.get(i).wireLine[0].end().z();
+
+                    indexHit++;
+
+                    if(measSurfaces.get(i).nMeas == 2){                
+                        hits[indexHit][0] = (float)measSurfaces.get(i).doca[1];
+                        hits[indexHit][1] = (float)measSurfaces.get(i).wireLine[1].origin().x();
+                        hits[indexHit][2] = (float)measSurfaces.get(i).wireLine[1].end().x();
+                        hits[indexHit][3] = (float)measSurfaces.get(i).wireLine[1].end().y();
+                        hits[indexHit][4] = (float)measSurfaces.get(i).wireLine[1].end().z();
+
+                        indexHit++;
+                    }                                
+                } 
+
+                float[] estSV = hbTSEstimator.predict(hits);
+                StateVecs svs = new StateVecs();
+                org.jlab.clas.tracking.kalmanfilter.AStateVecs.StateVec initSV = svs.new StateVec(0);
+                initSV.x = estSV[0];
+                initSV.y = estSV[1];
+                initSV.z = 229.; // State vector at z = 229 for AI training samples
+                initSV.tx = estSV[2];
+                initSV.ty = estSV[3];
+                initSV.Q = estSV[4];
+                                 
+                RungeKuttaDoca rk = new RungeKuttaDoca();
+                rk.SwimToZ(sector, initSV, dcSwim, measSurfaces.get(0).wireLine[0].end().z(), new float[3]); 
+                
+                KFitter kFZRef = new KFitter(true, 1, 1, dcSwim, Constants.getInstance().Z, Libr.JNP);
+                Matrix initCMatrix = new Matrix();                       
+                initSV.CM = new Matrix();                 
+                kFZRef.init(measSurfaces, initSV);						
+		
+                org.jlab.clas.tracking.kalmanfilter.AStateVecs.StateVec finalSV = svs.new StateVec(initSV);
+                rk.SwimToZ(sector, finalSV, dcSwim, measSurfaces.get(measSurfaces.size()-1).wireLine[0].end().z(), new float[3]);
+                kFZRef.sv.transported(true).put(measSurfaces.size()-1, finalSV);
+                
+                kFZRef.svzLength = measSurfaces.size();
+                kFZRef.calcFinalChisq(sector, true);
+                                
+                StateVec stateVec = new StateVec(finalSV.x,
+                                finalSV.y, finalSV.tx, finalSV.ty);
+                int q = (int) Math.signum(finalSV.Q);
+                double p = 1. / Math.abs(finalSV.Q);
+                stateVec.setZ(finalSV.z);
+
+                //set the track parameters 
+                cand.set_P(p);
+                cand.set_Q(q);
+
+                // candidate parameters 
+                cand.set_FitChi2(kFZRef.chi2);
+                cand.set_FitNDF(kFZRef.NDF);
+
+                cand.setFinalStateVec(stateVec);
+                cand.set_Id(cands.size() + 1);
+                this.setTrackPars(cand, null,
+                        null, stateVec,
+                        stateVec.getZ(),
+                        DcDetector, dcSwim);
+                
+                if(cand.get_Vtx0() != null){
+                    Point3D VTCS = cand.get(cand.size()-1).getCoordsInTiltedSector(cand.get_Vtx0().x(), cand.get_Vtx0().y(), cand.get_Vtx0().z());
+                    double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(sector, VTCS.z());
+
+                    List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);
+                    cand.setStateVecs(kfStateVecsAlongTrajectory);                                  
+                }
+
+                if (kFZRef.chi2 < Constants.MAXCHI2) cands.add(cand);                                              
+            }
+        }
+        
+        return cands;
     }
 
     /**

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCEngine.java
@@ -12,6 +12,7 @@ import org.jlab.rec.dc.Constants;
 import org.jlab.rec.dc.banks.Banks;
 import org.jlab.clas.tracking.kalmanfilter.zReference.KFitter;
 import org.jlab.clas.tracking.kalmanfilter.zReference.DAFilter;
+import org.jlab.rec.ai.dcHBTrackState.HBTrackStateEstimator;
 
 public class DCEngine extends ReconstructionEngine {
 
@@ -38,6 +39,9 @@ public class DCEngine extends ReconstructionEngine {
     protected boolean  useDAF         = true;
     private String   dafChi2Cut     = null;
     private String   dafAnnealingFactorsTB = null;
+    
+    protected String hbTSEModelFileInbending = "transformer_32d_4h_3l_inbending.pt"; // AI model file for HB track state estimator for inbending runs  
+    protected String hbTSEModelFileOutbending = "transformer_32d_4h_3l_outbending.pt"; // AI model file for HB track state estimator for outbending runs  
     
     public static final Logger LOGGER = Logger.getLogger(ReconstructionEngine.class.getName());
 
@@ -126,6 +130,14 @@ public class DCEngine extends ReconstructionEngine {
         if(this.getEngineConfigString("dafAnnealingFactorsTB")!=null){ 
             dafAnnealingFactorsTB=this.getEngineConfigString("dafAnnealingFactorsTB");
             KFitter.setDafAnnealingFactorsTB(dafAnnealingFactorsTB);
+        }
+                    
+        if (getEngineConfigString("hbTSEModelFileInbending") != null){
+            hbTSEModelFileInbending = getEngineConfigString("hbTSEModelFileInbending");
+        }
+        
+        if (getEngineConfigString("hbTSEModelFileOutbending") != null){
+            hbTSEModelFileOutbending = getEngineConfigString("hbTSEModelFileOutbending");
         }
                
         // Set geometry shifts for alignment code

--- a/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBTrackingAI.java
+++ b/reconstruction/dc/src/main/java/org/jlab/service/dc/DCHBTrackingAI.java
@@ -1,0 +1,362 @@
+package org.jlab.service.dc;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jlab.clas.swimtools.Swim;
+import org.jlab.clas.swimtools.Swimmer;
+import org.jlab.io.base.DataEvent;
+import org.jlab.rec.dc.Constants;
+import org.jlab.rec.dc.banks.HitReader;
+import org.jlab.rec.dc.banks.RecoBankWriter;
+import org.jlab.rec.dc.cluster.FittedCluster;
+import org.jlab.rec.dc.cross.Cross;
+import org.jlab.rec.dc.cross.CrossList;
+import org.jlab.rec.dc.cross.CrossListFinder;
+import org.jlab.rec.dc.hit.FittedHit;
+import org.jlab.rec.dc.hit.Hit;
+import org.jlab.rec.dc.nn.PatternRec;
+import org.jlab.rec.dc.segment.Segment;
+import org.jlab.rec.dc.track.Track;
+import org.jlab.rec.dc.track.TrackCandListFinder;
+import org.jlab.rec.dc.cluster.ClusterFinder;
+import org.jlab.rec.dc.cluster.ClusterFitter;
+import org.jlab.rec.dc.segment.SegmentFinder;
+import org.jlab.rec.dc.cross.CrossMaker;
+import org.jlab.rec.dc.trajectory.Road;
+import org.jlab.rec.dc.trajectory.RoadFinder;
+import static org.jlab.service.dc.DCEngine.LOGGER;
+import org.jlab.rec.ai.dcHBTrackState.HBTrackStateEstimator;
+
+/**
+ *
+ * @author tongtong
+ */
+public class DCHBTrackingAI extends DCEngine {    
+    private HBTrackStateEstimator hbTSEstimatorInbending = null;
+    private HBTrackStateEstimator hbTSEstimatorOutbending = null;
+
+    public DCHBTrackingAI() {
+        super("DCHTAI");
+        this.getBanks().init("HitBasedTrkg", "", "AI");
+        hbTSEstimatorInbending = new HBTrackStateEstimator(hbTSEModelFileInbending);
+        hbTSEstimatorOutbending = new HBTrackStateEstimator(hbTSEModelFileOutbending);        
+    }
+    
+    public DCHBTrackingAI(String outputBankPrefix) {
+        super("DCHTAI");
+        this.getBanks().init("HitBasedTrkg", "", outputBankPrefix);
+        hbTSEstimatorInbending = new HBTrackStateEstimator(hbTSEModelFileInbending);
+        hbTSEstimatorOutbending = new HBTrackStateEstimator(hbTSEModelFileOutbending);         
+    }
+    
+    @Override
+    public void setDropBanks() {
+        super.registerOutputBank(this.getBanks().getHitsBank());
+        super.registerOutputBank(this.getBanks().getClustersBank());
+        super.registerOutputBank(this.getBanks().getSegmentsBank());
+        super.registerOutputBank(this.getBanks().getCrossesBank());
+        super.registerOutputBank(this.getBanks().getTracksBank());
+        super.registerOutputBank(this.getBanks().getIdsBank());
+    }
+    
+    @Override
+    public boolean processDataEvent(DataEvent event) {
+        
+        int run = this.getRun(event);
+        if(run==0) {
+            LOGGER.log(Level.INFO, "RUN=0: Skipping event");
+            return true;
+        }
+        
+        HBTrackStateEstimator hbTSEstimator = null;
+        if(Swimmer.getTorScale() < 0)
+            hbTSEstimator = hbTSEstimatorInbending;
+        else if(Swimmer.getTorScale() > 0)
+            hbTSEstimator = hbTSEstimatorOutbending;
+        else{
+            Logger.getLogger(getClass().getName()).log(Level.SEVERE, "Torus scale = 0"); 
+            return true;
+        }
+        
+        ////// AI-assisted tracking
+        /* IO */
+        HitReader reader      = new HitReader(this.getBanks(), Constants.getInstance().dcDetector);
+        reader.initialize(event);
+        RecoBankWriter writer = new RecoBankWriter(this.getBanks());
+        // get Field
+        Swim dcSwim = new Swim();
+        LOGGER.log(Level.FINEST, "HB AI process event");
+
+        //AI
+        List<Track> trkcands = null;
+        List<Cross> crosses = null;
+        List<FittedCluster> clusters = new ArrayList<>();
+        List<Segment> segments = null;
+        List<FittedHit> fhits = null;
+
+        reader.read_NNHits(event);
+
+        //I) get the lists
+        List<Hit> hits = reader.get_DCHits();
+        fhits = new ArrayList<>();
+        //II) process the hits
+        // Exit if hit list is empty
+        if (hits.isEmpty()) {
+            return true;
+        }
+        PatternRec pr = new PatternRec();
+        segments = pr.RecomposeSegments(hits, Constants.getInstance().dcDetector);
+        Collections.sort(segments);
+
+        if (segments.isEmpty()) {
+            return true;
+        } 
+        //crossList
+        CrossList crosslist = pr.RecomposeCrossList(segments, Constants.getInstance().dcDetector);
+        crosses = new ArrayList<>();
+        
+        LOGGER.log(Level.FINEST, "num cands = "+crosslist.size());
+        for (List<Cross> clist : crosslist) {
+            crosses.addAll(clist); 
+            for(Cross c : clist)
+                LOGGER.log(Level.FINEST, "Pass Cross"+c.printInfo());
+        }
+        if (crosses.isEmpty()) {
+            for(Segment seg : segments) {
+                clusters.add(seg.get_fittedCluster());
+            }
+            event.appendBanks(
+                    writer.fillHBHitsBank(event, fhits),    
+                    writer.fillHBClustersBank(event, clusters),
+                    writer.fillHBSegmentsBank(event, segments));
+            return true;
+        } 
+        // update B field
+        CrossListFinder crossLister = new CrossListFinder();
+        for(Cross cr : crosses) {
+            crossLister.updateBFittedHits(event, cr, null, Constants.getInstance().dcDetector, null, dcSwim);
+        }
+        //find the list of  track candidates
+        TrackCandListFinder trkcandFinder = new TrackCandListFinder(Constants.HITBASE);
+        trkcands = trkcandFinder.getTrackCandsAI(crosslist,
+            Constants.getInstance().dcDetector,
+            dcSwim, hbTSEstimator);
+
+        // track found
+        int trkId = 1;
+        if (trkcands.size() > 0) {
+            // remove overlaps
+            trkcandFinder.removeOverlappingTracks(trkcands);
+            for (Track trk : trkcands) {
+                trk.setIsAITrack(true);
+                
+                for (Cross c : trk) {
+                    clusters.add(c.get_Segment1().get_fittedCluster());
+                    clusters.add(c.get_Segment2().get_fittedCluster());
+                }
+                
+                // reset the id
+                trk.set_Id(trkId);
+                trkcandFinder.matchHits(trk.getStateVecs(),
+                        trk,
+                        Constants.getInstance().dcDetector,
+                        dcSwim);
+                trkId++;
+            }
+        }
+        
+        ////// Find tracks by rest of clusters using conventional tracking
+        List<FittedCluster> clustersConv = null;
+        List<Segment> segmentsConv = null;
+        List<Cross> crossesConv = null;
+        List<Track> trkcandsConv = null;
+        
+        //1) read hits from the banks
+        Map<Integer, ArrayList<FittedHit>> hitsConv = reader.read_Hits(event);
+        
+        //2) find clusters from these hits
+        ClusterFinder clusFinder = new ClusterFinder();
+        ClusterFitter cf = new ClusterFitter();
+        clustersConv = clusFinder.RecomposeClusters(hitsConv, Constants.getInstance().dcDetector, cf);
+
+        //3) remove clusters which are on tracks
+        List<FittedCluster> removedClustersConv = new ArrayList();
+        for(FittedCluster cls : clustersConv){
+            boolean flag = false;
+            for(Track trk : trkcands){
+                if(flag) break;
+                for(Cross crs : trk){
+                    if(cls.get_Id() == crs.get_Segment1().get_Id() || cls.get_Id() == crs.get_Segment2().get_Id()) {
+                        removedClustersConv.add(cls);
+                        flag = true;
+                        break;
+                    }
+                }
+            }
+        }
+        clustersConv.removeAll(removedClustersConv);
+        clusters.addAll(clustersConv);
+        
+        //4) find segments from clusters
+        SegmentFinder segFinder = new SegmentFinder();
+        segmentsConv = segFinder.get_Segments(clustersConv,
+                event,
+                Constants.getInstance().dcDetector, false);
+        List<Segment> rmSegsConv = new ArrayList<>();
+        // clean up hit-based segments
+        double trkDocOverCellSize;
+        for (Segment se : segmentsConv) {
+            trkDocOverCellSize = 0;
+            for (FittedHit fh : se.get_fittedCluster()) {
+                trkDocOverCellSize += fh.get_ClusFitDoca() / fh.get_CellSize();
+            }
+            if (trkDocOverCellSize / se.size() > 1.1) {
+                rmSegsConv.add(se);
+            }
+        }
+        segmentsConv.removeAll(rmSegsConv);
+        segments.addAll(segmentsConv);
+        
+        //5) find crosses from segments
+        CrossMaker crossMake = new CrossMaker();
+        crossesConv = crossMake.find_Crosses(segmentsConv, Constants.getInstance().dcDetector);
+        crosses.addAll(crossesConv);
+        
+        //6) find cross lists from crosses
+        CrossList crosslistConv = crossLister.candCrossLists(event, crossesConv,
+                false,
+                null,
+                Constants.getInstance().dcDetector,
+                null,
+                dcSwim, false);       
+        
+        //7) find track candidates with 5 or 6 clusters
+        // track candidates with 6 clusters 
+        trkcandsConv = trkcandFinder.getTrackCandsAI(crosslistConv,
+                Constants.getInstance().dcDetector,
+                dcSwim, hbTSEstimator); 
+        
+        // track candidates with 5 clusters
+        RoadFinder rf = new RoadFinder();
+        List<Road> allRoadsConv = rf.findRoads(segmentsConv, Constants.getInstance().dcDetector);
+        List<Segment> Segs2RoadConv = new ArrayList<>();
+        List<Segment> psegmentsConv = new ArrayList<>();
+        for (Road r : allRoadsConv) { 
+            Segs2RoadConv.clear();
+            int missingSL = -1;
+            for (int ri = 0; ri < 3; ri++) {
+                if (r.get(ri).associatedCrossId == -1) {
+                    if (r.get(ri).get_Superlayer() % 2 == 1) {
+                        missingSL = r.get(ri).get_Superlayer() + 1;
+                    } else {
+                        missingSL = r.get(ri).get_Superlayer() - 1;
+                    }
+                }
+            } 
+            if(missingSL==-1) 
+                continue;
+            for (int ri = 0; ri < 3; ri++) {
+                for (Segment s : segmentsConv) {
+                    if (s.get_Sector() == r.get(ri).get_Sector() &&
+                            s.get_Region() == r.get(ri).get_Region() &&
+                            s.associatedCrossId == r.get(ri).associatedCrossId &&
+                            r.get(ri).associatedCrossId != -1) {
+                        if (s.get_Superlayer() % 2 == missingSL % 2){
+                            Segs2RoadConv.add(s); 
+                            break;
+                        }
+                    }
+                }
+            }
+            if (Segs2RoadConv.size() == 2) {
+                Segment pSegmentConv = rf.findRoadMissingSegment(Segs2RoadConv,
+                        Constants.getInstance().dcDetector,
+                        r.a);
+                if (pSegmentConv != null)
+                    psegmentsConv.add(pSegmentConv);
+            }
+        }
+
+        segmentsConv.addAll(psegmentsConv);
+        List<Cross> pcrossesConv = crossMake.find_Crosses(segmentsConv, Constants.getInstance().dcDetector);
+        List<Cross> fullPseudoCrossesConv = new ArrayList(); // Cross by two pseudo segments
+        for(Cross crs : pcrossesConv){
+            if(crs.get_Segment1().get_Id() == -1 && crs.get_Segment2().get_Id() == -1) fullPseudoCrossesConv.add(crs);
+        }
+        pcrossesConv.removeAll(fullPseudoCrossesConv);        
+        CrossList pcrosslistConv = crossLister.candCrossLists(event, pcrossesConv,
+                false,
+                null,
+                Constants.getInstance().dcDetector,
+                null,
+                dcSwim, true);
+        List<Track> mistrkcandsConv = trkcandFinder.getTrackCandsAI(pcrosslistConv,
+                Constants.getInstance().dcDetector,
+                dcSwim, hbTSEstimator);
+        
+        //8) Select overlapping tracks from all track candidates with 5 or 6 clusters, and update hits in tracks 
+        trkcandsConv.addAll(mistrkcandsConv);
+        if (!trkcandsConv.isEmpty()) {
+            // remove overlaps
+            trkcandFinder.removeOverlappingTracks(trkcandsConv);
+            for (Track trk : trkcandsConv) {
+                // reset the id
+                trk.set_Id(trkId);
+                trkcandFinder.matchHits(trk.getStateVecs(),
+                        trk,
+                        Constants.getInstance().dcDetector,
+                        dcSwim);
+                trkId++;
+            }
+        }
+                
+        //////gather all the hits for pointer bank creation
+        trkcands.addAll(trkcandsConv);
+        trkId=1;
+        for (Track trk : trkcands) {            
+            trk.calcTrajectory(trk.getId(), dcSwim, trk.get_Vtx0(), trk.get_pAtOrig(), trk.get_Q());
+            for (Cross c : trk) {
+                c.set_CrossDirIntersSegWires();
+                trkcandFinder.setHitDoubletsInfo(c.get_Segment1());
+                trkcandFinder.setHitDoubletsInfo(c.get_Segment2());
+                for (FittedHit h1 : c.get_Segment1()) {          
+                    h1.set_AssociatedHBTrackID(trkId);
+                    //if(h1.get_AssociatedHBTrackID()>0) 
+                    fhits.add(h1); 
+                }
+                for (FittedHit h2 : c.get_Segment2()) {
+                    h2.set_AssociatedHBTrackID(trkId);
+                    //if(h2.get_AssociatedHBTrackID()>0) 
+                    fhits.add(h2); 
+                }
+            }
+            trkId++;
+        }
+           
+        // no candidate found, stop here and save the hits,
+        // the clusters, the segments, the crosses
+        if (trkcands.isEmpty()) {
+            event.appendBanks(
+                    writer.fillHBHitsBank(event, fhits),    
+                    writer.fillHBClustersBank(event, clusters),
+                    writer.fillHBSegmentsBank(event, segments),
+                    writer.fillHBCrossesBank(event, crosses));
+        }
+        else {
+            event.appendBanks(
+                    writer.fillHBHitsBank(event, fhits),    
+                    writer.fillHBClustersBank(event, clusters),
+                    writer.fillHBSegmentsBank(event, segments),
+                    writer.fillHBCrossesBank(event, crosses),
+                    writer.fillHBTracksBank(event, trkcands),
+                    writer.fillHBHitsTrkIdBank(event, fhits),
+                    writer.fillHBTrajectoryBank(event, trkcands));
+        } 
+        return true;
+    }
+    
+}


### PR DESCRIPTION
A new engine, called as DCHBTrackingAI, is added to apply AI models for estimation of HB tracks.
Then, there are three engines for HB tracking:
1. DCHBPostClusterConv, where all possible cluster combos are tried, and tracking is processed with KF
2. DCHBPostClusterAI, where cluster combos are predicted by AI, and tracking is processed with KF
3. DCHBTrackingAI, where cluster combos are predicted by AI, and track states are estimated by AI

As test, HB tracks by AI has better resolution than HB tracks by KF. 
See details in slides: 
[HB Tracking by AI.pdf](https://github.com/user-attachments/files/24569105/HB.Tracking.by.AI.pdf)