### PR TITLE
build: automate dependency analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,27 +303,6 @@ jobs:
       - name: test run-groovy
         run: coatjava/bin/run-groovy validation/advanced-tests/test-run-groovy.groovy
 
-  dependency_analysis:
-    needs: [ build ]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up JDK
-        uses: actions/setup-java@v5
-        with:
-          java-version: ${{ env.JAVA_VERSION }}
-          distribution: ${{ env.java_distribution }}
-          cache: maven
-      - uses: actions/download-artifact@v7
-        with:
-          name: build_ubuntu-latest
-      - name: untar build
-        run: tar xzvf coatjava.tar.gz
-      - name: print dependency tree
-        run: libexec/dependency-tree.sh
-      - name: dependency analysis
-        run: libexec/dependency-analysis.sh
-
   # documentation
   #############################################################################
 
@@ -413,7 +392,6 @@ jobs:
   final:
     needs:
       - test_coatjava
-      - dependency_analysis
       - test_run-groovy
       - generate_documentation
     runs-on: ubuntu-latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -60,13 +60,6 @@ build:
       - coatjava.tar.gz
       - clara.tar.gz
 
-.depana:
-  allow_failure: true
-  stage: build
-  script:
-    - libexec/dependency-tree.sh
-    - libexec/dependency-analysis.sh
-
 download:
   stage: build
   script:

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -10,7 +10,6 @@ set -o pipefail
 ################################################################################
 
 cleanBuild=false
-anaDepends=false
 runSpotBugs=false
 downloadMaps=true
 downloadNets=true
@@ -46,7 +45,6 @@ DATA RETRIEVAL OPTIONS
 TESTING OPTIONS
     --spotbugs        also run spotbugs plugin
     --unittests       also run unit tests
-    --depana          run dependency analysis (only)
     --data            download test data (requires option `--lfs`)
 
 MAVEN OPTIONS
@@ -70,7 +68,10 @@ do
     --nonets)    downloadNets=false ;;
     --unittests) runUnitTests=true  ;;
     --clean)     cleanBuild=true    ;;
-    --depana)    anaDepends=true    ;;
+    --depana)
+      echo "ERROR: option \`$xx\` has been removed; dependency tree printout and analysis now happen automatically in the Maven build lifecycle" >&2
+      exit 1
+      ;;
     --quiet)
       mvnArgs+=(--quiet --batch-mode)
       wgetArgs+=(--quiet)
@@ -86,7 +87,7 @@ do
     --clara) installClara=true   ;;
     --data)  downloadData=true   ;;
     --xrootd)
-      echo "ERROR: option \`$xx\` is deprecated; use \`--help\` for guidance" >&2
+      echo "ERROR: option \`$xx\` has been removed; use \`--help\` for guidance" >&2
       exit 1
       ;;
     -h|--help)
@@ -147,13 +148,6 @@ if $cleanBuild || [ "$dataRetrieval" = "wipe" ]; then
   [ "$dataRetrieval" = "wipe" ] && echo "[+] REMOVED RETRIEVED DATA" || echo "[+] NOTE: retrieved data not removed; use \`--wipe\` if you need to remove them"
   $cleanBuild && echo "[+] DONE CLEANING; rerun without \`--clean\` to build"
   exit
-fi
-
-# run dependency analysis and exit
-if $anaDepends; then
-  libexec/dependency-analysis.sh
-  libexec/dependency-tree.sh
-  exit 0
 fi
 
 

--- a/common-tools/coat-libs/pom.xml
+++ b/common-tools/coat-libs/pom.xml
@@ -257,6 +257,15 @@
         <artifactId>maven-deploy-plugin</artifactId>
       </plugin>
 
+      <!-- no need for dependency analysis for this shaded JAR -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/libexec/dependency-analysis.sh
+++ b/libexec/dependency-analysis.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-# analyze maven dependencies
-# NOTE: skips `coat-libs`, since shaded JAR dependencies are "unused" according to `dependency:analyze`
-set -euo pipefail
-mvn dependency:analyze -DfailOnWarning=true -pl '!org.jlab.coat:coat-libs' --no-transfer-progress

--- a/libexec/dependency-tree.sh
+++ b/libexec/dependency-tree.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# print the maven dependency tree
-set -euo pipefail
-mvn dependency:tree -Ddetail=true --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -251,6 +251,7 @@
 
     <plugins> <!-- plugins inherited by all child POMs -->
 
+      <!-- static analysis -->
       <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
@@ -260,6 +261,7 @@
         </configuration>
       </plugin>
 
+      <!-- documentation generation -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
@@ -280,6 +282,7 @@
         </executions>
       </plugin>
 
+      <!-- general settings -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -289,7 +292,6 @@
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
@@ -299,6 +301,7 @@
         </configuration>
       </plugin>
 
+      <!-- JAR -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
@@ -323,6 +326,33 @@
         </configuration>
       </plugin>
 
+      <!-- dependency analysis -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.10.0</version>
+        <executions>
+          <execution>
+            <id>analyze</id>
+            <goals>
+              <goal>analyze-only</goal>
+            </goals>
+            <configuration>
+              <failOnWarning>true</failOnWarning>
+              <!-- ignore certain "unused but declared" warnings -->
+              <ignoredUnusedDeclaredDependencies>
+                <ignoredUnusedDeclaredDependency>ai.djl:model-zoo</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-model-zoo</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-engine</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-native-cpu</ignoredUnusedDeclaredDependency>
+                <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-jni</ignoredUnusedDeclaredDependency>
+              </ignoredUnusedDeclaredDependencies>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- dependency convergence -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
@@ -347,6 +377,7 @@
         </executions>
       </plugin>
 
+      <!-- coverage -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,9 @@
         <executions>
           <execution>
             <id>analyze</id>
+            <phase>verify</phase>
             <goals>
+              <goal>tree</goal>
               <goal>analyze-only</goal>
             </goals>
             <configuration>

--- a/reconstruction/alert/pom.xml
+++ b/reconstruction/alert/pom.xml
@@ -127,7 +127,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.9.0</version>
+        <version>3.10.0</version>
         <executions>
           <execution>
             <id>copy-dependencies</id>
@@ -141,15 +141,6 @@
             </configuration>
           </execution>
         </executions>
-        <configuration>
-          <ignoredUnusedDeclaredDependencies> <!-- tell 'dependency:analyze' to not complain that these are unused -->
-            <ignoredUnusedDeclaredDependency>ai.djl:model-zoo</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-model-zoo</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-engine</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-native-cpu</ignoredUnusedDeclaredDependency>
-            <ignoredUnusedDeclaredDependency>ai.djl.pytorch:pytorch-jni</ignoredUnusedDeclaredDependency>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
make it run automatically, rather than separately

- no need for the `--depana` argument of `build-coatjava.sh`
- both `dependency:tree` and `dependency-analyze` now run in the `verify` phase of the build lifecycle
  - `coat-libs` is excluded from `dependency:analyze`, as usual (shaded JAR has no "used" dependencies)
  - `djl` ignores are moved to the top-level POM, just to keep `dependency:analyze-only` configuration more centralized (of course then that setting would apply to all modules...)