### PR TITLE
fix: reduce string comparisons in ADC decoding, cleanup

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -28,6 +28,7 @@ public class DetectorEventDecoder {
     List<DetectorType> keysTrans    = null;
     List<DetectorType> keysFitter   = null;
     List<DetectorType> keysFilter   = null;
+    List<DetectorType> keysMicromega= null;
 
     private int runNumber = 10;
 
@@ -128,7 +129,9 @@ public class DetectorEventDecoder {
 
         scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp",
                                                       "/runcontrol/helicity","/daq/config/scalers/dsc1"}));
-        
+
+        keysMicromega = Arrays.asList(new DetectorType[]{DetectorType.BMT,DetectorType.FMT,DetectorType.FTTRK});
+
         checkTables();
     }
 
@@ -175,69 +178,63 @@ public class DetectorEventDecoder {
         }
 
         for(DetectorDataDgtz data : detectorData){
+            if (data.getADCSize() == 0) continue;
             int crate    = data.getDescriptor().getCrate();
             int slot     = data.getDescriptor().getSlot();
             int channel  = data.getDescriptor().getChannel();
             long hash    = IndexedTable.DEFAULT_GENERATOR.hashCode(crate,slot,channel);
             long hash0   = IndexedTable.DEFAULT_GENERATOR.hashCode(0,0,0);
+            boolean ismm = keysMicromega.contains(data.getDescriptor().getType());
+
             for (int j=0; j<keysFitter.size(); ++j) {
                 IndexedTable daq = tables.get(j);
                 DetectorType type = keysFitter.get(j);
                 //custom MM fitter
-            	if( ( (type == DetectorType.BMT)&&(data.getDescriptor().getType().getName().equals("BMT")) )
-                 || ( (type == DetectorType.FMT)&&(data.getDescriptor().getType().getName().equals("FMT")) )
-                 //|| ( (type == DetectorType.AHDC)&&(data.getDescriptor().getType().getName().equals("AHDC")) )
-                 || ( (type == DetectorType.FTTRK)&&(data.getDescriptor().getType().getName().equals("FTTRK")) ) ){
+                if (ismm && data.getDescriptor().getType() == type) {
                     short adcOffset = (short) daq.getDoubleValueByHash("adc_offset", hash0);
                     double fineTimeStampResolution = (byte) daq.getDoubleValueByHash("dream_clock", hash0);
                     double samplingTime = (byte) daq.getDoubleValueByHash("sampling_time", hash0);
                     int sparseSample = daq.getIntValueByHash("sparse", hash0);
-                    if (data.getADCSize() > 0) {
-                        ADCData adc = data.getADCData(0);
-                        mvtFitter.fit(adcOffset, fineTimeStampResolution, samplingTime, adc.getPulseArray(), adc.getTimeStamp(), sparseSample);
-                        adc.setHeight((short) (mvtFitter.adcMax));
-                        adc.setTime((int) (mvtFitter.timeMax));
-                        adc.setIntegral((int) (mvtFitter.integral));
-                        adc.setTimeStamp(mvtFitter.timestamp);
+                    ADCData adc = data.getADCData(0);
+                    mvtFitter.fit(adcOffset, fineTimeStampResolution, samplingTime, adc.getPulseArray(), adc.getTimeStamp(), sparseSample);
+                    adc.setHeight((short) (mvtFitter.adcMax));
+                    adc.setTime((int) (mvtFitter.timeMax));
+                    adc.setIntegral((int) (mvtFitter.integral));
+                    adc.setTimeStamp(mvtFitter.timestamp);
+                    // first one wins:
+                    break;
+                }
+                else if(daq.hasEntryByHash(hash)==true){
+                    int nsa = daq.getIntValueByHash("nsa", hash);
+                    int nsb = daq.getIntValueByHash("nsb", hash);
+                    int tet = daq.getIntValueByHash("tet", hash);
+                    int ped = 0;
+                    if(data.getDescriptor().getType() == DetectorType.RF && type == DetectorType.RF) {
+                        ped = daq.getIntValueByHash("pedestal", hash);
                     }
-                } else {
-                    if(daq.hasEntryByHash(hash)==true){
-                        int nsa = daq.getIntValueByHash("nsa", hash);
-                        int nsb = daq.getIntValueByHash("nsb", hash);
-                        int tet = daq.getIntValueByHash("tet", hash);
-                        int ped = 0;
-                        if(type == DetectorType.RF&&data.getDescriptor().getType().getName().equals("RF")) {
-                            ped = daq.getIntValueByHash("pedestal", hash);
-                        }
-                        if(data.getADCSize()>0){
-                            for(int i = 0; i < data.getADCSize(); i++){
-                                ADCData adc = data.getADCData(i);
-                                if(adc.getPulseSize()>0){
-                                    try {
-                                        extendedFitter.fit(nsa, nsb, tet, ped, adc.getPulseArray());
-                                    } catch (Exception e) {
-                                        System.out.println(">>>> error : fitting pulse "
-                                                            +  crate + " / " + slot + " / " + channel);
-                                    }
-                                    int adc_corrected = extendedFitter.adc + extendedFitter.ped*(nsa+nsb);
-                                    adc.setHeight((short) this.extendedFitter.pulsePeakValue);
-                                    adc.setIntegral(adc_corrected);
-                                    adc.setTimeWord(this.extendedFitter.t0);
-                                    adc.setPedestal((short) this.extendedFitter.ped);
-                                }
+                    for(int i = 0; i < data.getADCSize(); i++){
+                        ADCData adc = data.getADCData(i);
+                        if(adc.getPulseSize()>0){
+                            try {
+                                extendedFitter.fit(nsa, nsb, tet, ped, adc.getPulseArray());
+                            } catch (Exception e) {
+                                System.out.println(">>>> error : fitting pulse "
+                                    +  crate + " / " + slot + " / " + channel);
                             }
+                            int adc_corrected = extendedFitter.adc + extendedFitter.ped*(nsa+nsb);
+                            adc.setHeight((short) this.extendedFitter.pulsePeakValue);
+                            adc.setIntegral(adc_corrected);
+                            adc.setTimeWord(this.extendedFitter.t0);
+                            adc.setPedestal((short) this.extendedFitter.ped);
                         }
-                        if(data.getADCSize()>0){
-                            for(int i = 0; i < data.getADCSize(); i++){
-                                    data.getADCData(i).setADC(nsa, nsb);
-                            }
-                        }
+                        data.getADCData(i).setADC(nsa, nsb);
                     }
+                    // first one wins:
+                    break;
                 }
             }
         }
     }
-
 
     public void filterTDCs(List<DetectorDataDgtz>  detectorData){
         int maxMultiplicity = 1;


### PR DESCRIPTION
Note, this assumes unique `crate/slot/channel` in all `/daq/fadc` CCDB tables.  Now, the first match wins.  Previously the last match won.  For run 5038, the `RF/LTCC::adc` banks have a resulting difference, which will be addressed by fixing CCDB tables to be unique.

_Note, this was a component of #1051._