### PR TITLE
fix: reduce EVIO branch transversing in decoding, cleanup

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaDecoders.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaDecoders.java
@@ -1,0 +1,922 @@
+package org.jlab.detector.decode;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.jlab.coda.jevio.CompositeData;
+import org.jlab.coda.jevio.DataType;
+import org.jlab.coda.jevio.EvioException;
+import org.jlab.coda.jevio.EvioNode;
+import org.jlab.detector.decode.DetectorDataDgtz.ADCData;
+import org.jlab.detector.decode.DetectorDataDgtz.TDCData;
+import org.jlab.io.evio.EvioDataEvent;
+import org.jlab.io.evio.EvioTreeBranch;
+import org.jlab.utils.data.DataUtils;
+
+/**
+ * All static methods from CodaEventDecoder.
+ * 
+ * @author baltzell
+ */
+public class CodaDecoders {
+    
+    /**
+     * Returns an array of the branches in the event.
+     * @param event
+     * @return
+     */
+    public static List<EvioTreeBranch> getEventBranches(EvioDataEvent event){
+        ArrayList<EvioTreeBranch>  branches = new ArrayList<>();
+        try {
+            List<EvioNode> eventNodes = event.getStructureHandler().getNodes();
+            if (eventNodes==null) {
+                return branches;
+            }
+            for (EvioNode node : eventNodes){
+                EvioTreeBranch eBranch = new EvioTreeBranch(node.getTag(),node.getNum());
+                List<EvioNode>  childNodes = node.getChildNodes();
+                if (childNodes!=null){
+                    for (EvioNode child : childNodes){
+                        eBranch.addNode(child);
+                    }
+                    branches.add(eBranch);
+                }
+            }
+        } catch (EvioException ex) {
+            Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+        }
+        return branches;
+    }
+
+    public static void printByteBuffer(ByteBuffer buffer, int max, int columns){
+        int n = max;
+        if(buffer.capacity()<max) n = buffer.capacity();
+        StringBuilder str = new StringBuilder();
+        for(int i = 0 ; i < n; i++){
+            str.append(String.format("%02X ", buffer.get(i)));
+            if( (i+1)%columns==0 ) str.append("\n");
+        }
+        System.out.println(str.toString());
+    }
+
+    /*
+    * 	<dictEntry name="FADC250 Window Raw Data (mode 1 packed)" tag="0xe126" num="0" type="composite">
+    * <description format="c,m(c,ms)">
+    *  c 	"slot number"
+    * m	"number of channels fired"
+    * c	"channel number"
+    * m	"number of shorts in packed array"
+    * s	"packed fadc data"
+    * </description>
+    * </dictEntry>
+    */
+    public static void decodeComposite(ByteBuffer buffer, int offset, List<DataType> ctypes, List<Object> citems){
+        int position = offset;
+        int length   = buffer.capacity();
+        try {
+            while(position<(length-3)){
+                Short slot = (short) (0x00FF&(buffer.get(position)));
+                position++;
+                citems.add(slot);
+                ctypes.add(DataType.SHORT16);
+                Short counter =  (short) (0x00FF&(buffer.get(position)));
+                citems.add(counter);
+                ctypes.add(DataType.NVALUE);
+                position++;
+
+                for(int i = 0; i < counter; i++){
+                    Short channel = (short) (0x00FF&(buffer.get(position)));
+                    position++;
+                    citems.add(channel);
+                    ctypes.add(DataType.SHORT16);
+                    Short ndata = (short) (0x00FF&(buffer.get(position)));
+                    position++;
+                    citems.add(ndata);
+                    ctypes.add(DataType.NVALUE);
+                    for(int b = 0; b < ndata; b++){
+                        Short data = buffer.getShort(position);
+                        position+=2;
+                        citems.add(data);
+                        ctypes.add(DataType.SHORT16);
+                    }
+                }
+            }
+        } catch (Exception e){
+            System.out.println("Exception : Length = " + length + "  position = " + position);
+        }
+    }
+
+    /**
+     * SVT decoding
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static ArrayList<DetectorDataDgtz> getDataEntries_57617(Integer crate, EvioNode node, EvioDataEvent event){
+
+        ArrayList<DetectorDataDgtz>  rawdata = new ArrayList<>();
+
+        if(node.getTag()==57617){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+                List<Object>   cdataitems = compData.getItems();
+                int  totalSize = cdataitems.size();
+                int  position  = 0;
+                while( (position + 4) < totalSize){
+                    Byte    slot = (Byte)     cdataitems.get(position);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    int counter  = 0;
+                    position = position + 4;
+                    while(counter<nchannels){
+                        Byte   half    = (Byte) cdataitems.get(position);
+                        Byte   channel = (Byte) cdataitems.get(position+1);
+                        Byte   tdcbyte = (Byte) cdataitems.get(position+2);
+                        Short  tdc     = DataUtils.getShortFromByte(tdcbyte);
+                        Byte   adcbyte = (Byte)  cdataitems.get(position+3);
+
+                        // regular FSSR data entry
+                        int halfWord = DataUtils.getIntFromByte(half);
+                        int   chipID = DataUtils.getInteger(halfWord, 0, 2);
+                        int   halfID = DataUtils.getInteger(halfWord, 3, 3);
+                        int   adc    = adcbyte;
+                        //Integer channelKey = ((half<<8) | (channel & 0xff));
+
+                        // TDC data entry
+                        if(half == -128) {
+                            halfWord   = DataUtils.getIntFromByte(channel);
+                            halfID     = DataUtils.getInteger(halfWord, 2, 2);
+                            chipID     = DataUtils.getInteger(halfWord, 0, 1) + 1;
+                            channel    = 0;
+                            //channelKey = 0;
+                            tdc = (short) ((adcbyte<<8) | (tdcbyte & 0xff));
+                            adc = -1;
+                        }
+
+                        int channelID = halfID*10000 + chipID*1000 + channel;
+                        position += 4;
+                        counter++;
+                        DetectorDataDgtz entry = new DetectorDataDgtz(crate,slot,channelID);
+                        ADCData adcData = new ADCData();
+                        adcData.setIntegral(adc);
+                        adcData.setPedestal( (short) 0);
+                        adcData.setADC(0,0);
+                        adcData.setTime(tdc);
+                        adcData.setTimeStamp(time);
+                        entry.addADC(adcData);
+                        rawdata.add(entry);
+                    }
+                }
+
+            } catch (EvioException ex) {
+                //Logger.getLogger(EvioRawDataSource.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IndexOutOfBoundsException ex){
+                //System.out.println("[ERROR] ----> ERROR DECODING COMPOSITE DATA FOR ONE EVENT");
+            }
+        }
+        return rawdata;
+    }
+
+    /**
+     * Bank TAG=57657 used for ATOF PETIROC TDC values
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     *
+     * <dictEntry name="PETIROC Composite Data" tag="0xe139" num="0" type="composite">
+     *           <description format="c,i,l,N(c,i,i)">
+     *                       c   "slot number"
+     *                       i   "trigger number"
+     *                       l   "time stamp"
+     *                       N   "number of channels fired"
+     *                       c   "channel number"
+     *                       i   "tdc value"
+     *                       i   "width value"
+     *        </description>
+     * </dictEntry>
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57657(Integer crate, EvioNode node, EvioDataEvent event) {
+
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+
+        if(node.getTag()==57657){
+            try {
+                //System.err.println("Decoding ATOF PETIROC event!");
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+                while(position<cdatatypes.size()-4){
+                    Byte    slot       = (Byte)     cdataitems.get(position+0);
+                    Integer trig_num   = (Integer)  cdataitems.get(position+1);
+                    Long    time_stamp = (Long)    cdataitems.get(position+2);
+                    Integer nchannels  = (Integer) cdataitems.get(position+3);
+                    int     counter    = 0;
+
+                    position += 4; // slot, trig,time,nchannels
+                                   //
+                    while(counter<nchannels){
+                        Byte channel = (Byte) cdataitems.get(position+0);
+                        Integer tdc = (Integer) cdataitems.get(position+1);
+                        // width over threshold
+                        Integer tot = (Integer) cdataitems.get(position+2);
+
+                        DetectorDataDgtz bank = new DetectorDataDgtz(
+                            crate, slot.intValue(), channel.intValue());
+                        // the "bank" has a timestamp.
+                        // the tdc also can have a timestamp.
+                        // the tdc is added tot he "bank"
+                        // the "bank" is added to the "entries" (array of DetectorDataDgtz)
+                        // "entries" List<DetectorDataDgtz>  -> "bank" DetectorDataDgtz  -> "tdc" TDCData
+                        // there is a redundancy in timestamp: the same value is stored in TDCData and the DetectorDataDgz
+                        //
+                        bank.setTimeStamp(time_stamp);
+                        bank.setTrigger(trig_num);;
+                        TDCData tdc_data = new TDCData(tdc, tot);
+                        tdc_data.setTimeStamp(time_stamp).setOrder(counter);
+                        bank.addTDC(tdc_data);
+                        entries.add(bank);
+                        position += 3; // channel,tdc,tot
+                        counter++;
+                        //System.err.println("event: " + bank.toString());
+                    }
+                }
+
+                return entries;
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Bank TAG=57636 used for RICH TDC values
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57636(Integer crate, EvioNode node, EvioDataEvent event){
+
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+
+        if(node.getTag()==57636){
+            try {
+
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+                while(position<cdatatypes.size()-4){
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    //Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+
+                    while(counter<nchannels){
+                        Integer fiber = ((Byte) cdataitems.get(position))&0xFF;
+                        Integer channel = ((Byte) cdataitems.get(position+1))&0xFF;
+                        Short rawtdc = (Short) cdataitems.get(position+2);
+                        int edge = (rawtdc>>15)&0x1;
+                        int tdc = rawtdc&0x7FFF;
+
+                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),2*(fiber*192+channel)+edge);
+                        bank.addTDC(new TDCData(tdc));
+
+                        entries.add(bank);
+                        position += 3;
+                        counter++;
+                    }
+                }
+
+                return entries;
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Bank TAG=57648 used for DC (Drift Chambers) TDC and ToT values.
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57648(Integer crate, EvioNode node, EvioDataEvent event){
+        List<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57648){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+                //List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                int  totalSize = cdataitems.size();
+                int  position  = 0;
+                while( (position + 4) < totalSize){
+                    Byte    slot = (Byte)     cdataitems.get(position);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    int counter  = 0;
+                    position = position + 4;
+                    while(counter<nchannels){
+                        Byte   channel = (Byte) cdataitems.get(position);
+                        Short  tdc     = (Short) cdataitems.get(position+1);
+                        Short  tot     = (Short) cdataitems.get(position+2);
+                        position += 3;
+                        counter++;
+                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,channel);
+                        entry.addTDC(new TDCData(tdc, tot));
+                        entry.setTimeStamp(time);
+                        entries.add(entry);
+                    }
+                }
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IndexOutOfBoundsException ex){
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+        }
+        return entries;
+    }
+
+    /**
+     * Bank TAG=57622 used for DC (Drift Chambers) TDC values.
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57622(Integer crate, EvioNode node, EvioDataEvent event){
+        List<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57622){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+                //List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                int  totalSize = cdataitems.size();
+                int  position  = 0;
+                while( (position + 4) < totalSize){
+                    Byte    slot = (Byte)     cdataitems.get(position);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    int counter  = 0;
+                    position = position + 4;
+                    while(counter<nchannels){
+                        Byte   channel    = (Byte) cdataitems.get(position);
+                        Short  tdc     = (Short) cdataitems.get(position+1);
+                        position += 2;
+                        counter++;
+                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,channel);
+                        entry.addTDC(new TDCData(tdc));
+                        entry.setTimeStamp(time);
+                        entries.add(entry);
+                    }
+                }
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            } catch (IndexOutOfBoundsException ex){
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+
+        }
+        return entries;
+    }
+
+    /**
+     * Decoding MODE 7 data. for given crate.
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+//      <dictEntry name="FADC250 Pulse Integral Data (mode 3)" tag="0xe103" num="0" type="composite">
+//            <description format="c,i,l,N(c,N(s,i))">
+//                  c     "slot number" (8bit)
+//                  i     "trigger number" (32bit)
+//                  l     "time stamp" (64bit)
+//                  N     "number of channels fired" (32bit)
+//                  c     "channel number" (8bit)
+//                  N     "number of pulses" (32bit)
+//                  s     "tdc value" (16bit)
+//                  i     "adc value" (32bit)
+//            </description>
+//      </dictEntry>
+    public static List<DetectorDataDgtz> getDataEntries_57603(Integer crate, EvioNode node, EvioDataEvent event){
+        List<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57603){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+                while((position+4)<cdatatypes.size()){
+
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+                    while(counter<nchannels){
+                        Byte channel   = (Byte) cdataitems.get(position);
+                        Integer length = (Integer) cdataitems.get(position+1);
+
+                        position += 2;
+                        for(int loop = 0; loop < length; loop++){
+                            Short tdc    = (Short) cdataitems.get(position);
+                            Integer adc  = (Integer) cdataitems.get(position+1);
+                            DetectorDataDgtz  entry = new DetectorDataDgtz(crate,slot,channel);
+                            ADCData   adcData = new ADCData();
+                            adcData.setIntegral(adc).setTimeWord(tdc);
+                            entry.addADC(adcData);
+                            entry.setTimeStamp(time);
+                            entries.add(entry);
+                            position+=2;
+                        }
+                        counter++;
+                    }
+                }
+                return entries;
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Decoding MODE 7 data. for given crate.
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57602(Integer crate, EvioNode node, EvioDataEvent event){
+        List<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57602){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+                while((position+4)<cdatatypes.size()){
+
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+                    while(counter<nchannels){
+                        Byte channel   = (Byte) cdataitems.get(position);
+                        Integer length = (Integer) cdataitems.get(position+1);
+
+                        position += 2;
+                        for(int loop = 0; loop < length; loop++){
+                            Short tdc    = (Short) cdataitems.get(position);
+                            Integer adc  = (Integer) cdataitems.get(position+1);
+                            Short pmin   = (Short) cdataitems.get(position+2);
+                            Short pmax   = (Short) cdataitems.get(position+3);
+                            DetectorDataDgtz  entry = new DetectorDataDgtz(crate,slot,channel);
+                            ADCData   adcData = new ADCData();
+                            adcData.setIntegral(adc).setTimeWord(tdc).setPedestal(pmin).setHeight(pmax);
+                            entry.addADC(adcData);
+                            entry.setTimeStamp(time);
+                            entries.add(entry);
+                            position+=4;
+                        }
+                        counter++;
+                    }
+                }
+                return entries;
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Decoding MicroMegas Packed Data
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57641(Integer crate, EvioNode node, EvioDataEvent event){
+        // Micromegas packed data
+        // ----------------------
+
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57641){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                int jdata = 0;  // item counter
+                for( int i = 0 ; i < cdatatypes.size();  ) { // loop over data types
+
+                	Byte SLOT       =  (Byte)cdataitems.get( jdata++ ); i++;
+                	Integer EV_ID   =  (Integer)cdataitems.get( jdata++ ); i++;
+                	Long TIMESTAMP  =  (Long)cdataitems.get( jdata++ ); i++;
+                	Short nChannels =  (Short)cdataitems.get( jdata++ ); i++;
+
+                	for( int ch=0; ch<nChannels; ch++ ) {
+                    	Short CHANNEL = (Short)cdataitems.get( jdata++ ); i++;
+
+                        int nPulses = (Byte)cdataitems.get( jdata++ ); i++;
+                        for(int np = 0; np < nPulses; np++){
+
+                            int firstChannel = (Byte) cdataitems.get( jdata++ ); i++;
+
+                            int nBytes = (Byte)cdataitems.get( jdata++ ); i++;
+
+                            DetectorDataDgtz bank = new DetectorDataDgtz(crate,SLOT.intValue(),CHANNEL.intValue());
+
+                            int nSamples = nBytes*8/12;
+                            short[] samples = new short[ nSamples ];
+
+                            int s;
+                            for( int b=0;b<nBytes;b++ ) {
+                                short data = (short)((byte)cdataitems.get( jdata++ )&0xFF);
+
+                                s = (int)Math.floor( b * 8./12. );
+                                if( b%3 != 1) {
+                                    samples[s] += (short)data;
+                                }
+                                else {
+                                    samples[s] += (data&0x000F)<<8;
+                                    if( s+1 < nSamples ) samples[s+1] += ((data&0x00F0)>>4)<<8;
+                                }
+                            }
+                            i++;
+
+                            ADCData adcData = new ADCData();
+                            adcData.setTimeStamp(TIMESTAMP);
+                            adcData.setPulse(samples);
+                            adcData.setTime(firstChannel);
+                            bank.addADC(adcData);
+                            
+                            entries.add(bank);
+                        }
+                    } // end loop on channels
+                } // end loop on data types
+                return entries;
+
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * Decoding MicroMegas Packed Data
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57640(Integer crate, EvioNode node, EvioDataEvent event){
+        // Micromegas packed data
+        // ----------------------
+
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+        if(node.getTag()==57640){
+            try {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                int jdata = 0;  // item counter
+                for( int i = 0 ; i < cdatatypes.size();  ) { // loop over data types
+
+                	Byte CRATE      =  (Byte)cdataitems.get( jdata++ ); i++;
+                	Integer EV_ID   = (Integer)cdataitems.get( jdata++ ); i++;
+                	Long TIMESTAMP  =  (Long)cdataitems.get( jdata++ ); i++;
+                	Short nChannels =  (Short)cdataitems.get( jdata++ ); i++;
+
+                	for( int ch=0; ch<nChannels; ch++ ) {
+
+                    	Short CHANNEL = (Short)cdataitems.get( jdata++ ); i++;
+                    	int nBytes = (Byte)cdataitems.get( jdata++ ); i++;
+
+                    	DetectorDataDgtz bank = new DetectorDataDgtz(crate,CRATE.intValue(),CHANNEL.intValue());
+
+                    	int nSamples = nBytes*8/12;
+                    	short[] samples = new short[ nSamples ];
+
+                    	int s;
+                    	for( int b=0;b<nBytes;b++ ) {
+                    		short data = (short)((byte)cdataitems.get( jdata++ )&0xFF);
+
+                    		s = (int)Math.floor( b * 8./12. );
+                    		if( b%3 != 1) {
+                    			samples[s] += (short)data;
+                    		}
+                    		else {
+                    			samples[s] += (data&0x000F)<<8;
+                    			if( s+1 < nSamples ) samples[s+1] += ((data&0x00F0)>>4)<<8;
+                    		}
+
+                    	}
+                    	i++;
+
+                      ADCData adcData = new ADCData();
+                      adcData.setTimeStamp(TIMESTAMP);
+                      adcData.setPulse(samples);
+                      bank.addADC(adcData);
+                      entries.add(bank);
+                	} // end loop on channels
+                } // end loop on data types
+                return entries;
+
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    public static List<DetectorDataDgtz> getDataEntries_57627(Integer crate, EvioNode node, EvioDataEvent event){
+
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+
+        if(node.getTag()==57627){
+            try {
+
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+
+                while(position<cdatatypes.size()-4){
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+                    while(counter<nchannels){
+
+                        Short channel   = (Short) cdataitems.get(position);
+                        Integer length = (Integer) cdataitems.get(position+1);
+                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),channel.intValue());
+
+                        short[] shortbuffer = new short[length];
+                        for(int loop = 0; loop < length; loop++){
+                            Short sample    = (Short) cdataitems.get(position+2+loop);
+                            shortbuffer[loop] = sample;
+                        }
+                        //Added pulse fitting for MMs
+                        ADCData adcData = new ADCData();
+                        adcData.setTimeStamp(time);
+                        adcData.setPulse(shortbuffer);
+                        bank.addADC(adcData);
+                        entries.add(bank);
+                        position += 2+length;
+                        counter++;
+                    }
+                }
+                return entries;
+
+            } catch (EvioException ex) {
+                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * FADC250, Mode-1, bitpacked
+     * @param crate
+     * @param node
+     * @param event
+     * @return 
+     */
+    public static List<FADCData> getDataEntries_57638(Integer crate, EvioNode node, EvioDataEvent event){
+        List<FADCData>  entries = new ArrayList<>();
+        if(node.getTag()==57638){
+            ByteBuffer     compBuffer = node.getByteData(true);
+            List<DataType> cdatatypes = new ArrayList<>();
+            List<Object>   cdataitems = new ArrayList<>();
+            decodeComposite(compBuffer, 24, cdatatypes, cdataitems);
+            
+            int position = 0;
+            
+            while(position<cdatatypes.size()-3){
+                Short       slot = (Short)       cdataitems.get(position+0);
+                Short  nchannels =  (Short) cdataitems.get(position+1);
+                
+                position += 2;
+                int     counter = 0;
+                while(counter<nchannels){
+                    Short   channel = (Short) cdataitems.get(position);
+                    Short   length  = (Short) cdataitems.get(position+1);
+                    position +=2;
+                    short[] shortbuffer = new short[length];
+                    for(int loop = 0; loop < length; loop++){
+                        Short sample    = (Short) cdataitems.get(position+loop);
+                        shortbuffer[loop] = sample;
+                    }
+                    position+=length;
+                    counter++;
+                    FADCData data = new FADCData(crate,slot,channel);
+                    data.setBuffer(shortbuffer);
+                    if(length>18) entries.add(data);
+                }
+            }
+        }
+        return entries;
+    }
+    
+    /**
+     * decoding bank in Mode 1 - full ADC pulse.
+     * @param crate
+     * @param node
+     * @param event
+     * @return
+     */
+    public static List<DetectorDataDgtz> getDataEntries_57601(Integer crate, EvioNode node, EvioDataEvent event){
+        
+        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
+        
+        if(node.getTag()==57601){
+            try {
+                
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+                
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+
+                while(position<cdatatypes.size()-4){
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+                    while(counter<nchannels){
+                        Byte channel   = (Byte) cdataitems.get(position);
+                        Integer length = (Integer) cdataitems.get(position+1);
+                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),channel.intValue());
+
+                        short[] shortbuffer = new short[length];
+                        for(int loop = 0; loop < length; loop++){
+                            Short sample    = (Short) cdataitems.get(position+2+loop);
+                            shortbuffer[loop] = sample;
+                        }
+
+                        bank.addPulse(shortbuffer);
+                        bank.setTimeStamp(time);
+                        entries.add(bank);
+                        position += 2+length;
+                        counter++;
+                    }
+                }
+                return entries;
+
+            } catch (EvioException ex) {
+                ByteBuffer compBuffer = node.getByteData(true);
+                System.out.println("Exception in CRATE = " + crate + " LENGTH = " + compBuffer.array().length);
+                printByteBuffer(compBuffer, 120, 20);
+            }
+        }
+        return entries;
+    }
+
+    public static List<FADCData> getADCEntries_Tag(Integer crate, EvioNode node, EvioDataEvent event, int tagid){
+        List<FADCData>  entries = new ArrayList<>();
+        if(node.getTag()==tagid){
+            try {
+
+                ByteBuffer     compBuffer = node.getByteData(true);
+                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
+
+                List<DataType> cdatatypes = compData.getTypes();
+                List<Object>   cdataitems = compData.getItems();
+
+                if(cdatatypes.get(3) != DataType.NVALUE){
+                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
+                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
+                    return null;
+                }
+
+                int position = 0;
+
+                while(position<cdatatypes.size()-4){
+                    Byte    slot = (Byte)     cdataitems.get(position+0);
+                    //Integer trig = (Integer)  cdataitems.get(position+1);
+                    //Long    time = (Long)     cdataitems.get(position+2);
+
+                    Integer nchannels = (Integer) cdataitems.get(position+3);
+                    position += 4;
+                    int counter  = 0;
+                    while(counter<nchannels){
+                        Byte channel   = (Byte) cdataitems.get(position);
+                        Integer length = (Integer) cdataitems.get(position+1);
+                        FADCData   bank = new FADCData(crate,slot.intValue(),channel.intValue());
+                        short[] shortbuffer = new short[length];
+                        for(int loop = 0; loop < length; loop++){
+                            Short sample    = (Short) cdataitems.get(position+2+loop);
+                            shortbuffer[loop] = sample;
+                        }
+                        bank.setBuffer(shortbuffer);
+                        entries.add(bank);
+                        position += 2+length;
+                        counter++;
+                    }
+                }
+                return entries;
+
+            } catch (EvioException ex) {
+                ByteBuffer     compBuffer = node.getByteData(true);
+                System.out.println("Exception in CRATE = " + crate + " LENGTH = " + compBuffer.array().length);
+                printByteBuffer(compBuffer, 120, 20);
+            }
+        }
+        return entries;
+    }
+
+}

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CodaEventDecoder.java
@@ -1,17 +1,12 @@
 package org.jlab.detector.decode;
 
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.TreeMap;
 import org.jlab.coda.jevio.ByteDataTransformer;
-import org.jlab.coda.jevio.CompositeData;
 import org.jlab.coda.jevio.DataType;
-import org.jlab.coda.jevio.EvioException;
 import org.jlab.coda.jevio.EvioNode;
-import org.jlab.detector.decode.DetectorDataDgtz.ADCData;
 import org.jlab.detector.decode.DetectorDataDgtz.HelicityDecoderData;
 import org.jlab.detector.decode.DetectorDataDgtz.SCALERData;
 import org.jlab.detector.decode.DetectorDataDgtz.TDCData;
@@ -21,7 +16,6 @@ import org.jlab.io.evio.EvioDataEvent;
 import org.jlab.io.evio.EvioSource;
 import org.jlab.io.evio.EvioTreeBranch;
 import org.jlab.utils.data.DataUtils;
-
 import org.jlab.jnp.utils.json.JsonObject;
 
 /**
@@ -39,55 +33,14 @@ public class CodaEventDecoder {
     private byte helicityLevel3 = HelicityBit.UDF.value();
     private final List<Integer> triggerWords = new ArrayList<>();
     JsonObject  epicsData = new JsonObject();
+    TreeMap<Integer,EvioTreeBranch> branchMap = null;
 
     private int tiMaster = -1; 
 
     // FIXME:  move this to CCDB, e.g., meanwhile cannot reuse ROC id 
     private static final List<Integer> PCIE_ROCS = Arrays.asList(new Integer[]{78});
 
-    public CodaEventDecoder(){
-
-    }
-    /**
-     * returns detector digitized data entries from the event.
-     * all branches are analyzed and different types of digitized data
-     * is created for each type of ADC and TDC data.
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz> getDataEntries(EvioDataEvent event){
-        
-        //int event_size = event.getHandler().getStructure().getByteBuffer().array().length;
-        // This had been inserted to accommodate large EVIO events that
-        // were unreadable in JEVIO versions prior to 6.2:
-        //if(event_size>600*1024){
-        //    System.out.println("error: >>>> EVENT SIZE EXCEEDS 600 kB");
-        //    return new ArrayList<DetectorDataDgtz>();
-        //}
-        
-        // zero out the trigger bits, but let the others properties inherit
-        // from the previous event, in the case where there's no HEAD bank:
-        this.setTriggerBits(0);
-        List<DetectorDataDgtz>  rawEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        this.setTimeStamp(event);
-        for(EvioTreeBranch branch : branches){
-            List<DetectorDataDgtz>  list = this.getDataEntries(event,branch.getTag());
-            if(list != null){
-                rawEntries.addAll(list);
-            }
-        }
-        List<DetectorDataDgtz>  tdcEntries = this.getDataEntries_TDC(event);
-        rawEntries.addAll(tdcEntries);
-        List<DetectorDataDgtz>  vtpEntries = this.getDataEntries_VTP(event);
-        rawEntries.addAll(vtpEntries);
-        List<DetectorDataDgtz>  scalerEntries = this.getDataEntries_Scalers(event);
-        rawEntries.addAll(scalerEntries);
-
-        this.getDataEntries_EPICS(event);
-
-        return rawEntries;
-    }
+    public CodaEventDecoder(){}
 
     public JsonObject getEpicsData(){
         return this.epicsData;
@@ -95,17 +48,6 @@ public class CodaEventDecoder {
 
     public List<Integer> getTriggerWords(){
         return this.triggerWords;
-    }
-
-    private void printByteBuffer(ByteBuffer buffer, int max, int columns){
-        int n = max;
-        if(buffer.capacity()<max) n = buffer.capacity();
-        StringBuilder str = new StringBuilder();
-        for(int i = 0 ; i < n; i++){
-            str.append(String.format("%02X ", buffer.get(i)));
-            if( (i+1)%columns==0 ) str.append("\n");
-        }
-        System.out.println(str.toString());
     }
 
     public int getRunNumber(){
@@ -128,7 +70,127 @@ public class CodaEventDecoder {
         return this.helicityLevel3;
     }
 
-    public void setTimeStamp(EvioDataEvent event) {
+    public long getTriggerBits() {
+        return triggerBits;
+    }
+
+    public void setTriggerBits(long triggerBits) {
+        this.triggerBits = triggerBits;
+    }
+
+    /**
+     * Load map by crate. 
+     *
+     * @param event 
+     */
+    private void cacheBranches(EvioDataEvent event) {
+        branchMap = new TreeMap<>();
+        for (EvioTreeBranch branch : CodaDecoders.getEventBranches(event))
+            if (!branchMap.containsKey(branch.getTag()))
+                branchMap.put(branch.getTag(), branch);
+    }
+
+    /**
+     * returns detector digitized data entries from the event.
+     * all branches are analyzed and different types of digitized data
+     * is created for each type of ADC and TDC data.
+     * @param event
+     * @return
+     */
+    public List<DetectorDataDgtz> getDataEntries(EvioDataEvent event){
+
+        cacheBranches(event);
+        
+        //int event_size = event.getHandler().getStructure().getByteBuffer().array().length;
+        // This had been inserted to accommodate large EVIO events that
+        // were unreadable in JEVIO versions prior to 6.2:
+        //if(event_size>600*1024){
+        //    System.out.println("error: >>>> EVENT SIZE EXCEEDS 600 kB");
+        //    return new ArrayList<DetectorDataDgtz>();
+        //}
+        
+        // zero out the trigger bits, but let the others properties inherit
+        // from the previous event, in the case where there's no HEAD bank:
+        this.setTriggerBits(0);
+        List<DetectorDataDgtz>  rawEntries = new ArrayList<>();
+        this.setTimeStamp(event);
+        for(EvioTreeBranch branch : branchMap.values()){
+            List<DetectorDataDgtz>  list = this.getDataEntries(event,branch.getTag());
+            if(list != null){
+                rawEntries.addAll(list);
+            }
+        }
+        List<DetectorDataDgtz>  tdcEntries = this.getDataEntries_TDC(event);
+        rawEntries.addAll(tdcEntries);
+        List<DetectorDataDgtz>  vtpEntries = this.getDataEntries_VTP(event);
+        rawEntries.addAll(vtpEntries);
+        List<DetectorDataDgtz>  scalerEntries = this.getDataEntries_Scalers(event);
+        rawEntries.addAll(scalerEntries);
+
+        this.getDataEntries_EPICS(event);
+
+        return rawEntries;
+    }
+
+    /**
+     * returns list of decoded data in the event for given crate.
+     * @param event
+     * @param crate
+     * @return
+     */
+    private List<DetectorDataDgtz> getDataEntries(EvioDataEvent event, int crate){
+        List<DetectorDataDgtz>   bankEntries = new ArrayList<>();
+        EvioTreeBranch cbranch = branchMap.getOrDefault(crate, null);
+        if(cbranch == null ) return null;
+        for (EvioNode node : cbranch.getNodes()) {
+            if (node.getTag() == 57615) {
+                this.tiMaster = crate;
+                this.readHeaderBank(crate, node, event);
+            }
+        }
+        for(EvioNode node : cbranch.getNodes()){
+            switch (node.getTag()) {
+                case 57617:
+                    //  This is regular integrated pulse mode, used for FTOF/FTCAL/ECAL
+                    return CodaDecoders.getDataEntries_57617(crate, node, event);
+                case 57603:
+                    //  This is regular integrated pulse mode, used for streaming
+                    return CodaDecoders.getDataEntries_57603(crate, node, event);
+                case 57602:
+                    //  This is regular integrated pulse mode, used for FTOF/FTCAL/ECAL
+                    return CodaDecoders.getDataEntries_57602(crate, node, event);
+                case 57601:
+                    //  This is regular integrated pulse mode, used for FTOF/FTCAL/ECAL
+                    return CodaDecoders.getDataEntries_57601(crate, node, event);
+                case 57627:
+                    //  This is regular integrated pulse mode, used for MM
+                    return CodaDecoders.getDataEntries_57627(crate, node, event);
+                case 57640:
+                    //  This is bit-packed pulse mode, used for MM
+                    return CodaDecoders.getDataEntries_57640(crate, node, event);
+                case 57622:
+                    //  This is regular DCRB bank with TDCs only
+                    return CodaDecoders.getDataEntries_57622(crate, node, event);
+                case 57648:
+                    //  This is DCRB bank with TDCs and widths
+                    return CodaDecoders.getDataEntries_57648(crate, node, event);
+                case 57636:
+                    //  RICH TDC data
+                    return CodaDecoders.getDataEntries_57636(crate, node, event);
+                case 57657:
+                    //  ATOF Petiroc TDC data
+                    return CodaDecoders.getDataEntries_57657(crate, node, event);
+                case 57641:
+                    //  RTPC  data decoding
+                    return CodaDecoders.getDataEntries_57641(crate, node, event);
+                default:
+                    break;
+            }
+        }
+        return bankEntries;
+    }
+
+    private void setTimeStamp(EvioDataEvent event) {
 
         long ts = -1;
 
@@ -176,178 +238,7 @@ public class CodaEventDecoder {
         this.timeStamp = ts ;
     }
 
-    public long getTriggerBits() {
-        return triggerBits;
-    }
-
-    public void setTriggerBits(long triggerBits) {
-        this.triggerBits = triggerBits;
-    }
-
-    public List<FADCData> getADCEntries(EvioDataEvent event){
-        List<FADCData>  entries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
-            List<FADCData>  list = this.getADCEntries(event,branch.getTag());
-            if(list != null){
-                entries.addAll(list);
-            }
-        }
-        return entries;
-    }
-
-    public List<FADCData> getADCEntries(EvioDataEvent event, int crate){
-        List<FADCData>  entries = new ArrayList<>();
-
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
-
-        if(cbranch == null ) return null;
-
-        for(EvioNode node : cbranch.getNodes()){
-            if(node.getTag()==57638){
-                return this.getDataEntries_57638(crate, node, event);
-            }
-        }
-
-        return entries;
-    }
-
-    public List<FADCData> getADCEntries(EvioDataEvent event, int crate, int tagid){
-
-        List<FADCData>  adc = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
-        if(cbranch == null ) return null;
-
-        for(EvioNode node : cbranch.getNodes()){
-           if(node.getTag()==tagid){
-                //  This is regular integrated pulse mode, used for FTOF
-                // FTCAL and EC/PCAL
-                return this.getADCEntries_Tag(crate, node, event,tagid);
-            }
-        }
-        return adc;
-    }
-
-    /**
-     * returns list of decoded data in the event for given crate.
-     * @param event
-     * @param crate
-     * @return
-     */
-    public List<DetectorDataDgtz> getDataEntries(EvioDataEvent event, int crate){
-
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        List<DetectorDataDgtz>   bankEntries = new ArrayList<>();
-
-        EvioTreeBranch cbranch = this.getEventBranch(branches, crate);
-        if(cbranch == null ) return null;
-
-        for (EvioNode node : cbranch.getNodes()) {
-            if (node.getTag() == 57615) {
-                //  This is regular integrated pulse mode, used for FTOF
-                // FTCAL and EC/PCAL
-                this.tiMaster = crate;
-                this.readHeaderBank(crate, node, event);
-            }
-        }
-        for(EvioNode node : cbranch.getNodes()){
-
-            if(node.getTag()==57617){
-                //  This is regular integrated pulse mode, used for FTOF
-                // FTCAL and EC/PCAL
-                return this.getDataEntries_57617(crate, node, event);
-            }
-            else if(node.getTag()==57603){
-                //  This is regular integrated pulse mode, used for streaming
-                return this.getDataEntries_57603(crate, node, event);
-            }
-            else if(node.getTag()==57602){
-                //  This is regular integrated pulse mode, used for FTOF
-                // FTCAL and EC/PCAL
-                return this.getDataEntries_57602(crate, node, event);
-            }
-            else if(node.getTag()==57601){
-                //  This is regular integrated pulse mode, used for FTOF
-                // FTCAL and EC/PCAL
-                return this.getDataEntries_57601(crate, node, event);
-            }
-            else if(node.getTag()==57627){
-                //  This is regular integrated pulse mode, used for MM
-                return this.getDataEntries_57627(crate, node, event);
-            }
-            else if(node.getTag()==57640){
-                //  This is bit-packed pulse mode, used for MM
-                return this.getDataEntries_57640(crate, node, event);
-            }
-            else if(node.getTag()==57622){
-                //  This is regular DCRB bank with TDCs only
-                return this.getDataEntries_57622(crate, node, event);
-            }
-            else if(node.getTag()==57648){
-                //  This is DCRB bank with TDCs and widths
-                return this.getDataEntries_57648(crate, node, event);
-            }
-            else if(node.getTag()==57636){
-                //  RICH TDC data
-                return this.getDataEntries_57636(crate, node, event);
-            } else if (node.getTag() == 57657) {
-              //  ATOF Petiroc TDC data 
-              return this.getDataEntries_57657(crate, node, event);
-            } else if (node.getTag() == 57641) {
-              //  RTPC  data decoding
-              return this.getDataEntries_57641(crate, node, event);
-            }
-        }
-        return bankEntries;
-    }
-
-    /**
-     * Returns an array of the branches in the event.
-     * @param event
-     * @return
-     */
-    public List<EvioTreeBranch>  getEventBranches(EvioDataEvent event){
-        ArrayList<EvioTreeBranch>  branches = new ArrayList<>();
-        try {
-
-            List<EvioNode>  eventNodes = event.getStructureHandler().getNodes();
-            if(eventNodes==null){
-                return branches;
-            }
-
-            for(EvioNode node : eventNodes){
-                EvioTreeBranch eBranch = new EvioTreeBranch(node.getTag(),node.getNum());
-                List<EvioNode>  childNodes = node.getChildNodes();
-                if(childNodes!=null){
-                    for(EvioNode child : childNodes){
-                        eBranch.addNode(child);
-                    }
-                    branches.add(eBranch);
-                }
-            }
-
-        } catch (EvioException ex) {
-            Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-        }
-        return branches;
-    }
-    /**
-     * returns branch with with given tag
-     * @param branches
-     * @param tag
-     * @return
-     */
-    public EvioTreeBranch  getEventBranch(List<EvioTreeBranch> branches, int tag){
-        for(EvioTreeBranch branch : branches){
-            if(branch.getTag()==tag) return branch;
-        }
-        return null;
-    }
-
-    public void readHeaderBank(Integer crate, EvioNode node, EvioDataEvent event){
+    private void readHeaderBank(Integer crate, EvioNode node, EvioDataEvent event){
 
         if(node.getDataTypeObj()==DataType.INT32||node.getDataTypeObj()==DataType.UINT32){
             try {
@@ -376,865 +267,9 @@ public class CodaEventDecoder {
         }
     }
 
-    /**
-     * SVT decoding
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public ArrayList<DetectorDataDgtz>  getDataEntries_57617(Integer crate, EvioNode node, EvioDataEvent event){
-
-        ArrayList<DetectorDataDgtz>  rawdata = new ArrayList<>();
-
-        if(node.getTag()==57617){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-                List<Object>   cdataitems = compData.getItems();
-                int  totalSize = cdataitems.size();
-                int  position  = 0;
-                while( (position + 4) < totalSize){
-                    Byte    slot = (Byte)     cdataitems.get(position);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    int counter  = 0;
-                    position = position + 4;
-                    while(counter<nchannels){
-                        Byte   half    = (Byte) cdataitems.get(position);
-                        Byte   channel = (Byte) cdataitems.get(position+1);
-                        Byte   tdcbyte = (Byte) cdataitems.get(position+2);
-                        Short  tdc     = DataUtils.getShortFromByte(tdcbyte);
-                        Byte   adcbyte = (Byte)  cdataitems.get(position+3);
-
-                        // regular FSSR data entry
-                        int halfWord = DataUtils.getIntFromByte(half);
-                        int   chipID = DataUtils.getInteger(halfWord, 0, 2);
-                        int   halfID = DataUtils.getInteger(halfWord, 3, 3);
-                        int   adc    = adcbyte;
-                        //Integer channelKey = ((half<<8) | (channel & 0xff));
-
-                        // TDC data entry
-                        if(half == -128) {
-                            halfWord   = DataUtils.getIntFromByte(channel);
-                            halfID     = DataUtils.getInteger(halfWord, 2, 2);
-                            chipID     = DataUtils.getInteger(halfWord, 0, 1) + 1;
-                            channel    = 0;
-                            //channelKey = 0;
-                            tdc = (short) ((adcbyte<<8) | (tdcbyte & 0xff));
-                            adc = -1;
-                        }
-
-                        int channelID = halfID*10000 + chipID*1000 + channel;
-                        position += 4;
-                        counter++;
-                        DetectorDataDgtz entry = new DetectorDataDgtz(crate,slot,channelID);
-                        ADCData adcData = new ADCData();
-                        adcData.setIntegral(adc);
-                        adcData.setPedestal( (short) 0);
-                        adcData.setADC(0,0);
-                        adcData.setTime(tdc);
-                        adcData.setTimeStamp(time);
-                        entry.addADC(adcData);
-                        rawdata.add(entry);
-                    }
-                }
-
-            } catch (EvioException ex) {
-                //Logger.getLogger(EvioRawDataSource.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (IndexOutOfBoundsException ex){
-                //System.out.println("[ERROR] ----> ERROR DECODING COMPOSITE DATA FOR ONE EVENT");
-            }
-        }
-        return rawdata;
-    }
-
-    public List<FADCData>  getADCEntries_Tag(Integer crate, EvioNode node, EvioDataEvent event, int tagid){
-        List<FADCData>  entries = new ArrayList<>();
-        if(node.getTag()==tagid){
-            try {
-
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-
-                while(position<cdatatypes.size()-4){
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    //Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-                    while(counter<nchannels){
-                        Byte channel   = (Byte) cdataitems.get(position);
-                        Integer length = (Integer) cdataitems.get(position+1);
-                        FADCData   bank = new FADCData(crate,slot.intValue(),channel.intValue());
-                        short[] shortbuffer = new short[length];
-                        for(int loop = 0; loop < length; loop++){
-                            Short sample    = (Short) cdataitems.get(position+2+loop);
-                            shortbuffer[loop] = sample;
-                        }
-                        bank.setBuffer(shortbuffer);
-                        entries.add(bank);
-                        position += 2+length;
-                        counter++;
-                    }
-                }
-                return entries;
-
-            } catch (EvioException ex) {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                System.out.println("Exception in CRATE = " + crate + "  RUN = " + this.runNumber
-                + "  EVENT = " + this.eventNumber + " LENGTH = " + compBuffer.array().length);
-                this.printByteBuffer(compBuffer, 120, 20);
-            }
-        }
-        return entries;
-    }
-
-    /*
-    * 	<dictEntry name="FADC250 Window Raw Data (mode 1 packed)" tag="0xe126" num="0" type="composite">
-    * <description format="c,m(c,ms)">
-    *  c 	"slot number"
-    * m	"number of channels fired"
-    * c	"channel number"
-    * m	"number of shorts in packed array"
-    * s	"packed fadc data"
-    * </description>
-    * </dictEntry>
-    */
-    public void decodeComposite(ByteBuffer buffer, int offset, List<DataType> ctypes, List<Object> citems){
-        int position = offset;
-        int length   = buffer.capacity();
-        try {
-            while(position<(length-3)){
-                Short slot = (short) (0x00FF&(buffer.get(position)));
-                position++;
-                citems.add(slot);
-                ctypes.add(DataType.SHORT16);
-                Short counter =  (short) (0x00FF&(buffer.get(position)));
-                citems.add(counter);
-                ctypes.add(DataType.NVALUE);
-                position++;
-
-                for(int i = 0; i < counter; i++){
-                    Short channel = (short) (0x00FF&(buffer.get(position)));
-                    position++;
-                    citems.add(channel);
-                    ctypes.add(DataType.SHORT16);
-                    Short ndata = (short) (0x00FF&(buffer.get(position)));
-                    position++;
-                    citems.add(ndata);
-                    ctypes.add(DataType.NVALUE);
-                    for(int b = 0; b < ndata; b++){
-                        Short data = buffer.getShort(position);
-                        position+=2;
-                        citems.add(data);
-                        ctypes.add(DataType.SHORT16);
-                    }
-                }
-            }
-        } catch (Exception e){
-            System.out.println("Exception : Length = " + length + "  position = " + position);
-        }
-    }
-
-    public List<FADCData>  getDataEntries_57638(Integer crate, EvioNode node, EvioDataEvent event){
-        List<FADCData>  entries = new ArrayList<>();
-        if(node.getTag()==57638){
-            ByteBuffer     compBuffer = node.getByteData(true);
-            List<DataType> cdatatypes = new ArrayList<>();
-            List<Object>   cdataitems = new ArrayList<>();
-            this.decodeComposite(compBuffer, 24, cdatatypes, cdataitems);
-            
-            int position = 0;
-            
-            while(position<cdatatypes.size()-3){
-                Short       slot = (Short)       cdataitems.get(position+0);
-                Short  nchannels =  (Short) cdataitems.get(position+1);
-                
-                position += 2;
-                int     counter = 0;
-                while(counter<nchannels){
-                    Short   channel = (Short) cdataitems.get(position);
-                    Short   length  = (Short) cdataitems.get(position+1);
-                    position +=2;
-                    short[] shortbuffer = new short[length];
-                    for(int loop = 0; loop < length; loop++){
-                        Short sample    = (Short) cdataitems.get(position+loop);
-                        shortbuffer[loop] = sample;
-                    }
-                    position+=length;
-                    counter++;
-                    FADCData data = new FADCData(crate,slot,channel);
-                    data.setBuffer(shortbuffer);
-                    if(length>18) entries.add(data);
-                }
-            }
-        }
-        return entries;
-    }
-    
-    /**
-     * decoding bank in Mode 1 - full ADC pulse.
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57601(Integer crate, EvioNode node, EvioDataEvent event){
-        
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-        
-        if(node.getTag()==57601){
-            try {
-                
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-                
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-
-                while(position<cdatatypes.size()-4){
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-                    while(counter<nchannels){
-                        Byte channel   = (Byte) cdataitems.get(position);
-                        Integer length = (Integer) cdataitems.get(position+1);
-                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),channel.intValue());
-
-                        short[] shortbuffer = new short[length];
-                        for(int loop = 0; loop < length; loop++){
-                            Short sample    = (Short) cdataitems.get(position+2+loop);
-                            shortbuffer[loop] = sample;
-                        }
-
-                        bank.addPulse(shortbuffer);
-                        bank.setTimeStamp(time);
-                        entries.add(bank);
-                        position += 2+length;
-                        counter++;
-                    }
-                }
-                return entries;
-
-            } catch (EvioException ex) {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                System.out.println("Exception in CRATE = " + crate + "  RUN = " + this.runNumber
-                + "  EVENT = " + this.eventNumber + " LENGTH = " + compBuffer.array().length);
-                this.printByteBuffer(compBuffer, 120, 20);
-            }
-        }
-        return entries;
-    }
-
-    public List<DetectorDataDgtz>  getDataEntries_57627(Integer crate, EvioNode node, EvioDataEvent event){
-
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-
-        if(node.getTag()==57627){
-            try {
-
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-
-                while(position<cdatatypes.size()-4){
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-                    while(counter<nchannels){
-
-                        Short channel   = (Short) cdataitems.get(position);
-                        Integer length = (Integer) cdataitems.get(position+1);
-                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),channel.intValue());
-
-                        short[] shortbuffer = new short[length];
-                        for(int loop = 0; loop < length; loop++){
-                            Short sample    = (Short) cdataitems.get(position+2+loop);
-                            shortbuffer[loop] = sample;
-                        }
-                        //Added pulse fitting for MMs
-                        ADCData adcData = new ADCData();
-                        adcData.setTimeStamp(time);
-                        adcData.setPulse(shortbuffer);
-                        bank.addADC(adcData);
-                        entries.add(bank);
-                        position += 2+length;
-                        counter++;
-                    }
-                }
-                return entries;
-
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-    /**
-     * Decoding MicroMegas Packed Data
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57640(Integer crate, EvioNode node, EvioDataEvent event){
-        // Micromegas packed data
-        // ----------------------
-
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57640){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                int jdata = 0;  // item counter
-                for( int i = 0 ; i < cdatatypes.size();  ) { // loop over data types
-
-                	Byte CRATE      =  (Byte)cdataitems.get( jdata++ ); i++;
-                	Integer EV_ID   = (Integer)cdataitems.get( jdata++ ); i++;
-                	Long TIMESTAMP  =  (Long)cdataitems.get( jdata++ ); i++;
-                	Short nChannels =  (Short)cdataitems.get( jdata++ ); i++;
-
-                	for( int ch=0; ch<nChannels; ch++ ) {
-
-                    	Short CHANNEL = (Short)cdataitems.get( jdata++ ); i++;
-                    	int nBytes = (Byte)cdataitems.get( jdata++ ); i++;
-
-                    	DetectorDataDgtz bank = new DetectorDataDgtz(crate,CRATE.intValue(),CHANNEL.intValue());
-
-                    	int nSamples = nBytes*8/12;
-                    	short[] samples = new short[ nSamples ];
-
-                    	int s;
-                    	for( int b=0;b<nBytes;b++ ) {
-                    		short data = (short)((byte)cdataitems.get( jdata++ )&0xFF);
-
-                    		s = (int)Math.floor( b * 8./12. );
-                    		if( b%3 != 1) {
-                    			samples[s] += (short)data;
-                    		}
-                    		else {
-                    			samples[s] += (data&0x000F)<<8;
-                    			if( s+1 < nSamples ) samples[s+1] += ((data&0x00F0)>>4)<<8;
-                    		}
-
-                    	}
-                    	i++;
-
-                      ADCData adcData = new ADCData();
-                      adcData.setTimeStamp(TIMESTAMP);
-                      adcData.setPulse(samples);
-                      bank.addADC(adcData);
-                      entries.add(bank);
-                	} // end loop on channels
-                } // end loop on data types
-                return entries;
-
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-        /**
-     * Decoding MicroMegas Packed Data
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57641(Integer crate, EvioNode node, EvioDataEvent event){
-        // Micromegas packed data
-        // ----------------------
-
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57641){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                int jdata = 0;  // item counter
-                for( int i = 0 ; i < cdatatypes.size();  ) { // loop over data types
-
-                	Byte SLOT       =  (Byte)cdataitems.get( jdata++ ); i++;
-                	Integer EV_ID   =  (Integer)cdataitems.get( jdata++ ); i++;
-                	Long TIMESTAMP  =  (Long)cdataitems.get( jdata++ ); i++;
-                	Short nChannels =  (Short)cdataitems.get( jdata++ ); i++;
-
-                	for( int ch=0; ch<nChannels; ch++ ) {
-                    	Short CHANNEL = (Short)cdataitems.get( jdata++ ); i++;
-
-                        int nPulses = (Byte)cdataitems.get( jdata++ ); i++;
-                        for(int np = 0; np < nPulses; np++){
-
-                            int firstChannel = (Byte) cdataitems.get( jdata++ ); i++;
-
-                            int nBytes = (Byte)cdataitems.get( jdata++ ); i++;
-
-                            DetectorDataDgtz bank = new DetectorDataDgtz(crate,SLOT.intValue(),CHANNEL.intValue());
-
-                            int nSamples = nBytes*8/12;
-                            short[] samples = new short[ nSamples ];
-
-                            int s;
-                            for( int b=0;b<nBytes;b++ ) {
-                                short data = (short)((byte)cdataitems.get( jdata++ )&0xFF);
-
-                                s = (int)Math.floor( b * 8./12. );
-                                if( b%3 != 1) {
-                                    samples[s] += (short)data;
-                                }
-                                else {
-                                    samples[s] += (data&0x000F)<<8;
-                                    if( s+1 < nSamples ) samples[s+1] += ((data&0x00F0)>>4)<<8;
-                                }
-                            }
-                            i++;
-
-                            ADCData adcData = new ADCData();
-                            adcData.setTimeStamp(TIMESTAMP);
-                            adcData.setPulse(samples);
-                            adcData.setTime(firstChannel);
-                            bank.addADC(adcData);
-                            
-                            entries.add(bank);
-                        }
-                    } // end loop on channels
-                } // end loop on data types
-                return entries;
-
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-    /**
-     * Decoding MODE 7 data. for given crate.
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57602(Integer crate, EvioNode node, EvioDataEvent event){
-        List<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57602){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-                while((position+4)<cdatatypes.size()){
-
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-                    while(counter<nchannels){
-                        Byte channel   = (Byte) cdataitems.get(position);
-                        Integer length = (Integer) cdataitems.get(position+1);
-
-                        position += 2;
-                        for(int loop = 0; loop < length; loop++){
-                            Short tdc    = (Short) cdataitems.get(position);
-                            Integer adc  = (Integer) cdataitems.get(position+1);
-                            Short pmin   = (Short) cdataitems.get(position+2);
-                            Short pmax   = (Short) cdataitems.get(position+3);
-                            DetectorDataDgtz  entry = new DetectorDataDgtz(crate,slot,channel);
-                            ADCData   adcData = new ADCData();
-                            adcData.setIntegral(adc).setTimeWord(tdc).setPedestal(pmin).setHeight(pmax);
-                            entry.addADC(adcData);
-                            entry.setTimeStamp(time);
-                            entries.add(entry);
-                            position+=4;
-                        }
-                        counter++;
-                    }
-                }
-                return entries;
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-    /**
-     * Decoding MODE 7 data. for given crate.
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-//      <dictEntry name="FADC250 Pulse Integral Data (mode 3)" tag="0xe103" num="0" type="composite">
-//            <description format="c,i,l,N(c,N(s,i))">
-//                  c     "slot number" (8bit)
-//                  i     "trigger number" (32bit)
-//                  l     "time stamp" (64bit)
-//                  N     "number of channels fired" (32bit)
-//                  c     "channel number" (8bit)
-//                  N     "number of pulses" (32bit)
-//                  s     "tdc value" (16bit)
-//                  i     "adc value" (32bit)
-//            </description>
-//      </dictEntry>
-    public List<DetectorDataDgtz>  getDataEntries_57603(Integer crate, EvioNode node, EvioDataEvent event){
-        List<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57603){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-                while((position+4)<cdatatypes.size()){
-
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-                    while(counter<nchannels){
-                        Byte channel   = (Byte) cdataitems.get(position);
-                        Integer length = (Integer) cdataitems.get(position+1);
-
-                        position += 2;
-                        for(int loop = 0; loop < length; loop++){
-                            Short tdc    = (Short) cdataitems.get(position);
-                            Integer adc  = (Integer) cdataitems.get(position+1);
-                            DetectorDataDgtz  entry = new DetectorDataDgtz(crate,slot,channel);
-                            ADCData   adcData = new ADCData();
-                            adcData.setIntegral(adc).setTimeWord(tdc);
-                            entry.addADC(adcData);
-                            entry.setTimeStamp(time);
-                            entries.add(entry);
-                            position+=2;
-                        }
-                        counter++;
-                    }
-                }
-                return entries;
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-    /**
-     * Bank TAG=57622 used for DC (Drift Chambers) TDC values.
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57622(Integer crate, EvioNode node, EvioDataEvent event){
-        List<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57622){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-                //List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                int  totalSize = cdataitems.size();
-                int  position  = 0;
-                while( (position + 4) < totalSize){
-                    Byte    slot = (Byte)     cdataitems.get(position);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    int counter  = 0;
-                    position = position + 4;
-                    while(counter<nchannels){
-                        Byte   channel    = (Byte) cdataitems.get(position);
-                        Short  tdc     = (Short) cdataitems.get(position+1);
-                        position += 2;
-                        counter++;
-                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,channel);
-                        entry.addTDC(new TDCData(tdc));
-                        entry.setTimeStamp(time);
-                        entries.add(entry);
-                    }
-                }
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (IndexOutOfBoundsException ex){
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-
-        }
-        return entries;
-    }
-
-    /**
-     * Bank TAG=57648 used for DC (Drift Chambers) TDC and ToT values.
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57648(Integer crate, EvioNode node, EvioDataEvent event){
-        List<DetectorDataDgtz>  entries = new ArrayList<>();
-        if(node.getTag()==57648){
-            try {
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-                //List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                int  totalSize = cdataitems.size();
-                int  position  = 0;
-                while( (position + 4) < totalSize){
-                    Byte    slot = (Byte)     cdataitems.get(position);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    Long    time = (Long)     cdataitems.get(position+2);
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    int counter  = 0;
-                    position = position + 4;
-                    while(counter<nchannels){
-                        Byte   channel = (Byte) cdataitems.get(position);
-                        Short  tdc     = (Short) cdataitems.get(position+1);
-                        Short  tot     = (Short) cdataitems.get(position+2);
-                        position += 3;
-                        counter++;
-                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,channel);
-                        entry.addTDC(new TDCData(tdc, tot));
-                        entry.setTimeStamp(time);
-                        entries.add(entry);
-                    }
-                }
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            } catch (IndexOutOfBoundsException ex){
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-
-        }
-        return entries;
-    }
-
-    /**
-     * Bank TAG=57636 used for RICH TDC values
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57636(Integer crate, EvioNode node, EvioDataEvent event){
-
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-
-        if(node.getTag()==57636){
-            try {
-
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-                while(position<cdatatypes.size()-4){
-                    Byte    slot = (Byte)     cdataitems.get(position+0);
-                    //Integer trig = (Integer)  cdataitems.get(position+1);
-                    //Long    time = (Long)     cdataitems.get(position+2);
-
-                    Integer nchannels = (Integer) cdataitems.get(position+3);
-                    position += 4;
-                    int counter  = 0;
-
-                    while(counter<nchannels){
-                        Integer fiber = ((Byte) cdataitems.get(position))&0xFF;
-                        Integer channel = ((Byte) cdataitems.get(position+1))&0xFF;
-                        Short rawtdc = (Short) cdataitems.get(position+2);
-                        int edge = (rawtdc>>15)&0x1;
-                        int tdc = rawtdc&0x7FFF;
-
-                        DetectorDataDgtz bank = new DetectorDataDgtz(crate,slot.intValue(),2*(fiber*192+channel)+edge);
-                        bank.addTDC(new TDCData(tdc));
-
-                        entries.add(bank);
-                        position += 3;
-                        counter++;
-                    }
-                }
-
-                return entries;
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-    /**
-     * Bank TAG=57657 used for ATOF PETIROC TDC values
-     * @param crate
-     * @param node
-     * @param event
-     * @return
-     *
-     * <dictEntry name="PETIROC Composite Data" tag="0xe139" num="0" type="composite">
-     *           <description format="c,i,l,N(c,i,i)">
-     *                       c   "slot number"
-     *                       i   "trigger number"
-     *                       l   "time stamp"
-     *                       N   "number of channels fired"
-     *                       c   "channel number"
-     *                       i   "tdc value"
-     *                       i   "width value"
-     *        </description>
-     * </dictEntry>
-     */
-    public List<DetectorDataDgtz>  getDataEntries_57657(Integer crate, EvioNode node, EvioDataEvent event){
-
-        ArrayList<DetectorDataDgtz>  entries = new ArrayList<>();
-
-        if(node.getTag()==57657){
-            try {
-                //System.err.println("Decoding ATOF PETIROC event!");
-                ByteBuffer     compBuffer = node.getByteData(true);
-                CompositeData  compData = new CompositeData(compBuffer.array(),event.getByteOrder());
-
-                List<DataType> cdatatypes = compData.getTypes();
-                List<Object>   cdataitems = compData.getItems();
-
-                if(cdatatypes.get(3) != DataType.NVALUE){
-                    System.err.println("[EvioRawDataSource] ** error ** corrupted "
-                    + " bank. tag = " + node.getTag() + " num = " + node.getNum());
-                    return null;
-                }
-
-                int position = 0;
-                while(position<cdatatypes.size()-4){
-                    Byte    slot       = (Byte)     cdataitems.get(position+0);
-                    Integer trig_num   = (Integer)  cdataitems.get(position+1);
-                    Long    time_stamp = (Long)    cdataitems.get(position+2);
-                    Integer nchannels  = (Integer) cdataitems.get(position+3);
-                    int     counter    = 0;
-
-                    position += 4; // slot, trig,time,nchannels
-                                   //
-                    while(counter<nchannels){
-                        Byte channel = (Byte) cdataitems.get(position+0);
-                        Integer tdc = (Integer) cdataitems.get(position+1);
-                        // width over threshold
-                        Integer tot = (Integer) cdataitems.get(position+2);
-
-                        DetectorDataDgtz bank = new DetectorDataDgtz(
-                            crate, slot.intValue(), channel.intValue());
-                        // the "bank" has a timestamp.
-                        // the tdc also can have a timestamp.
-                        // the tdc is added tot he "bank"
-                        // the "bank" is added to the "entries" (array of DetectorDataDgtz)
-                        // "entries" List<DetectorDataDgtz>  -> "bank" DetectorDataDgtz  -> "tdc" TDCData
-                        // there is a redundancy in timestamp: the same value is stored in TDCData and the DetectorDataDgz
-                        //
-                        bank.setTimeStamp(time_stamp);
-                        bank.setTrigger(trig_num);;
-                        TDCData tdc_data = new TDCData(tdc, tot);
-                        tdc_data.setTimeStamp(time_stamp).setOrder(counter);
-                        bank.addTDC(tdc_data);
-                        entries.add(bank);
-                        position += 3; // channel,tdc,tot
-                        counter++;
-                        //System.err.println("event: " + bank.toString());
-                    }
-                }
-
-                return entries;
-            } catch (EvioException ex) {
-                Logger.getLogger(CodaEventDecoder.class.getName()).log(Level.SEVERE, null, ex);
-            }
-        }
-        return entries;
-    }
-
-
-
-    public void getDataEntries_EPICS(EvioDataEvent event){
+    private void getDataEntries_EPICS(EvioDataEvent event){
         epicsData = new JsonObject();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchMap.values()){
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57620) {
                     byte[] stringData =  ByteDataTransformer.toByteArray(node.getStructureBuffer(true));
@@ -1260,8 +295,7 @@ public class CodaEventDecoder {
 
     public HelicityDecoderData getDataEntries_HelicityDecoder(EvioDataEvent event){
         HelicityDecoderData data = null;
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
+        for(EvioTreeBranch branch : branchMap.values()){
             for(EvioNode node : branch.getNodes()){
                 if(node.getTag()==57651) {
                     
@@ -1338,13 +372,11 @@ public class CodaEventDecoder {
         return data;
     }
 
-    public List<DetectorDataDgtz> getDataEntries_Scalers(EvioDataEvent event){
+    private List<DetectorDataDgtz> getDataEntries_Scalers(EvioDataEvent event){
 
         List<DetectorDataDgtz> scalerEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
-            int  crate = branch.getTag();
-            for(EvioNode node : branch.getNodes()){
+        for(int crate : branchMap.keySet()) {
+            for(EvioNode node : branchMap.get(crate).getNodes()){
                 if(node.getTag()==57637 || node.getTag()==57621){
                     int num = node.getNum();
                     int[] intData =  ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
@@ -1418,72 +450,16 @@ public class CodaEventDecoder {
         return scalerEntries;
     }
 
-    public List<DetectorDataDgtz> getDataEntries_VTP(EvioDataEvent event){
-
-        List<DetectorDataDgtz> vtpEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
-            int  crate = branch.getTag();
-            for(EvioNode node : branch.getNodes()){
-                if(node.getTag()==57634){
-                    int[] intData =  ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
-                    for(int loop = 0; loop < intData.length; loop++){
-                        int  dataEntry = intData[loop];
-                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,0,0);
-                        entry.addVTP(new VTPData(dataEntry));
-                        vtpEntries.add(entry);
-                    }
-                }
-            }
-        }
-        return vtpEntries;
-    }
-    /**
-     * reads the TDC values from the bank with tag = 57607, decodes
-     * them and returns a list of digitized detector object.
-     * @param event
-     * @return
-     */
-    public List<DetectorDataDgtz>  getDataEntries_TDC(EvioDataEvent event){
-
-        List<DetectorDataDgtz> tdcEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-
-        for(EvioTreeBranch branch : branches){
-            int  crate = branch.getTag();
-            EvioTreeBranch cbranch = this.getEventBranch(branches, branch.getTag());
-            for(EvioNode node : cbranch.getNodes()){
-                if(node.getTag()==57607){
-                    int[] intData = ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
-                    for(int loop = 2; loop < intData.length; loop++){
-                        int  dataEntry = intData[loop];
-                        int  slot      = DataUtils.getInteger(dataEntry, 27, 31 );
-                        int  chan      = DataUtils.getInteger(dataEntry, 19, 25);
-                        int  value     = DataUtils.getInteger(dataEntry,  0, 18);
-                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,chan);
-                        entry.addTDC(new TDCData(value));
-                        tdcEntries.add(entry);
-                    }
-                }
-            }
-        }
-        return tdcEntries;
-    }
-
-
     /**
      * decoding bank that contains TI time stamp.
      * @param event
      * @return
      */
-    public List<DetectorDataDgtz>  getDataEntries_TI(EvioDataEvent event){
+    private List<DetectorDataDgtz>  getDataEntries_TI(EvioDataEvent event){
 
         List<DetectorDataDgtz> tiEntries = new ArrayList<>();
-        List<EvioTreeBranch> branches = this.getEventBranches(event);
-        for(EvioTreeBranch branch : branches){
-            int  crate = branch.getTag();
-            EvioTreeBranch cbranch = this.getEventBranch(branches, branch.getTag());
-            for(EvioNode node : cbranch.getNodes()){
+        for(int crate : branchMap.keySet()) {
+            for(EvioNode node : branchMap.get(crate).getNodes()){
                 if(node.getTag()==57610){
                     long[] longData = ByteDataTransformer.toLongArray(node.getStructureBuffer(true));
                     int[]  intData  = ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
@@ -1515,6 +491,72 @@ public class CodaEventDecoder {
         }
 
         return tiEntries;
+    }
+
+    private List<DetectorDataDgtz> getDataEntries_VTP(EvioDataEvent event){
+        List<DetectorDataDgtz> vtpEntries = new ArrayList<>();
+        for(int crate : branchMap.keySet()) {
+            for(EvioNode node : branchMap.get(crate).getNodes()){
+                if(node.getTag()==57634){
+                    int[] intData =  ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
+                    for(int loop = 0; loop < intData.length; loop++){
+                        int  dataEntry = intData[loop];
+                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,0,0);
+                        entry.addVTP(new VTPData(dataEntry));
+                        vtpEntries.add(entry);
+                    }
+                }
+            }
+        }
+        return vtpEntries;
+    }
+
+    /**
+     * reads the TDC values from the bank with tag = 57607, decodes
+     * them and returns a list of digitized detector object.
+     * @param event
+     * @return
+     */
+    private List<DetectorDataDgtz>  getDataEntries_TDC(EvioDataEvent event){
+        List<DetectorDataDgtz> tdcEntries = new ArrayList<>();
+        for(int crate : branchMap.keySet()) {
+            for(EvioNode node : branchMap.get(crate).getNodes()){
+                if(node.getTag()==57607){
+                    int[] intData = ByteDataTransformer.toIntArray(node.getStructureBuffer(true));
+                    for(int loop = 2; loop < intData.length; loop++){
+                        int  dataEntry = intData[loop];
+                        int  slot      = DataUtils.getInteger(dataEntry, 27, 31 );
+                        int  chan      = DataUtils.getInteger(dataEntry, 19, 25);
+                        int  value     = DataUtils.getInteger(dataEntry,  0, 18);
+                        DetectorDataDgtz   entry = new DetectorDataDgtz(crate,slot,chan);
+                        entry.addTDC(new TDCData(value));
+                        tdcEntries.add(entry);
+                    }
+                }
+            }
+        }
+        return tdcEntries;
+    }
+
+    public List<FADCData> getADCEntries(EvioDataEvent event){
+        List<FADCData>  entries = new ArrayList<>();
+        for(EvioTreeBranch branch : branchMap.values()){
+            List<FADCData>  list = this.getADCEntries(event,branch.getTag());
+            if (list != null) entries.addAll(list);
+        }
+        return entries;
+    }
+
+    private List<FADCData> getADCEntries(EvioDataEvent event, int crate){
+        List<FADCData>  entries = new ArrayList<>();
+        EvioTreeBranch cbranch = branchMap.getOrDefault(crate, null);
+        if(cbranch == null ) return null;
+        for(EvioNode node : cbranch.getNodes()){
+            if(node.getTag()==57638){
+                return CodaDecoders.getDataEntries_57638(crate, node, event);
+            }
+        }
+        return entries;
     }
 
     public static void main(String[] args){


### PR DESCRIPTION
Note, this changes the row-ordering in many raw HIPO banks, now sorted by crate.  That change can be ignored with  `hipo-diff`'s new sorting option.

_That crate number currently exists only in the online CODA database (and resulting EVIO/HIPO files)._

_Note, this was a component of #1051._