### PR TITLE
test: RG-A Sp18 6.4 GeV `rebuild-scalers` with 125MHz clock and generalized clock rollover correction

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -78,6 +78,7 @@ public class DaqScaler {
             String prefix = String.format("clocktest [%s]", this.getClass().getSimpleName());
             System.out.println(String.format("%s: -----------", prefix));
             System.out.println(String.format("%s: toString: %s", prefix, this.toString()));
+            System.out.println(String.format("%s: seconds=%f  liveSeconds=%f", prefix, seconds, liveSeconds));
 
             final double fcup_slope  = fcupTable.getDoubleValue("slope",0,0,0);  // Hz/nA
             final double fcup_offset = fcupTable.getDoubleValue("offset",0,0,0); // Hz

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -75,10 +75,10 @@ public class DaqScaler {
 
         if (this.clock > 0) {
 
-            String prefix = String.format("clocktest [%s]", this.getClass().getSimpleName());
-            System.out.println(String.format("%s: -----------", prefix));
-            System.out.println(String.format("%s: toString: %s", prefix, this.toString()));
-            System.out.println(String.format("%s: seconds=%f  liveSeconds=%f", prefix, seconds, liveSeconds));
+            // String prefix = String.format("clocktest [%s]", this.getClass().getSimpleName());
+            // System.out.println(String.format("%s: -----------", prefix));
+            // System.out.println(String.format("%s: toString: %s", prefix, this.toString()));
+            // System.out.println(String.format("%s: seconds=%f  liveSeconds=%f", prefix, seconds, liveSeconds));
 
             final double fcup_slope  = fcupTable.getDoubleValue("slope",0,0,0);  // Hz/nA
             final double fcup_offset = fcupTable.getDoubleValue("offset",0,0,0); // Hz
@@ -104,9 +104,9 @@ public class DaqScaler {
                 this.beamChargeGated = qg * fcup_atten / fcup_slope;
             }
 
-            System.out.println(String.format("%s: BANK fcup=%d  fcupGated=%d", prefix, this.fcup, this.gatedFcup));
-            System.out.println(String.format("%s: CCDB fcup_offset=%f  fcup_slope=%f  fcup_atten=%f", prefix, fcup_offset, fcup_slope, fcup_atten));
-            System.out.println(String.format("%s: clockFreq=%f  beamCharge=%f  beamChargeGated=%f", prefix, this.clockFreq, this.beamCharge, this.beamChargeGated));
+            // System.out.println(String.format("%s: BANK fcup=%d  fcupGated=%d", prefix, this.fcup, this.gatedFcup));
+            // System.out.println(String.format("%s: CCDB fcup_offset=%f  fcup_slope=%f  fcup_atten=%f", prefix, fcup_offset, fcup_slope, fcup_atten));
+            // System.out.println(String.format("%s: clockFreq=%f  beamCharge=%f  beamChargeGated=%f", prefix, this.clockFreq, this.beamCharge, this.beamChargeGated));
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -103,7 +103,7 @@ public class DaqScaler {
                 this.beamChargeGated = qg * fcup_atten / fcup_slope;
             }
 
-            System.out.println(String.format("%s: BANK fcup=%f  fcupGated=%f", prefix, this.fcup, this.gatedFcup));
+            System.out.println(String.format("%s: BANK fcup=%d  fcupGated=%d", prefix, this.fcup, this.gatedFcup));
             System.out.println(String.format("%s: CCDB fcup_offset=%f  fcup_slope=%f  fcup_atten=%f", prefix, fcup_offset, fcup_slope, fcup_atten));
             System.out.println(String.format("%s: clockFreq=%f  beamCharge=%f  beamChargeGated=%f", prefix, this.clockFreq, this.beamCharge, this.beamChargeGated));
         }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScaler.java
@@ -74,6 +74,11 @@ public class DaqScaler {
     protected void calibrate(IndexedTable fcupTable,IndexedTable slmTable,double seconds,double liveSeconds) {
 
         if (this.clock > 0) {
+
+            String prefix = String.format("clocktest [%s]", this.getClass().getSimpleName());
+            System.out.println(String.format("%s: -----------", prefix));
+            System.out.println(String.format("%s: toString: %s", prefix, this.toString()));
+
             final double fcup_slope  = fcupTable.getDoubleValue("slope",0,0,0);  // Hz/nA
             final double fcup_offset = fcupTable.getDoubleValue("offset",0,0,0); // Hz
             final double fcup_atten  = fcupTable.getDoubleValue("atten",0,0,0);  // attenuation
@@ -97,6 +102,10 @@ public class DaqScaler {
                 this.beamCharge = q * fcup_atten / fcup_slope;
                 this.beamChargeGated = qg * fcup_atten / fcup_slope;
             }
+
+            System.out.println(String.format("%s: BANK fcup=%f  fcupGated=%f", prefix, this.fcup, this.gatedFcup));
+            System.out.println(String.format("%s: CCDB fcup_offset=%f  fcup_slope=%f  fcup_atten=%f", prefix, fcup_offset, fcup_slope, fcup_atten));
+            System.out.println(String.format("%s: clockFreq=%f  beamCharge=%f  beamChargeGated=%f", prefix, this.clockFreq, this.beamCharge, this.beamChargeGated));
         }
     }
 

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -361,60 +361,65 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
      * 2.  Assume any subsequent clock decrease is a rollover. 
      */
     public void fixClockRollover() {
-        boolean modified = true;
-        // ungated clock
-        while (modified) {
-            modified = false;
-            for (int i=this.scalers.size()-1; i>0; --i) {
-                Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
-                Dsc2Scaler next     = this.scalers.get(i).dsc2;
-                long corr           = previous.clock - next.clock + 1;
-                boolean is_rollover = previous.clock > next.clock;
-                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
-                if (is_rollover || is_gap) {
-                    if(is_gap) corr = -corr;
-                    for (int j=i; j<this.scalers.size(); ++j) {
-                        if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
-                        this.scalers.get(j).dsc2.clock += corr;
-                        if (j==i) {
-                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
-                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
-                          if(is_gap) System.out.println("GAP!");
-                        }
+        // fixed rollover size
+        final long ROLLOVER = 2*(long)Integer.MAX_VALUE;
+        // loop over ungated and gated, to apply correction separately for each
+        final int is_ungated = 0;
+        final int is_gated   = 1;
+        for (int clk : List.of(is_ungated, is_gated)) {
+            boolean modified = true;
+            while (modified) {
+                modified = false;
+                for (int i=this.scalers.size()-1; i>0; --i) {
+                    Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
+                    Dsc2Scaler next     = this.scalers.get(i).dsc2;
+                    String  clock_name;
+                    long    diff;
+                    boolean is_rollover;
+                    switch (clk) {
+                        case is_ungated:
+                            clock_name  = "ungated clock";
+                            diff        = previous.clock - next.clock + 1;
+                            is_rollover = previous.clock > next.clock;
+                            break;
+                        default: // is_gated
+                            clock_name  = "gated clock";
+                            diff        = previous.gatedClock - next.gatedClock + 1;
+                            is_rollover = previous.gatedClock > next.gatedClock;
+                            break;
                     }
-                    modified = true;
-                    break;
-                }
-            }
-        }
-        // repeat for gated clock
-        modified = true;
-        while (modified) {
-            modified = false;
-            for (int i=this.scalers.size()-1; i>0; --i) {
-                Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
-                Dsc2Scaler next     = this.scalers.get(i).dsc2;
-                long corr           = previous.gatedClock - next.gatedClock + 1;
-                boolean is_rollover = previous.gatedClock > next.gatedClock;
-                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
-                if (is_rollover || is_gap) {
-                    if(is_gap) corr = -corr;
-                    for (int j=i; j<this.scalers.size(); ++j) {
-                        if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
-                        this.scalers.get(j).dsc2.gatedClock += corr;
-                        if (j==i) {
-                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
-                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
-                          if(is_gap) System.out.println("GAP!");
+                    boolean is_gap = diff <= -ROLLOVER / 2;
+                    if (is_rollover || is_gap) {
+                        for (int j=i; j<this.scalers.size(); ++j) {
+                            switch (clk) {
+                                case is_ungated:
+                                    if (j==i)   logger.info( String.format("fixing ungated clock rollover:  %d ->", this.scalers.get(j).dsc2.clock));
+                                    if (is_gap) this.scalers.get(j).dsc2.clock -= ROLLOVER;
+                                    else        this.scalers.get(j).dsc2.clock += ROLLOVER;
+                                    if (j==i)   logger.info( String.format("                             -> %d", this.scalers.get(j).dsc2.clock));
+                                    break;
+                                default: // is_gated
+                                    if (j==i)   logger.info( String.format("fixing gated clock rollover:  %d ->", this.scalers.get(j).dsc2.gatedClock));
+                                    if (is_gap) this.scalers.get(j).dsc2.gatedClock -= ROLLOVER;
+                                    else        this.scalers.get(j).dsc2.gatedClock += ROLLOVER;
+                                    if (j==i)   logger.info( String.format("                           -> %d", this.scalers.get(j).dsc2.gatedClock));
+                                    break;
+                            }
+                            if (j==i) {
+                                if (Math.abs( ((double)diff/ROLLOVER) - 1 ) > 0.01) {
+                                    logger.warning("found " + clock_name + " rollover of unexpected size " + diff + " (expected about " + ROLLOVER + ")");
+                                }
+                            }
                         }
+                        modified = true;
+                        break;
                     }
-                    modified = true;
-                    break;
                 }
             }
         }
     }
-    
+
+
     public static void main(String[] args) {
         
         final String dir = System.getenv("HOME")+"/data/";

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -406,8 +406,9 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                                     break;
                             }
                             if (j==i) {
-                                if (Math.abs( ((double)diff/ROLLOVER) - 1 ) > 0.01) {
-                                    logger.warning("found " + clock_name + " rollover of unexpected size " + diff + " (expected about " + ROLLOVER + ")");
+                                double rat = Math.abs((double)diff/ROLLOVER) - 1;
+                                if (Math.abs(rat) > 0.001) {
+                                    logger.warning("found " + clock_name + " rollover of unexpected size; off by " + rat*100 + "%");
                                 }
                             }
                         }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -362,18 +362,51 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
      */
     public void fixClockRollover() {
         boolean modified = true;
+        // ungated clock
         while (modified) {
             modified = false;
             for (int i=this.scalers.size()-1; i>0; --i) {
                 Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
-                Dsc2Scaler next = this.scalers.get(i).dsc2;
-                if (previous.clock > next.clock) {
+                Dsc2Scaler next     = this.scalers.get(i).dsc2;
+                long corr           = previous.clock - next.clock + 1;
+                boolean is_rollover = previous.clock > next.clock;
+                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
+                if (is_rollover || is_gap) {
+                    if(is_gap) corr = -corr;
                     for (int j=i; j<this.scalers.size(); ++j) {
-                        if (j==i) System.out.print( String.format("FIXING CLOCK ROLLOVER:  %d %d -> ",this.scalers.get(j).dsc2.clock,this.scalers.get(j).dsc2.gatedClock));
-                        this.scalers.get(j).dsc2.clock += 2*(long)Integer.MAX_VALUE;
-                        // The gated clock also rolls over (but it's triggered by the ungated clock, not itself!?):
-                        this.scalers.get(j).dsc2.gatedClock += 2*(long)Integer.MAX_VALUE;
-                        if (j==i) System.out.println(String.format("%d %d",this.scalers.get(j).dsc2.clock,this.scalers.get(j).dsc2.gatedClock));
+                        if (j==i) System.out.print( String.format("FIXING UNGATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.clock));
+                        this.scalers.get(j).dsc2.clock += corr;
+                        if (j==i) {
+                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.clock));
+                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
+                          if(is_gap) System.out.println("GAP!");
+                        }
+                    }
+                    modified = true;
+                    break;
+                }
+            }
+        }
+        // repeat for gated clock
+        modified = true;
+        while (modified) {
+            modified = false;
+            for (int i=this.scalers.size()-1; i>0; --i) {
+                Dsc2Scaler previous = this.scalers.get(i-1).dsc2;
+                Dsc2Scaler next     = this.scalers.get(i).dsc2;
+                long corr           = previous.gatedClock - next.gatedClock + 1;
+                boolean is_rollover = previous.gatedClock > next.gatedClock;
+                boolean is_gap      = corr <= -2*(long)Integer.MAX_VALUE;
+                if (is_rollover || is_gap) {
+                    if(is_gap) corr = -corr;
+                    for (int j=i; j<this.scalers.size(); ++j) {
+                        if (j==i) System.out.print( String.format("FIXING GATED CLOCK ROLLOVER:  %d -> ",this.scalers.get(j).dsc2.gatedClock));
+                        this.scalers.get(j).dsc2.gatedClock += corr;
+                        if (j==i) {
+                          System.out.println(String.format("%d",this.scalers.get(j).dsc2.gatedClock));
+                          System.out.println((double)corr/(2*(long)Integer.MAX_VALUE));
+                          if(is_gap) System.out.println("GAP!");
+                        }
                     }
                     modified = true;
                     break;

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/DaqScalersSequence.java
@@ -407,7 +407,7 @@ public class DaqScalersSequence implements Comparator<DaqScalers> {
                             }
                             if (j==i) {
                                 double rat = Math.abs((double)diff/ROLLOVER) - 1;
-                                if (Math.abs(rat) > 0.001) {
+                                if (Math.abs(rat) > 0.005) {
                                     logger.warning("found " + clock_name + " rollover of unexpected size; off by " + rat*100 + "%");
                                 }
                             }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -38,7 +38,7 @@ public class Dsc2Scaler extends DaqScaler{
      * @param seconds dwell time, provided in case the clock rolls over
      */
     public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-        this.clockFreq=1e6;
+        this.clockFreq=1e6; // FIXME: this is what's actually used
         this.read(bank);
         this.calibrate(fcupTable,slmTable,seconds);
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/scalers/Dsc2Scaler.java
@@ -38,7 +38,7 @@ public class Dsc2Scaler extends DaqScaler{
      * @param seconds dwell time, provided in case the clock rolls over
      */
     public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, double seconds) {
-        this.clockFreq=1e6; // FIXME: this is what's actually used
+        this.clockFreq=125e6; // for RG-A spring 2018 6.4 GeV data
         this.read(bank);
         this.calibrate(fcupTable,slmTable,seconds);
     }
@@ -50,7 +50,7 @@ public class Dsc2Scaler extends DaqScaler{
      * @param dscTable /daq/config/scalers/dsc1 CCDB table
      */
     public Dsc2Scaler(Bank bank, IndexedTable fcupTable, IndexedTable slmTable, IndexedTable dscTable) {
-        this.clockFreq = dscTable.getIntValue("frequency", 0,0,0);
+        this.clockFreq = 125e6; // for RG-A spring 2018 6.4 GeV data // dscTable.getIntValue("frequency", 0,0,0);
         this.read(bank);
         this.calibrate(fcupTable,slmTable);
     }


### PR DESCRIPTION
### do not merge
This is for preserving the fixes we know are needed for the FC charge for RG-A Spring 2018 6.4 GeV data; more fixes and studies may be needed.

### Fixes

1. generalized clock rollover correction
    - separates gated and ungated clock corrections
    - accounts for step-ups of ~2<sup>32</sup> counts (original rollover correction only corrects step-downs)
    - does not assume the step size is 2<sup>32</sup> (though perhaps we _should_ assume this, actually)
2. we have fit the clock counts vs. timestamp and determined the DSC2 clock frequency was 125 MHz for most 6.4 GeV runs (see below)
    - the charge is calculated using a hard-coded clock frequency of 125 MHz

See also https://github.com/JeffersonLab/coatjava/pull/1116

### Clock Frequencies

```
run  gated   ungated
---  -----   -------
3031 85.0613 87.9861
3036 105.197 108.704
3037 88.6238 92.3011
3038 111.833 114.652
3048 67.1008 74.8741
3049 54.6598 58.9931
3050 113.333 124.878
3051 113.617 124.885
3052 116.11  124.874
3060 99.8533 122.867
3061 121.758 124.876
3063 120.068 124.873
3064 115.691 124.872
3065 116.811 124.878
3083 112.302 124.402
3087 115.264 124.875
3105 120.941 124.881
3820 116.593 124.872
3822 118.102 124.872
3827 113.382 124.881
3834 119.726 124.867
3839 120.865 124.874
3841 118.942 124.877
3842 119.552 124.874
3843 122.162 124.867
3845 120.322 124.872
3846 122.366 124.866
3847 120.262 124.873
3848 120.741 124.869
3849 120.474 124.875
3850 118.252 124.878
3851 122.605 124.869
3852 119.853 124.874
3853 119.05  124.877
3855 122.028 124.872
3856 123.003 124.873
3857 122.75  124.875
```