### PR TITLE
fix: avoid call to method that recalibrates already-calibrated dsc2

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalers.java
@@ -150,8 +150,12 @@ public class DaqScalers {
      * @return  
      */
     public static DaqScalers create(Bank rawScalerBank,IndexedTable fcupTable,IndexedTable slmTable,IndexedTable helTable,IndexedTable dscTable) {
+        StruckScalers struck = StruckScalers.read(rawScalerBank,fcupTable,slmTable,helTable);
         Dsc2Scaler dsc2 = new Dsc2Scaler(rawScalerBank,fcupTable,slmTable,dscTable);
-        return DaqScalers.create(rawScalerBank,fcupTable,slmTable,helTable,dsc2.getGatedClockSeconds());
+        DaqScalers ds = new DaqScalers();
+        ds.dsc2 = dsc2;
+        ds.struck = struck;
+        return ds;
     }
 
     /**


### PR DESCRIPTION
The unnecessary recalibration was introducing a bias because the time from the gated clock was being used in the offset correction of the ungated fcup, and further multiplied by the lifetime, in the offset correction of the gated fcup