### PR TITLE
add optional efficiency check

### DIFF
--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
@@ -3,6 +3,7 @@ package org.jlab.analysis.efficiency;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeMap;
 import org.jlab.jnp.hipo4.data.Bank;
 import org.jlab.jnp.hipo4.data.Event;
@@ -187,7 +188,7 @@ public class Truth {
         return s.toString();
     }
 
-    private static TreeMap<Integer,Float> parseEfficiencyString(String arg) {
+    private static Map<Integer,Float> parseEfficiencyString(String arg) {
         TreeMap<Integer,Float> m = new TreeMap<>();
         if (arg.contains(",")) {
             for (String s : arg.split(","))
@@ -205,13 +206,26 @@ public class Truth {
         }
         return m;
     }
+
+    public boolean checkEfficiencies(Map<Integer,Float> pids) {
+        boolean good = true;
+        for (int pid : pids.keySet()) {
+            if (get(pid, pid) < pids.get(pid)) {
+                System.err.println(String.format(
+                    ">>> trutheff:  pid %d efficiency is %f, below %f limit",
+                    pid, get(pid,pid), pids.get(pid)));
+                good = false;
+            }
+        }
+        return good;
+    } 
     
     public static void main(String[] args) {
         OptionParser o = new OptionParser("trutheff");
         o.addOption("-e", "", "efficiency requirement (e.g. 321:0.9,11:0.95");
         o.setRequiresInputList(true);
         o.parse(args);
-        TreeMap<Integer,Float> pids = parseEfficiencyString(o.getOption("-e").stringValue());
+        Map<Integer,Float> pids = parseEfficiencyString(o.getOption("-e").stringValue());
         HipoReader r = new HipoReader();
         r.open(o.getInputList().get(0));
         Truth t = new Truth(r.getSchemaFactory());
@@ -219,16 +233,7 @@ public class Truth {
         System.out.println(t.toMarkdown());
         System.out.println(t.toJson());
         System.out.println(t.toTable());
-        boolean good = true;
-        for (int pid : pids.keySet()) {
-            if (t.get(pid, pid) < pids.get(pid)) {
-                System.err.println(String.format(
-                    ">>> trutheff:error: pid %d efficiency is %f, below %f limit",
-                    pid, t.get(pid,pid), pids.get(pid)));
-                good = false;
-            }
-        }
-        if (!good) System.exit(7);
+        if (!t.checkEfficiencies(pids)) System.exit(7);
     }
 
 }

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
@@ -188,10 +188,31 @@ public class Truth {
         return s.toString();
     }
 
+    private static TreeMap<Integer,Float> parseEfficiencyString(String arg) {
+        TreeMap<Integer,Float> m = new TreeMap<>();
+        if (arg.contains(",")) {
+            for (String s : arg.split(","))
+                m.putAll(parseEfficiencyString(s));
+        }
+        else if (arg.contains(":")) {
+            String[] x = arg.split(":");
+            try {
+                if (x.length == 2) m.put(Integer.valueOf(x[0]), Float.valueOf(x[1]));
+                else throw new RuntimeException("Invalid pid specification:  "+arg);
+            }
+            catch (NumberFormatException e) {
+                throw new RuntimeException("Invalid pid specification:  "+arg);
+            }
+        }
+        return m;
+    }
+    
     public static void main(String[] args) {
         OptionParser o = new OptionParser("trutheff");
+        o.addOption("-e", "", "efficiency requirement (e.g. 321:0.9,11:0.95");
         o.setRequiresInputList(true);
         o.parse(args);
+        TreeMap<Integer,Float> pids = parseEfficiencyString(o.getOption("-e").stringValue());
         HipoReader r = new HipoReader();
         r.open(o.getInputList().get(0));
         Truth t = new Truth(r.getSchemaFactory());
@@ -199,6 +220,16 @@ public class Truth {
         System.out.println(t.toTable());
         System.out.println(t.toJson());
         System.out.println(t.toMarkdown());
+        boolean good = true;
+        for (int pid : pids.keySet()) {
+            if (t.get(pid, pid) < pids.get(pid)) {
+                System.err.println(String.format(
+                    ">>> trutheff:error: pid %d efficiency is %f, below %f limit",
+                    pid, t.get(pid,pid), pids.get(pid)));
+                good = false;
+            }
+        }
+        if (!good) System.exit(7);
     }
 
 }

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
@@ -216,9 +216,9 @@ public class Truth {
         r.open(o.getInputList().get(0));
         Truth t = new Truth(r.getSchemaFactory());
         t.add(o.getInputList());
-        System.out.println(t.toTable());
-        System.out.println(t.toJson());
         System.out.println(t.toMarkdown());
+        System.out.println(t.toJson());
+        System.out.println(t.toTable());
         boolean good = true;
         for (int pid : pids.keySet()) {
             if (t.get(pid, pid) < pids.get(pid)) {

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
@@ -207,7 +207,7 @@ public class Truth {
         return m;
     }
 
-    public boolean checkEfficiencies(Map<Integer,Float> pids) {
+    private boolean checkEfficiencies(Map<Integer,Float> pids) {
         boolean good = true;
         for (int pid : pids.keySet()) {
             if (get(pid, pid) < pids.get(pid)) {
@@ -218,8 +218,18 @@ public class Truth {
             }
         }
         return good;
-    } 
-    
+    }
+
+    /**
+     * Efficiency cut values specificed as pid1:eff1[pid2:eff2[...]]
+     * For example, 2212:0.9,11:0.95 is 90% for proton and 95% for electron.
+     * @param arg
+     * @return whether all efficiency cuts pass
+     */
+    public boolean checkEfficiencies(String arg) {
+        return checkEfficiencies(parseEfficiencyString(arg));
+    }
+
     public static void main(String[] args) {
         OptionParser o = new OptionParser("trutheff");
         o.addOption("-e", "", "efficiency requirement (e.g. 321:0.9,11:0.95");

--- a/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
+++ b/common-tools/clas-analysis/src/main/java/org/jlab/analysis/efficiency/Truth.java
@@ -15,8 +15,7 @@ import org.jlab.utils.options.OptionParser;
 
 /**
  * Efficiency matrix calculator based solely on the MC::GenMatch truth-matching
- * bank (which is purely hit-based), and a pid assignment match in MC::Particle
- * and REC::Particle.
+ * bank, and a pid assignment match in MC::Particle and REC::Particle.
  * 
  * @author baltzell
  */


### PR DESCRIPTION
The CLI-driven `trutheff` will now deliver a non-zero exit code if the efficiency is low.  For example, `trutheff -pid 2212:0.9,11:0.95` will exit non-zero if proton/electron efficiency is below 90/95%.  This could replace all components of our old 2-particle-EB-tests downstream of event generation in `validation/advanced-tests`.  This new efficiency check can also be called programmatically, e.g.:

     org.jlab.analysis.efficiency.Truth.checkEfficiencies("2212:0.9,11:0.95")