### PR TITLE
Fix issue : alert gains and tot tables not found

### DIFF
--- a/reconstruction/alert/src/main/java/org/jlab/service/ahdc/AHDCEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/service/ahdc/AHDCEngine.java
@@ -29,7 +29,6 @@ import java.util.logging.Logger;
 import org.jlab.detector.calib.utils.DatabaseConstantProvider;
 import org.jlab.geom.detector.alert.AHDC.AlertDCDetector;
 import org.jlab.geom.detector.alert.AHDC.AlertDCFactory;
-import org.jlab.rec.alert.constants.CalibrationConstantsLoader;
 import org.jlab.detector.pulse.ModeAHDC;
 
 /** AHDCEngine reconstruction service.
@@ -83,23 +82,6 @@ public class AHDCEngine extends ReconstructionEngine {
         if (modeTrackFinding == ModeTrackFinding.AI_Track_Finding) {
             modelTrackFinding = new ModelTrackFinding();
         }
-
-        // Requires calibration constants
-        String[] alertTables = new String[] {
-            	"/calibration/alert/ahdc/time_offsets",
-                "/calibration/alert/ahdc/time_to_distance",
-                "/calibration/alert/ahdc/raw_hit_cuts",
-                "/calibration/alert/atof/effective_velocity",
-                "/calibration/alert/atof/time_walk",
-                "/calibration/alert/atof/attenuation",
-                "/calibration/alert/atof/time_offsets",
-                "/calibration/alert/ahdc/gains",
-		"/calibration/alert/ahdc/time_over_threshold"
-		
-        };
-        requireConstants(Arrays.asList(alertTables));
-        
-        this.getConstantsManager().setVariation("default");
         
         this.registerOutputBank("AHDC::hits","AHDC::preclusters","AHDC::clusters","AHDC::track","AHDC::mc","AHDC::ai:prediction");
 
@@ -121,12 +103,6 @@ public class AHDCEngine extends ReconstructionEngine {
             if (newRun <= 0) {
                 LOGGER.warning("AHDCEngine:  got run <= 0 in RUN::config, skipping event.");
                 return false;
-            }
-            // Load the constants
-            //-------------------
-            if(Run != newRun) {
-                CalibrationConstantsLoader.Load(newRun, this.getConstantsManager());
-                Run = newRun;
             }
         }
 

--- a/reconstruction/alert/src/main/java/org/jlab/service/atof/ATOFEngine.java
+++ b/reconstruction/alert/src/main/java/org/jlab/service/atof/ATOFEngine.java
@@ -138,7 +138,9 @@ public class ATOFEngine extends ReconstructionEngine {
                 "/calibration/alert/atof/effective_velocity",
                 "/calibration/alert/atof/time_walk",
                 "/calibration/alert/atof/attenuation",
-                "/calibration/alert/atof/time_offsets"
+                "/calibration/alert/atof/time_offsets",
+                "/calibration/alert/ahdc/gains",
+                "/calibration/alert/ahdc/time_over_threshold"
         };
         
         Map<String, Integer> tableMap = new HashMap<>();


### PR DESCRIPTION
I noticed this error for a very long time, but it is only now that **I notice that (may be) the calibration constants for the gain and the ToT were never taken into account.** 

```shell
INFO: [ConstantsManager] --->  loading table for run = 22712
INFO: [DB] ---> open 22712 | rge_spring2024 | Fri Feb 27 08:18:12 EST 2026 | mysql://clas12reader@clasdb-farm.jlab.org/clas12
INFO: ***** >>> add table = /calibration/alert/atof/attenuation
INFO: ***** >>> add table = /calibration/alert/ahdc/time_offsets
INFO: ***** >>> add table = /calibration/alert/ahdc/time_to_distance
INFO: ***** >>> add table = /calibration/alert/atof/time_offsets
INFO: ***** >>> add table = /calibration/alert/ahdc/raw_hit_cuts
INFO: ***** >>> add table = /calibration/alert/atof/time_walk
INFO: ***** >>> add table = /calibration/alert/atof/effective_velocity
SEVERE: [getConstants] error ( run = 22712 )  table not found with name : /calibration/alert/ahdc/gains</b>
SEVERE: [getConstants] error ( run = 22712 )  table not found with name : /calibration/alert/ahdc/time_over_threshold
```

**Before this PR**

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/5494ee37-4861-4ba2-b655-1a9d67eb5a2c" />

**After this PR**

<img width="400" height="300" alt="image" src="https://github.com/user-attachments/assets/6f1038af-ee3b-4f20-a1fd-bc6fc06aac85" />

This way of handling the code masked the issue : https://github.com/JeffersonLab/coatjava/blob/1ccf10abda9f41899da3e8b16a5c9749a15197fd/reconstruction/alert/src/main/java/org/jlab/rec/ahdc/Hit/HitReader.java#L158-L165


Fortunately, the ADC calibration has no effect on the Kalman Filter.

In any case, the error disappears with the pull request.
