### PR TITLE
feat:  add OptionValue convenience method

### DIFF
--- a/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionValue.java
+++ b/common-tools/clas-utils/src/main/java/org/jlab/utils/options/OptionValue.java
@@ -53,4 +53,8 @@ public class OptionValue {
         arguments.remove(index);
         return true;
     }
+
+    public boolean isDefault() {
+        return this.optionValue.equals(this.optionDefault);
+    }
 }


### PR DESCRIPTION
just to reduce verbosity on option parsing boolean interpretation, e.g.,  `OptionParser.getOption("-b").isDefault()`