### PR TITLE
fix: separate rollover correction for gated and ungated clocks

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -81,6 +81,14 @@ public class DaqScaler {
             final double slm_offset  = slmTable.getDoubleValue("offset",0,0,0);  // Hz
             final double slm_atten   = slmTable.getDoubleValue("atten",0,0,0);   // attenuation
 
+            // increase clock frequency by this factor
+            // double clockFreqFactor = 10.0;
+            // seconds     /= clockFreqFactor;
+            // liveSeconds /= clockFreqFactor;
+
+            // String prefix = String.format("TICK [%s]", this.getClass().getSimpleName());
+            // System.out.println(String.format("%s freq(orig)=%f seconds=%f liveSeconds=%f ", prefix, this.clockFreq, seconds, liveSeconds) + this.toString());
+
             double q  = (double)this.slm      - slm_offset * seconds;
             double qg = (double)this.gatedSlm - slm_offset * liveSeconds;
             this.beamChargeSLM = q * slm_atten / slm_slope;
@@ -90,13 +98,17 @@ public class DaqScaler {
             if (fcup_atten<1e-8 || fcup_slope<1e-8) {
                 this.beamCharge = this.beamChargeSLM;
                 this.beamChargeGated = this.beamChargeGatedSLM;
+                // System.out.println(String.format("%s [slm]:   %f  %f", prefix, this.beamChargeGated, this.beamCharge));
             }
             else {
                 q  = (double)this.fcup      - fcup_offset * seconds;
                 qg = (double)this.gatedFcup - fcup_offset * liveSeconds;
                 this.beamCharge = q * fcup_atten / fcup_slope;
                 this.beamChargeGated = qg * fcup_atten / fcup_slope;
+                // System.out.println(String.format("%s [fcup]:  %f  %f", prefix, this.beamChargeGated, this.beamCharge));
             }
+            // if(this.getClass().getSimpleName().equals("Dsc2Scaler"))
+            //   System.out.println(String.format("%s  %f  %f  %s", prefix, this.beamChargeGated, this.beamCharge, this.toString()));
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -369,9 +369,10 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
                 Dsc2Scaler next     = this.scalers.get(i).dsc2;
                 if (previous.clock > next.clock) {
+                    var corr = previous.clock - next.clock + 1;
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
-                        this.scalers.get(j).dsc2.clock += previous.clock - next.clock;
+                        this.scalers.get(j).dsc2.clock += corr;
                         if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
                     }
                     modified = true;
@@ -387,9 +388,10 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
                 Dsc2Scaler next     = this.scalers.get(i).dsc2;
                 if (previous.gatedClock > next.gatedClock) {
+                    var corr = previous.gatedClock - next.gatedClock + 1;
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
-                        this.scalers.get(j).dsc2.gatedClock += previous.gatedClock - next.gatedClock;
+                        this.scalers.get(j).dsc2.gatedClock += corr;
                         if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
                     }
                     modified = true;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -368,12 +368,19 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
             for (int i=this.scalers.size()-1; i>0; --i) {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
                 Dsc2Scaler next     = this.scalers.get(i).dsc2;
-                if (previous.clock > next.clock) {
-                    var corr = previous.clock - next.clock + 1;
+                long corr           = previous.clock - next.clock + 1;
+                boolean is_rollover = previous.clock > next.clock;
+                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
+                if (is_rollover || is_gap) {
+                    if(is_gap) corr = -corr;
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
                         this.scalers.get(j).dsc2.clock += corr;
-                        if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
+                        if (j==i) {
+                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
+                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
+                          if(is_gap) System.out.println("GAP!");
+                        }
                     }
                     modified = true;
                     break;
@@ -387,12 +394,19 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
             for (int i=this.scalers.size()-1; i>0; --i) {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
                 Dsc2Scaler next     = this.scalers.get(i).dsc2;
-                if (previous.gatedClock > next.gatedClock) {
-                    var corr = previous.gatedClock - next.gatedClock + 1;
+                long corr           = previous.gatedClock - next.gatedClock + 1;
+                boolean is_rollover = previous.gatedClock > next.gatedClock;
+                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
+                if (is_rollover || is_gap) {
+                    if(is_gap) corr = -corr;
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
                         this.scalers.get(j).dsc2.gatedClock += corr;
-                        if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
+                        if (j==i) {
+                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
+                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
+                          if(is_gap) System.out.println("GAP!");
+                        }
                     }
                     modified = true;
                     break;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -362,18 +362,35 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
      */
     public void fixClockRollover() {
         boolean modified = true;
+        // ungated clock
         while (modified) {
             modified = false;
             for (int i=this.scalers.size()-1; i>0; --i) {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
-                Dsc2Scaler next = this.scalers.get(i).dsc2;
+                Dsc2Scaler next     = this.scalers.get(i).dsc2;
                 if (previous.clock > next.clock) {
                     for (int j=i; j<this.scalers.size(); ++j) {
-                        if (j==i) System.out.print( String.format("FIXING CLOCK ROLLOVER:  %d %d -> ",this.scalers.get(j).dsc2.clock,this.scalers.get(j).dsc2.gatedClock));
+                        if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
                         this.scalers.get(j).dsc2.clock += 2*(long)Integer.MAX_VALUE;
-                        // The gated clock also rolls over (but it's triggered by the ungated clock, not itself!?):
+                        if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
+                    }
+                    modified = true;
+                    break;
+                }
+            }
+        }
+        // repeat for gated clock
+        modified = true;
+        while (modified) {
+            modified = false;
+            for (int i=this.scalers.size()-1; i>0; --i) {
+                Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
+                Dsc2Scaler next     = this.scalers.get(i).dsc2;
+                if (previous.gatedClock > next.gatedClock) {
+                    for (int j=i; j<this.scalers.size(); ++j) {
+                        if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
                         this.scalers.get(j).dsc2.gatedClock += 2*(long)Integer.MAX_VALUE;
-                        if (j==i) System.out.println(String.format("%d %d",this.scalers.get(j).dsc2.clock,this.scalers.get(j).dsc2.gatedClock));
+                        if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
                     }
                     modified = true;
                     break;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -371,7 +371,7 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                 if (previous.clock > next.clock) {
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
-                        this.scalers.get(j).dsc2.clock += 2*(long)Integer.MAX_VALUE;
+                        this.scalers.get(j).dsc2.clock += previous.clock - next.clock;
                         if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
                     }
                     modified = true;
@@ -389,7 +389,7 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                 if (previous.gatedClock > next.gatedClock) {
                     for (int j=i; j<this.scalers.size(); ++j) {
                         if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
-                        this.scalers.get(j).dsc2.gatedClock += 2*(long)Integer.MAX_VALUE;
+                        this.scalers.get(j).dsc2.gatedClock += previous.gatedClock - next.gatedClock;
                         if (j==i) System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
                     }
                     modified = true;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/StruckScaler.java
@@ -53,7 +53,7 @@ public class StruckScaler extends DaqScaler {
 
     @Override
     public String toString() {
-        return String.format("i=%s h=%d q=%d %s",this.interval,this.helicity.value(),this.quartet.value(),super.toString());
+        return String.format("[STRUCK] i=%s h=%d q=%d %s",this.interval,this.helicity.value(),this.quartet.value(),super.toString());
     }
 
     /**


### PR DESCRIPTION
RG-A 6.4 GeV clock issues

# Issue 1: Clock frequency is ~125 MHz for most runs:

- CCDB assumes 1 MHz for these data
- Reheat procedure (from `clas12-timeline`) uses a code path which _does not_ use CCDB, rather it uses the _hard-coded_ 1 MHz value; see https://github.com/JeffersonLab/coatjava/pull/1128

| run number | gated clock frequency [MHz] |  ungated clock frequency [MHz] |
| --- | --- | --- |
| 3031 | 85.0613 | 87.9861 |
| 3036 | 105.197 | 108.704 |
| 3037 | 88.6238 | 92.3011 |
| 3038 | 111.833 | 114.652 |
| 3048 | 67.1008 | 74.8741 |
| 3049 | 54.6598 | 58.9931 |
| 3050 | 113.333 | 124.878 |
| 3051 | 113.617 | 124.885 |
| 3052 | 116.11  | 124.874 |
| 3060 | 99.8533 | 122.867 |
| 3061 | 121.758 | 124.876 |
| 3063 | 120.068 | 124.873 |
| 3064 | 115.691 | 124.872 |
| 3065 | 116.811 | 124.878 |
| 3083 | 112.302 | 124.402 |
| 3087 | 115.264 | 124.875 |
| 3105 | 120.941 | 124.881 |
| 3820 | 116.593 | 124.872 |
| 3822 | 118.102 | 124.872 |
| 3827 | 113.382 | 124.881 |
| 3834 | 119.726 | 124.867 |
| 3839 | 120.865 | 124.874 |
| 3841 | 118.942 | 124.877 |
| 3842 | 119.552 | 124.874 |
| 3843 | 122.162 | 124.867 |
| 3845 | 120.322 | 124.872 |
| 3846 | 122.366 | 124.866 |
| 3847 | 120.262 | 124.873 |
| 3848 | 120.741 | 124.869 |
| 3849 | 120.474 | 124.875 |
| 3850 | 118.252 | 124.878 |
| 3851 | 122.605 | 124.869 |
| 3852 | 119.853 | 124.874 |
| 3853 | 119.05  | 124.877 |
| 3855 | 122.028 | 124.872 |
| 3856 | 123.003 | 124.873 |
| 3857 | 122.75  | 124.875 |

# Issue 2: Rollover Structure is different
- much more frequent
- gated clock rollover includes step ups, rather than just step down
  - this PR attempts to resolve this by generalizing the rollover correction

<img width="2556" height="1393" alt="2026-03-16-111727_2556x1393_scrot" src="https://github.com/user-attachments/assets/30c20dd5-64f3-497d-9d34-1848efd36602" />

# Notes
This PR, together with changing the clock frequency to the appropriate value, appear to provide a better charge estimate; however, there may still be unknown issues.