### PR TITLE
feat:  add generic EVIO+HIPO reader service

### DIFF
--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
@@ -1,13 +1,11 @@
 package org.jlab.io.clara;
 
-import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
 import org.jlab.clara.engine.EngineDataType;
 import org.jlab.clara.std.services.AbstractEventReaderService;
 import org.jlab.clara.std.services.EventReaderException;
 import org.jlab.coda.jevio.EvioException;
-import org.jlab.io.evio.EvioDataEvent;
 import org.jlab.io.evio.EvioSource;
 import org.jlab.jnp.hipo4.data.Event;
 import org.jlab.jnp.hipo4.io.HipoReader;

--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
@@ -26,8 +26,12 @@ public class Clas12Reader extends AbstractEventReaderService<Object> {
         if (path.toString().endsWith(".hipo")) {
             type = Clas12Types.HIPO;
             HipoReader r = new HipoReader();
-            r.open(path.toString());
-            return r;
+            try {
+                r.open(path.toString());
+                return r;
+            } catch (Exception e) {
+                throw new EventReaderException(e);
+            }
         }
         else {
             type = Clas12Types.EVIO;

--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Reader.java
@@ -1,0 +1,88 @@
+package org.jlab.io.clara;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import org.jlab.clara.engine.EngineDataType;
+import org.jlab.clara.std.services.AbstractEventReaderService;
+import org.jlab.clara.std.services.EventReaderException;
+import org.jlab.coda.jevio.EvioException;
+import org.jlab.io.evio.EvioDataEvent;
+import org.jlab.io.evio.EvioSource;
+import org.jlab.jnp.hipo4.data.Event;
+import org.jlab.jnp.hipo4.io.HipoReader;
+import org.json.JSONObject;
+
+/**
+ * Just reads EVIO or HIPO, and passes it along.
+ * 
+ * @author baltzell
+ */
+public class Clas12Reader extends AbstractEventReaderService<Object> {
+
+    EngineDataType type = Clas12Types.HIPO;
+    private long maxEvents;
+
+    @Override
+    protected Object createReader(Path path, JSONObject opts) throws EventReaderException {
+        if (path.toString().endsWith(".hipo")) {
+            type = Clas12Types.HIPO;
+            HipoReader r = new HipoReader();
+            r.open(path.toString());
+            return r;
+        }
+        else {
+            type = Clas12Types.EVIO;
+            EvioSource r = new EvioSource();
+            r.open(path.toString());
+            maxEvents = r.getEventCount();
+            return r;
+        }
+    }
+
+    @Override
+    protected void closeReader() {
+        if (type == Clas12Types.EVIO) {
+            ((EvioSource)reader).close();
+        }
+        else {
+            ((HipoReader)reader).close();
+        }
+    }
+
+    @Override
+    protected int readEventCount() throws EventReaderException {
+        if (type == Clas12Types.EVIO) {
+            return ((EvioSource)reader).getEventCount();
+        }
+        else {
+            return ((HipoReader)reader).getEventCount();
+        }
+    }
+
+    @Override
+    protected Object readEvent(int eventNumber) throws EventReaderException {
+        try {
+            if (type == Clas12Types.EVIO) {
+                if (eventNumber++ >= maxEvents) return null;
+                return ((EvioSource)reader).getEventBuffer(eventNumber, true);
+                //return new EvioDataEvent(b.array(), readByteOrder());
+            }
+            else {
+                return ((HipoReader)reader).getEvent(new Event(),eventNumber);
+            }
+        } catch (EvioException e) {
+            throw new EventReaderException(e);
+        }
+    }
+
+    @Override
+    public ByteOrder readByteOrder() throws EventReaderException {
+        return ByteOrder.LITTLE_ENDIAN;
+    }
+
+    @Override
+    protected EngineDataType getDataType() {
+        return type;
+    }
+}

--- a/common-tools/clara-io/src/main/resources/org/jlab/io/clara/Clas12Reader.yaml
+++ b/common-tools/clara-io/src/main/resources/org/jlab/io/clara/Clas12Reader.yaml
@@ -1,0 +1,11 @@
+---
+name: Clas12Reader
+engine: org.jlab.io.clara.Clas12Reader
+type: java
+
+author: Nathan Baltzell
+email: baltzell@jlab.org
+
+version: 0.1
+description:
+  Reads EVIO or HIPO events from a file and passes them along unchanged.


### PR DESCRIPTION
This `Clas12Reader` is `EvioToEvioReader + HipoToHipoReader`, currently chosen at runtime based on `.hipo` file suffix.   This will become useful with the (multi-threaded) `DecoderEngine` in #1229.

The previous `Clas12Reader` was `DecoderReader + HipoToHipoReader`.   That was a bit confusing and could be restored with a different name, probably `Clas12Decoder` is a better fit.


