### PR TITLE
fix: avert unwanted log level changes from upstream `JDBCProvider`

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/DatabaseConstantProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/DatabaseConstantProvider.java
@@ -23,6 +23,7 @@ import org.jlab.utils.groups.IndexedTable;
 import org.jlab.utils.groups.IndexedTableViewer;
 import org.jlab.utils.system.FileSystemExecScan;
 import org.jlab.logging.SplitLogManager;
+import org.jlab.logging.LogLevelGuard;
 
 /**
  *
@@ -34,6 +35,7 @@ public class DatabaseConstantProvider implements ConstantProvider {
     static {
         SplitLogManager.configureHandlers(LOGGER, false);
     }
+    private LogLevelGuard logGuard = new LogLevelGuard("org.freehep.math.minuit");
     
     private final HashMap<String,String[]> constantContainer = new HashMap<>();
     private final boolean PRINT_ALL = true;
@@ -148,7 +150,9 @@ public class DatabaseConstantProvider implements ConstantProvider {
 
         LOGGER.log(Level.INFO, String.format("[DB] ---> open %s | %s | %s | %s", runNumber, variation, databaseDate, address));
         
+        logGuard.save();
         provider.connect();
+        logGuard.restore();
         
         if(provider.isConnected()){
             LOGGER.log(Level.FINE,"[DB] --->  database connection  : success");

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/calib/utils/RCDBProvider.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.jlab.logging.SplitLogManager;
+import org.jlab.logging.LogLevelGuard;
 
 import org.rcdb.RCDB;
 import org.rcdb.Condition;
@@ -38,6 +39,7 @@ public class RCDBProvider {
     static {
         SplitLogManager.configureHandlers(LOGGER, false);
     }
+    private LogLevelGuard logGuard = new LogLevelGuard("org.freehep.math.minuit");
 
     public static final String DEFAULTADDRESS = "mysql://rcdb@clasdb.jlab.org/rcdb";
 
@@ -89,7 +91,9 @@ public class RCDBProvider {
         provider = RCDB.createProvider(address);
         try {
             LOGGER.log(Level.FINE,"[RCDB] --->  open connection with : " + address);
+            logGuard.save();
             provider.connect();
+            logGuard.restore();
         }
         catch (Exception e) {
             LOGGER.log(Level.SEVERE,"",e);

--- a/common-tools/clas-logging/src/main/java/org/jlab/logging/LogLevelGuard.java
+++ b/common-tools/clas-logging/src/main/java/org/jlab/logging/LogLevelGuard.java
@@ -1,0 +1,39 @@
+package org.jlab.logging;
+
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Kluge around certain upstream function calls that alter log levels against our will.
+ * @author dilks
+ */
+public class LogLevelGuard {
+
+  private final List<String> loggerNames;
+  private final Map<String, Level> savedLevels = new HashMap<>();
+
+  /**
+   * constructor
+   * @param loggerNames the names of the Loggers to guard
+   */
+  public LogLevelGuard(String... loggerNames) {
+    this.loggerNames = List.of(loggerNames);
+  }
+
+  /** save the log levels */
+  public void save() {
+    for(var name : loggerNames)
+      savedLevels.put(name, Logger.getLogger(name).getLevel());
+  }
+
+  /** restore the log levels */
+  public void restore() {
+    for(var entry : savedLevels.entrySet())
+      if(entry.getValue() != null)
+        Logger.getLogger(entry.getKey()).setLevel(entry.getValue());
+  }
+
+}


### PR DESCRIPTION
Calling `JDBCProvider.connect()` destroys the log level of certain loggers, _viz._ `org.freehep.math.minuit`. Instead of attempting to fix upstream, we can save desired log levels and restore them; this is the fix we pretty much do downstream anyway (_e.g._, in `calcode`), where we typically just keep setting the log level we want.