### PR TITLE
fix:  use events instead of events/thread in scaling script

### DIFF
--- a/libexec/scaling
+++ b/libexec/scaling
@@ -6,7 +6,7 @@ def cli():
     cli.add_argument('-y','--yaml',   metavar='YAML',help='path to YAML file',required=True)
     cli.add_argument('-c','--clara',  metavar='DIR',help='CLARA_HOME path (default=$CLARA_HOME)',default=os.getenv('CLARA_HOME',None))
     cli.add_argument('-t','--threads',metavar='#',help='threads (default=4,8)',default='4,8')
-    cli.add_argument('-e','--events', metavar='#',help='events per thread (default=555)',default=555,type=int)
+    cli.add_argument('-e','--events', metavar='#',help='events per threads (default=2555)',default=2555,type=int)
     cli.add_argument('-N','--numa',   metavar='#',help='NUMA socket (default=None, choices=[0,1])',default=None,type=int,choices=[0,1])
     cli.add_argument('datafile', help='input EVIO/HIPO data file')
     cfg = cli.parse_args()
@@ -58,7 +58,7 @@ def benchmark(cfg, threads, log):
     # add the run-clara command:
     cmd.extend([cfg.run_clara,
             '-c',cfg.clara,
-            '-n',str(cfg.events*int(threads)),
+            '-n',str(cfg.events),
             '-t',str(threads),
             '-l',
             '-y',cfg.yaml,


### PR DESCRIPTION
The previous `events*threads` thing was not helpful.