### PR TITLE
prevent loading of translation tables if run=0

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/CLASDecoder.java
@@ -744,9 +744,9 @@ public class CLASDecoder {
                     }
 
                     int runNumberCoda = codaDecoder.getRunNumber();
-                    this.setRunNumber(runNumberCoda);
                   
                     if (runNumberCoda > 0) {
+                        this.setRunNumber(runNumberCoda);
                         detectorDecoder.translate(dataList);
                         detectorDecoder.fitPulses(dataList);
                         detectorDecoder.filterTDCs(dataList);


### PR DESCRIPTION
addresses #1169 

for the record:
- older versions like 13.5.2 were also complaining about missing tables for run=0 but were not giving exceptions
- the problem appeared independently of whether decoding was done in clara or standalone