### PR TITLE
use schema directory in dst-maker

### DIFF
--- a/bin/dst-maker
+++ b/bin/dst-maker
@@ -1,32 +1,10 @@
-#!/bin/sh
+#!/bin/bash
 
-usage="\nUsage: dst-maker -o outputfile inputfile [inputfile [...]]\n"
+. `dirname $0`/../libexec/env.sh
 
-if [ "$#" -lt 3 ]; then
-  echo -e $usage
-  exit
-elif [ "$1" != "-o" ]; then
-  echo -e $usage
-  exit
-elif [ -e $2 ]; then
-  echo -e $usage
-  echo File already exists: $2
-  exit
-else
-  for x in ${@:3}
-  do
-    if ! [ -e $x ]; then
-      echo -e $usage
-      echo File does not exist: $x
-      exit
-    fi
-  done
-fi
+export MALLOC_ARENA_MAX=1
 
-hipo-utils \
- -filter \
- -b 'RUN::*,RAW::epics,RAW::scaler,HEL::flip,HEL::online,REC::*,RECFT::*,MC::*' \
- -merge \
- -o $2 \
- ${@:3}
-
+java ${JAVA_OPTS-} -Xmx1280m -Xms768m -XX:+UseSerialGC \
+    -cp ${COATJAVA_CLASSPATH:-''} \
+    org.jlab.io.utils.DstMaker \
+    $*

--- a/common-tools/clas-io/src/main/java/org/jlab/io/utils/DstMaker.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/utils/DstMaker.java
@@ -1,0 +1,58 @@
+package org.jlab.io.utils;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.jlab.io.base.DataEvent;
+import org.jlab.io.hipo.HipoDataSource;
+import org.jlab.io.hipo.HipoDataSync;
+import org.jlab.jnp.hipo4.data.SchemaFactory;
+import org.jlab.utils.options.OptionParser;
+import org.jlab.utils.system.ClasUtilsFile;
+
+public class DstMaker {
+   
+    public static void main(String args[]) {
+
+        OptionParser opt = new OptionParser("dst-maker");
+        opt.addOption("-s","dst","schema path, or stock schema name (default=dst)");
+        opt.addRequired("-o","output file");
+        opt.setRequiresInputList(true);
+        opt.parse(args);
+
+        HipoDataSync w = new HipoDataSync();
+        w.setCompressionType(2);
+
+        SchemaFactory schema = new SchemaFactory();
+        String stock = ClasUtilsFile.getResourceDir("CLAS12DIR","etc/bankdefs/hipo4/singles");
+        String user = opt.getOption("-s").stringValue();
+        if (Files.isDirectory((new File(stock+"/"+user)).toPath())) {
+            System.out.println("Assuming -s is a stock schema:  "+user);
+            schema.initFromDirectory(stock+"/"+user);
+        }
+        else if (Files.isDirectory((new File(user)).toPath())) {
+            System.out.println("Assuming -s is a schema path:  "+user);
+            schema.initFromDirectory(user);
+        }
+        else {
+            System.err.println("Unable to initialize schema from -s "+user);
+            System.exit(2);
+        }
+        w.open(opt.getOption("-o").stringValue());
+
+        for (String input : opt.getInputList()) {
+            HipoDataSource r = new HipoDataSource();
+            r.open(input);
+            while (r.hasEvent()) {
+                DataEvent e = r.getNextEvent();
+                for (String name : e.getBankList()) {
+                    if (!schema.hasSchema(name)) {
+                        e.removeBank(name);
+                    }
+                }
+                w.writeEvent(e);
+            }
+            r.close();
+        }
+        w.close();
+    }
+}

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/reco/EngineProcessor.java
@@ -312,7 +312,6 @@ public class EngineProcessor {
             progress.updateStatus();
         }
         progress.showStatus();
-        writer.close();
     }
 
     public void processFile(EvioSource reader, HipoDataSync writer, int skipEvents, int maxEvents) {
@@ -335,7 +334,6 @@ public class EngineProcessor {
             progress.updateStatus();
         }
         progress.showStatus();
-        writer.close();
     }
 
     /**}
@@ -360,6 +358,7 @@ public class EngineProcessor {
             writer.open(output);
             processFile(reader, writer, nskip, nevents);
         }
+        writer.close();
     }
 
     /**


### PR DESCRIPTION
This replaces the `bin/dst-maker` shell script, which was just `hipo-utils` with a hard-coded bank list, with Java that  defaults to the path of the stock `dst` schema and option to specify another stock schema or absolute schema path.