### PR TITLE
feat:  increase run-clara JVM memory requests

### DIFF
--- a/bin/run-clara
+++ b/bin/run-clara
@@ -54,7 +54,7 @@ inputs=$@
 # Configure JVM memory settings (overridedable via $JAVA_OPTS):
 gb_init=$((threads))
 gb_max=$((threads+2))
-[ $threads -gt 1 ] && ! [ -z ${large+x} ] gb_max=$((threads*2))
+[ $threads -gt 1 ] && ! [ -z ${large+x} ] && gb_max=$((threads*2))
 java_opts="-Xms${gb_init}g -Xmx${gb_max}g"
 
 # Check configuration:

--- a/bin/run-clara
+++ b/bin/run-clara
@@ -52,14 +52,9 @@ shift $((OPTIND-1))
 inputs=$@
 
 # Configure JVM memory settings (overridedable via $JAVA_OPTS):
-if [ -z ${large+x} ]
-then
-    gb_max=$((threads<3?threads+2:threads+2-threads/4))
-    gb_init=$((threads<3?threads:threads-threads/3))
-else
-    gb_max=$((threads<3?threads+2:threads+2-threads/8))
-    gb_init=$((threads<3?threads:threads-threads/6))
-fi
+gb_init=$((threads))
+gb_max=$((threads+2))
+[ $threads -gt 1 ] && ! [ -z ${large+x} ] gb_max=$((threads*2))
 java_opts="-Xms${gb_init}g -Xmx${gb_max}g"
 
 # Check configuration:


### PR DESCRIPTION
Simpler calculation, more inline with present hardware:

| Threads | `-Xxms` (GB) | `-Xxmx` (GB) |  large `-Xxmx` (GB) |
| :-: | :-: | :-: | :-: |
| N | N | N+2 | N<2 ? N+2 : N*2 |
| 1 | 1 | 3 | 3 |
| 2 | 2 | 4 | 4 |
| 3 | 3 | 5 | 6 |
| 4 | 4 | 6 | 8 |
| ... | ... | ... | ... |
| 8 | 8 | 10 | 16 |
| 16 | 16 | 18 | 32 |
| ... | ... | ... | ... |