### PR TITLE
fix null issue for finalSV in KF for new HB tracking

### DIFF
--- a/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
+++ b/reconstruction/dc/src/main/java/org/jlab/rec/dc/track/TrackCandListFinder.java
@@ -294,6 +294,8 @@ public class TrackCandListFinder {
                 
                 if(cand.get_Vtx0() != null){
                     Point3D VTCS = cand.get(cand.size()-1).getCoordsInTiltedSector(cand.get_Vtx0().x(), cand.get_Vtx0().y(), cand.get_Vtx0().z());
+                    finalSV.k = measSurfaces.size()-1;
+                    kFZRef.finalStateVec = finalSV;                    
                     double deltaPathToVtx =  kFZRef.getDeltaPathToVtx(sector, VTCS.z());
 
                     List<org.jlab.rec.dc.trajectory.StateVec> kfStateVecsAlongTrajectory = setKFStateVecsAlongTrajectory(kFZRef, deltaPathToVtx);


### PR DESCRIPTION
To use the function getDeltaPathToVtx() in org.jlab.clas.tracking.kalmanfilter.zReference.KFitter, finalStateVec needs to be set. 
New HB tracking by AI applies KF package for propagation.
In dc_v1,  the function getDeltaPathToVtx() is not called, so the bug is missed to be found when test of new HB tracking with RGA data.
In dc_v2, the function getDeltaPathToVtx() is called for fixing of path length issue.