### PR TITLE
fix(build): duplicate `maven-enforcer-plugin` declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,28 +263,6 @@
 
     <plugins> <!-- plugins inherited by all child POMs -->
 
-      <!-- Java version enforcer -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.2</version>
-        <executions>
-          <execution>
-            <id>enforce-java</id>
-            <goals>
-              <goal>enforce</goal>
-            </goals>
-            <configuration>
-              <rules>
-                <requireJavaVersion>
-                  <version>[21,)</version>
-                </requireJavaVersion>
-              </rules>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
       <!-- static analysis -->
       <plugin>
         <groupId>com.github.spotbugs</groupId>
@@ -388,12 +366,13 @@
         </executions>
       </plugin>
 
-      <!-- dependency convergence -->
+      <!-- enforcers -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <version>3.6.2</version>
         <executions>
+          <!-- dependency convergence -->
           <execution>
             <id>enforce-dependency-convergence</id>
             <goals>
@@ -407,6 +386,20 @@
                     <exclude>com.google.protobuf:protobuf-java</exclude> <!-- `org.jlab.ccdbrcdb:ccdbrcdb` use v3, but `org.jlab.coda.xmsg` uses v2 -->
                   </excludes>
                 </dependencyConvergence>
+              </rules>
+            </configuration>
+          </execution>
+          <!-- Java version enforcer -->
+          <execution>
+            <id>enforce-java</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[21,)</version>
+                </requireJavaVersion>
               </rules>
             </configuration>
           </execution>


### PR DESCRIPTION
fixes
```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jlab.clas:common-tools:pom:13.7.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-enforcer-plugin @ org.jlab.clas:coatjava:13.7.1-SNAPSHOT, /home/dilks/j/coatjava/pom.xml, line 392, column 15
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.jlab.clas:coatjava:pom:13.7.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.apache.maven.plugins:maven-enforcer-plugin @ line 392, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
```