### PR TITLE
feat:  decouple macos/linux build jobs to reduce CI latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,6 +310,36 @@ jobs:
           echo "COMMAND: ${{ matrix.cmd }}"
           ${{ matrix.cmd }}
 
+  test_coatjava_macos:
+    needs: [ build_macos ]
+    strategy:
+      fail-fast: true
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.java_distribution }}
+          cache: maven
+      - uses: actions/download-artifact@v8
+        with:
+          name: build_macos
+      - uses: cvmfs-contrib/github-action-cvmfs@v5
+        with:
+          cvmfs_repositories: 'oasis.opensciencegrid.org'
+      - name: untar build
+        run: |
+          tar xzvf coatjava.tar.gz
+          tar xzvf clara.tar.gz
+      - name: run test
+        run: |
+          git lfs install
+          git submodule update --init validation/advanced-tests/data
+          cd validation/advanced-tests
+          ./run-eb-tests.sh -100 electronproton
+
   test_run-groovy:
     needs: [ build ]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,8 +283,6 @@ jobs:
           - { id: eb-epc,   cmd: ./run-eb-tests.sh -100 electronprotonC  }
           - { id: eb-enc,   cmd: ./run-eb-tests.sh -100 electronneutronC }
           - { id: eb-eftpi, cmd: ./run-eb-tests.sh -100 electronFTpion   }
-          # run one macos test
-          - { runner: macos-latest, id: eb-ep, cmd: ./run-eb-tests.sh -100 electronproton }
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           tar czvf clara.tar.gz clara
       - uses: actions/upload-artifact@v7
         with:
-          name: build_macos-latest
+          name: build_macos
           retention-days: 1
           path: |
               coatjava.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,14 +61,10 @@ jobs:
   # build
   #############################################################################
 
-  build:
+  build-macos:
     strategy:
       fail-fast: true
-      matrix:
-        runner:
-          - ubuntu-latest
-          - macos-latest
-    runs-on: ${{ matrix.runner }}
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -95,7 +91,43 @@ jobs:
           tar czvf clara.tar.gz clara
       - uses: actions/upload-artifact@v7
         with:
-          name: build_${{ matrix.runner }}
+          name: build_macos-latest
+          retention-days: 1
+          path: |
+              coatjava.tar.gz
+              clara.tar.gz
+
+  build:
+    strategy:
+      fail-fast: true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          java-version: ${{ env.JAVA_VERSION }}
+          distribution: ${{ env.java_distribution }}
+          cache: maven
+      - name: setup cvmfs
+        uses: cvmfs-contrib/github-action-cvmfs@v5
+        with:
+          cvmfs_repositories: 'oasis.opensciencegrid.org'
+      - name: cvmfs
+        run: ls /cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/ccdb/ccdb_latest.sqlite
+      - name: bump version to tag if tag trigger
+        if: ${{ github.ref_type == 'tag' }}
+        run: libexec/version-bump.sh ${{ github.ref_name }}
+      - name: build
+        run: |
+          ./build-coatjava.sh --lfs --no-progress -T${{ env.nthreads }}
+          ./bin/install-clara -b -c ./coatjava ./clara
+      - name: tar # tarball to preserve permissions
+        run: |
+          tar czvf coatjava.tar.gz coatjava
+          tar czvf clara.tar.gz clara
+      - uses: actions/upload-artifact@v7
+        with:
+          name: build_ubuntu-latest
           retention-days: 1
           path: |
               coatjava.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
   # build
   #############################################################################
 
-  build-macos:
+  build_macos:
     strategy:
       fail-fast: true
     runs-on: macos-latest


### PR DESCRIPTION
Previously the downstream tests always wait on the macos build, which are much slower than the linux builds, but only actually use the linux builds.  This avoids that latency at the cost of some duplication ...