### PR TITLE
fix: indexing issue between DECAYS::Particle and REC::VertDoca bank

### DIFF
--- a/common-tools/clas-decay-tools/src/main/java/org/jlab/clas/decay/analysis/Decay.java
+++ b/common-tools/clas-decay-tools/src/main/java/org/jlab/clas/decay/analysis/Decay.java
@@ -584,8 +584,8 @@ public class Decay extends Particle {
         if(getVertBank()!=null) { 
             int nrows2 = getVertBank().rows();
             for(int loop2 = 0; loop2 < nrows2; loop2++){
-                if(p1.getIdx()-1==(int) getVertBank().getShort("index1", loop2)
-                        && p2.getIdx()-1==(int) getVertBank().getShort("index2", loop2)) {
+                if(p1.getIdx()==(int) getVertBank().getShort("index1", loop2)
+                        && p2.getIdx()==(int) getVertBank().getShort("index2", loop2)) {
                     p1.vIndex=loop2;
                     p2.vIndex=loop2;
                     
@@ -620,8 +620,8 @@ public class Decay extends Particle {
                     pass=true;
                     return pass;
                 }
-                if(p2.getIdx()-1==(int) getVertBank().getShort("index1", loop2)
-                        && p1.getIdx()-1==(int) getVertBank().getShort("index2", loop2)) {
+                if(p2.getIdx()==(int) getVertBank().getShort("index1", loop2)
+                        && p1.getIdx()==(int) getVertBank().getShort("index2", loop2)) {
                     p1.vIndex=loop2;
                     p2.vIndex=loop2;
                     //r =  (double) getVertBank().getFloat("r", loop2);


### PR DESCRIPTION
Fix off-by-one mismatch in `REC::VertDoca` matching for decay reconstruction.

The decay code was comparing `p1.getIdx()-1` / `p2.getIdx()-1` to `REC::VertDoca.index1` / `index2`, which caused valid charged-particle pairs to miss the vertex-bank match and be dropped from `DECAYS::Particle`.

This PR removes the unnecessary `-1` offset in the four affected comparisons so that `REC::Particle` indices are matched correctly to `REC::VertDoca`. This restores missing valid decay candidates without changing the reconstruction logic otherwise.