### PR TITLE
fix:  reduce DCA swim stopper overhead

### DIFF
--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
@@ -1365,12 +1365,13 @@ public class Swim {
             Point3D dcaCand = new Point3D(y[0],y[1],y[2]); 
             double maxDoca = Double.POSITIVE_INFINITY;
             
-            for(Line3D l : polylines) { 
-                if(l.distance(dcaCand).length()<maxDoca) {
-                    maxDoca=l.distance(dcaCand).length();
+            for(Line3D l : polylines) {
+                double doca = l.distance(dcaCand).length();
+                if (doca < maxDoca) {
+                    maxDoca = doca;
                 } 
             }
-            if(maxDoca<_doca) {
+            if (maxDoca < _doca) {
                 _doca = maxDoca; 
                 return false;
             }

--- a/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
+++ b/common-tools/swim-tools/src/main/java/org/jlab/clas/swimtools/Swim.java
@@ -1361,12 +1361,11 @@ public class Swim {
         
         @Override
         public boolean stopIntegration(double t, double[] y) {
-           
             Point3D dcaCand = new Point3D(y[0],y[1],y[2]); 
             double maxDoca = Double.POSITIVE_INFINITY;
-            
-            for(Line3D l : polylines) {
-                double doca = l.distance(dcaCand).length();
+            int nlines = polylines.size();
+            for(int i=0; i<nlines; i++) {
+                double doca = polylines.get(i).distance(dcaCand).length();
                 if (doca < maxDoca) {
                     maxDoca = doca;
                 } 
@@ -1376,7 +1375,6 @@ public class Swim {
                 return false;
             }
             return true;
-            
         }
 
         /**


### PR DESCRIPTION
1. halve number of DOCA calculations
2. use index loops in time-sensitive stuff

targeted based on an asprof flamegraph: [www.jlab.org/~baltzell/tmp/a](http://www.jlab.org/~baltzell/tmp/a)