### PR TITLE
truncate AHDC waveforms

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
@@ -30,6 +30,9 @@ import org.jlab.utils.system.ClasUtilsFile;
  * @author gavalian
  */
 public class CLASDecoder {
+       
+    // truncate EVIO waveforms longer than this:
+    final static int MAX_BANK_WF_LENGTH = 30;
 
     protected DetectorEventDecoder detectorDecoder = null;
     protected SchemaFactory           schemaFactory = new SchemaFactory();
@@ -203,7 +206,7 @@ public class CLASDecoder {
             b.putLong( 4, i, a.get(i).getADCData(0).getTimeStamp());
             b.putInt("time", i, (int)a.get(i).getADCData(0).getTime());
             DetectorDataDgtz.ADCData xxx = a.get(i).getADCData(0);
-            for (int j=0; j<xxx.getPulseSize(); ++j)
+            for (int j=0; j<xxx.getPulseSize() && j<MAX_BANK_WF_LENGTH; ++j)
                 b.putShort(j+5, i, xxx.getPulseValue(j));
         }
         return b;


### PR DESCRIPTION
The DAQ configuration for AHDC was never fully understood and controlled during the RG-L experiment.  This truncates AHDC waveform EVIO readout, before the transition to HIPO, to the current HIPO bank's length of 30 samples.