### PR TITLE
fix:  little CVT speedup and cleanup

### DIFF
--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
@@ -268,7 +268,6 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
         double weightedZ1 = 0;                  // SVT/BMT strip centroid positions of endpoints
         double weightedZ2 = 0;                  // SVT/BMT strip centroid positions of endpoints
         double weightedZC = 0;                  // BMT strip centroid positions of strip midpoint
-        double weightedZ0 = 0;                  // BMT strip centroid positions of strip midpoint with no LC
         
         int nbhits = this.size();
         //sort for bmt detector
@@ -356,7 +355,6 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
                 weightedZC += strpEn * stCent.z();
                 weightedX0 += strpEn * stCent0.x();
                 weightedY0 += strpEn * stCent0.y();
-                weightedZ0 += strpEn * stCent0.z();
                 weightedStrp += strpEn * (double) strpNb;
                 weightedStrp0 += strpEn * (double) strpNb0;
                 
@@ -397,7 +395,6 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
             weightedZC /= totEn;
             weightedX0 /= totEn;
             weightedY0 /= totEn;
-            weightedZ0 /= totEn;
             weightedZ /= totEn;
             weightedPhi  = Math.atan2(weightedYC, weightedXC);
             weightedPhi0 = Math.atan2(weightedY0, weightedX0);

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
@@ -63,8 +63,44 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
     private Vector3D _s; //svt vector perpendicular to cluster pseudo-strip direction in the module plane or bmt vector perpendicular to cluster pseudo-strip in direction tangential to the cluster surface in the middle of the arc
     private Vector3D _n; //svt vector normal to the cluster module plane or bmt vector normal to the cluster surface in the middle of the arc
     public boolean flagForExclusion = false;
-    
+   
+    public Cluster(ArrayList<Hit> hits, int id) {
+        super(hits.size());
+        this._Id = id;
+        this._Detector = hits.get(0).getDetector();
+        this._Type = hits.get(0).getType();
+        this._Sector = hits.get(0).getSector();
+        this._Layer = hits.get(0).getLayer();
+        this._Tlayer = hits.get(0).getLayer();
+        if(this._Detector==DetectorType.BMT) 
+            this._Tlayer+=6;
+        this.addAll(hits);
+    }
 
+    public Cluster(int size, Hit hit, int id) {
+        super(size);
+        this._Id = id;
+        this._Detector = hit.getDetector();
+        this._Type = hit.getType();
+        this._Sector = hit.getSector();
+        this._Layer = hit.getLayer();
+        this._Tlayer = hit.getLayer();
+        if(this._Detector==DetectorType.BMT) 
+            this._Tlayer+=6;
+    }
+    
+    public Cluster(int size, DetectorType detector, BMTType type, int sector, int layer, int cid) {
+        super(size);
+        this._Detector = detector;
+        this._Type = type;
+        this._Sector = sector;
+        this._Layer = layer;
+        this._Id = cid;
+        this._Tlayer = layer;
+        if(detector==DetectorType.BMT) 
+            this._Tlayer+=6;
+    }
+    
     public Cluster(DetectorType detector, BMTType type, int sector, int layer, int cid) {
         this._Detector = detector;
         this._Type = type;
@@ -84,7 +120,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * number.
      */
     public Cluster newCluster(Hit hit, int cid) {
-        return new Cluster(hit.getDetector(), hit.getType(), hit.getSector(), hit.getLayer(), cid);
+        return new Cluster(0, hit.getDetector(), hit.getType(), hit.getSector(), hit.getLayer(), cid);
     }
 
     public DetectorType getDetector() {

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
@@ -12,7 +12,6 @@ import org.jlab.detector.base.DetectorDescriptor;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.geom.prim.Arc3D;
 import org.jlab.geom.prim.Cylindrical3D;
-import org.jlab.geom.prim.Plane3D;
 import org.jlab.geom.prim.Transformation3D;
 import org.jlab.rec.cvt.Geometry;
 import org.jlab.rec.cvt.bmt.BMTType;
@@ -725,12 +724,12 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
         Surface surface = null;
         
         if(this.getDetector()==DetectorType.BST) {
-            Point3D endPt1 = this.getLine().origin();
-            Point3D endPt2 = this.getLine().end();
+            //Point3D endPt1 = this.getLine().origin();
+            //Point3D endPt2 = this.getLine().end();
 //            org.jlab.clas.tracking.objects.Strip strp = new org.jlab.clas.tracking.objects.Strip(this.getId(), this.getCentroid(), 
 //                                                                                                 endPt1.x(), endPt1.y(), endPt1.z(),
 //                                                                                                 endPt2.x(), endPt2.y(), endPt2.z());
-            Plane3D plane = new Plane3D(endPt1, this.getN());
+            //Plane3D plane = new Plane3D(endPt1, this.getN());
             surface = Geometry.getInstance().getSVT().getSurface(this.getLayer(), this.getSector(), this.getId(), 
                                                        this.getCentroid(), this.getLine());
             surface.hemisphere = Math.signum(this.center().y());
@@ -803,8 +802,6 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
         int return_val = ((CompPhi == 0) ? return_val1 : CompPhi);
 
         return return_val;
-        
-        
     }
 
     private double PhiInRange(double phi) {
@@ -866,22 +863,22 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
 
     public void update(int trackId, HitOnTrack traj) {
         
-        Point3D  trackPos = new Point3D(traj.x, traj.y, traj.z);
-        Vector3D trackDir = new Vector3D(traj.px, traj.py, traj.pz).asUnit();
+        Point3D trackPos = new Point3D(traj.x, traj.y, traj.z);
                 
         this.setAssociatedTrackID(trackId);
         this.setCentroidResidual(traj.residual);
         this.setSeedResidual(trackPos); 
         this.setTrakInters(trackPos);
-
         
-        if(this.getDetector()==DetectorType.BMT && this.getType()==BMTType.C) {  
-            this.setS(this.getAxis().direction().asUnit());
-            this.setN(this.getAxis().distance(trackPos).direction().asUnit());
-            this.setL(this.getS().cross(this.getN()).asUnit());
-        }
-        if(this.getDetector()==DetectorType.BMT && this.getType()==BMTType.Z) {  
-            this.setCentroidResidual(traj.residual*this.getTile().baseArc().radius());    
+        if(this.getDetector() == DetectorType.BMT) {
+            if (this.getType() == BMTType.C) {  
+                this.setS(this.getAxis().direction().asUnit());
+                this.setN(this.getAxis().distance(trackPos).direction().asUnit());
+                this.setL(this.getS().cross(this.getN()).asUnit());
+            }
+            else if (this.getType() == BMTType.Z) {  
+                this.setCentroidResidual(traj.residual*this.getTile().baseArc().radius());
+            }
         }
         
         for (Hit hit : this) {

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/Cluster.java
@@ -8,6 +8,7 @@ import org.jlab.rec.cvt.hit.Hit;
 import java.util.Collections;
 import org.jlab.clas.tracking.kalmanfilter.AKFitter.HitOnTrack;
 import org.jlab.clas.tracking.kalmanfilter.Surface;
+import org.jlab.detector.base.DetectorDescriptor;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.geom.prim.Arc3D;
 import org.jlab.geom.prim.Cylindrical3D;
@@ -27,10 +28,8 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
 
     private static final long serialVersionUID = 9153980362683755204L;
 
-    private DetectorType _Detector;		//  The detector SVT or BMT
+    private DetectorDescriptor _Descriptor;
     private BMTType  _Type;                   //   The detector type  for BMT C or Z
-    private int _Sector;      		//	sector[1...]
-    private int _Layer;    	 		//	layer [1,...]
     private int _Tlayer;                // layer in tracker comprising 6 svt layers and 6 bmt layer [1...12]
     private int _Id;			//	cluster Id
     private double _Centroid; 		// after LC (Lorentz Correction)
@@ -67,12 +66,10 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
     public Cluster(ArrayList<Hit> hits, int id) {
         super(hits.size());
         this._Id = id;
-        this._Detector = hits.get(0).getDetector();
+        this._Descriptor = hits.get(0).getDescriptor();
         this._Type = hits.get(0).getType();
-        this._Sector = hits.get(0).getSector();
-        this._Layer = hits.get(0).getLayer();
         this._Tlayer = hits.get(0).getLayer();
-        if(this._Detector==DetectorType.BMT) 
+        if(this._Descriptor.getType() == DetectorType.BMT) 
             this._Tlayer+=6;
         this.addAll(hits);
     }
@@ -80,21 +77,20 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
     public Cluster(int size, Hit hit, int id) {
         super(size);
         this._Id = id;
-        this._Detector = hit.getDetector();
+        this._Descriptor = hit.getDescriptor();
         this._Type = hit.getType();
-        this._Sector = hit.getSector();
-        this._Layer = hit.getLayer();
         this._Tlayer = hit.getLayer();
-        if(this._Detector==DetectorType.BMT) 
+        if(this._Descriptor.getType() == DetectorType.BMT) 
             this._Tlayer+=6;
     }
     
     public Cluster(int size, DetectorType detector, BMTType type, int sector, int layer, int cid) {
         super(size);
-        this._Detector = detector;
+        this._Descriptor = new DetectorDescriptor();
+        this._Descriptor.setType(detector);
+        this._Descriptor.setSector(sector);
+        this._Descriptor.setLayer(layer);
         this._Type = type;
-        this._Sector = sector;
-        this._Layer = layer;
         this._Id = cid;
         this._Tlayer = layer;
         if(detector==DetectorType.BMT) 
@@ -102,10 +98,11 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
     }
     
     public Cluster(DetectorType detector, BMTType type, int sector, int layer, int cid) {
-        this._Detector = detector;
+        this._Descriptor = new DetectorDescriptor();
+        this._Descriptor.setType(detector);
+        this._Descriptor.setSector(sector);
+        this._Descriptor.setLayer(layer);
         this._Type = type;
-        this._Sector = sector;
-        this._Layer = layer;
         this._Id = cid;
         this._Tlayer = layer;
         if(detector==DetectorType.BMT) 
@@ -124,11 +121,11 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
     }
 
     public DetectorType getDetector() {
-        return _Detector;
+        return _Descriptor.getType();
     }
 
     public void setDetector(DetectorType _Detector) {
-        this._Detector = _Detector;
+        this._Descriptor.setType(_Detector);
     }
 
     public BMTType getType() {
@@ -144,7 +141,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @return the sector of the cluster
      */
     public int getSector() {
-        return _Sector;
+        return this._Descriptor.getSector();
     }
 
     /**
@@ -152,7 +149,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @param _Sector sector of the cluster
      */
     public void setSector(int _Sector) {
-        this._Sector = _Sector;
+        this._Descriptor.setSector(_Sector);
     }
 
     /**
@@ -160,7 +157,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @return the layer of the cluster
      */
     public int getLayer() {
-        return _Layer;
+        return this._Descriptor.getLayer();
     }
 
     /**
@@ -168,7 +165,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @param _Layer the layer of the cluster
      */
     public void setLayer(int _Layer) {
-        this._Layer = _Layer;
+        this._Descriptor.setLayer(_Layer);
     }
 
     /**
@@ -206,7 +203,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @return region (1...4)
      */
     public int getRegion() {
-        return (int) (this._Layer + 1) / 2;
+        return (int) (this.getLayer() + 1) / 2;
     }
 
     /**
@@ -214,7 +211,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
      * @return superlayer 1 or 2 in region (1...4)
      */
     public int getRegionSlayer() {
-        return (this._Layer + 1) % 2 + 1;
+        return (this.getLayer() + 1) % 2 + 1;
     }
 
     /**
@@ -377,7 +374,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
 
             }
             if (totEn == 0) {
-                System.err.println(" Cluster energy is null .... exit "+this._Detector+" "+this._Type);
+                System.err.println(" Cluster energy is null .... exit "+this._Descriptor.getType()+" "+this._Type);
                 
                 return;
             }
@@ -802,7 +799,7 @@ public class Cluster extends ArrayList<Hit> implements Comparable<Cluster> {
         double arg_phi  = arg.getPhi0();
 
         int CompPhi = this_phi < arg_phi ? -1 : this_phi == arg_phi ? 0 : 1;
-        int CompLay = this._Layer < arg._Layer ? -1 : this._Layer == arg._Layer ? 0 : 1;
+        int CompLay = this.getLayer() < arg.getLayer() ? -1 : this.getLayer() == arg.getLayer() ? 0 : 1;
         int CompId = this.getSeedStrip().getStrip()< arg.getSeedStrip().getStrip() ? -1 : this.getSeedStrip().getStrip() == arg.getSeedStrip().getStrip() ? 0 : 1;
 
         int return_val1 = ((CompLay == 0) ? CompId : CompLay);

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/ClusterFinder.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/cluster/ClusterFinder.java
@@ -3,7 +3,6 @@ package org.jlab.rec.cvt.cluster;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import org.jlab.detector.base.DetectorType;
 import org.jlab.rec.cvt.hit.Hit;
 
 /**
@@ -51,7 +50,6 @@ public class ClusterFinder {
             }
 
         }
-        int cid = 1;  // cluster id, will increment with each new good cluster
 
         // for each layer and sector, a loop over the strips
         // is done to define clusters in that module's layer
@@ -77,10 +75,7 @@ public class ClusterFinder {
                         }
                     
                         // define new cluster 
-                        Cluster this_cluster = new Cluster(hits.get(0).getDetector(), hits.get(0).getType(), hits.get(0).getSector(), l + 1, cid++);
-                        this_cluster.setId(clusters.size() + 1);
-                        // add hits to the cluster
-                        this_cluster.addAll(hits); 
+                        Cluster this_cluster = new Cluster(hits, clusters.size()+1);
                         if(hits.size()>2) {
                             for(int hi = 1; hi<hits.size()-1; hi++) { //interpolate between neighboring strips
                                 if(hits.get(hi).getStrip().getEdep()<hits.get(hi-1).getStrip().getEdep()
@@ -89,17 +84,12 @@ public class ClusterFinder {
                                 }
                             }
                         }
-                        for (Hit h : hits) {
-                            h.setAssociatedClusterID(this_cluster.getId());
-                            //h.newClustering = true; //RDV fix me!
+                        int size = hits.size();
+                        for (int i=0; i<size; i++) {
+                            hits.get(i).setAssociatedClusterID(this_cluster.getId());
                         }
                         
                         this_cluster.calc_CentroidParams();
-                        //if(this_cluster.getDetector()==DetectorType.BST) {
-                        //    for (Hit h : this_cluster) {
-                        //        h.newClustering = false;
-                        //    }
-                        //}
                         Collections.sort(this_cluster);
                        
                         //make list of clusters

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/hit/Hit.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/hit/Hit.java
@@ -47,6 +47,10 @@ public class Hit implements Comparable<Hit> {
         this._Strip = strip;
     }
 
+    public DetectorDescriptor getDescriptor() {
+        return _Descriptor;
+    }
+    
     public DetectorType getDetector() {
         return _Descriptor.getType();
     }

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/hit/Hit.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/hit/Hit.java
@@ -1,5 +1,6 @@
 package org.jlab.rec.cvt.hit;
 
+import org.jlab.detector.base.DetectorDescriptor;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.geom.prim.Line3D;
 import org.jlab.geom.prim.Point3D;
@@ -16,12 +17,8 @@ public class Hit implements Comparable<Hit> {
     // class implements Comparable interface to allow for sorting a collection of hits by wire number values
 
     private int _Id;		       //    Hit Id
-
-    private DetectorType _Detector;    //   the detector SVT or BMT
+    private DetectorDescriptor _Descriptor;
     private BMTType      _Type;        //   for the BMT, either C or Z
-
-    private int _Sector;      	       //   sector[1...24] for SVT, [1..3] for BMT
-    private int _Layer;    	       //   layer [1,...]
     private Strip _Strip;    	       //   Strip object
     
     private double _docaToTrk;              // 3-D distance of closest approach of the helix to the wire 
@@ -35,29 +32,34 @@ public class Hit implements Comparable<Hit> {
     public int MCstatus = -1;
     public boolean isCorrupted;
 
-    // constructor
-    public Hit(DetectorType detector, BMTType type, int sector, int layer, Strip strip) {
-        this._Detector = detector;     // 0 = SVT, 1 = BMT
-        this._Type     = type;               // set according to BMTType
-        this._Sector   = sector;
-        this._Layer    = layer;
+    public Hit(DetectorDescriptor descriptor, BMTType type, Strip strip) {
+        this._Descriptor = descriptor;
+        this._Type     = type;
         this._Strip    = strip;
-
+    }
+    
+    public Hit(DetectorType detector, BMTType type, int sector, int layer, Strip strip) {
+        this._Descriptor = new DetectorDescriptor();
+        this._Descriptor.setType(detector);
+        this._Descriptor.setSector(sector);
+        this._Descriptor.setLayer(layer);
+        this._Type = type;
+        this._Strip = strip;
     }
 
     public DetectorType getDetector() {
-        return _Detector;
+        return _Descriptor.getType();
     }
 
-    public void setDetector(DetectorType _detector) {
-        this._Detector = _detector;
+    public final void setDetector(DetectorType _detector) {
+        this._Descriptor.setType(_detector);
     }
 
     public BMTType getType() {
         return _Type;
     }
 
-    public void setType(BMTType type) {
+    public final void setType(BMTType type) {
         this._Type = type;
     }
 
@@ -66,7 +68,7 @@ public class Hit implements Comparable<Hit> {
      * @return the sector (1...24)
      */
     public int getSector() {
-        return _Sector;
+        return _Descriptor.getSector();
     }
 
     /**
@@ -74,8 +76,8 @@ public class Hit implements Comparable<Hit> {
      *
      * @param _Sector
      */
-    public void setSector(int _Sector) {
-        this._Sector = _Sector;
+    public final void setSector(int _Sector) {
+        this._Descriptor.setSector(_Sector);
     }
 
     /**
@@ -83,7 +85,7 @@ public class Hit implements Comparable<Hit> {
      * @return the layer (1...8)
      */
     public int getLayer() {
-        return _Layer;
+        return _Descriptor.getLayer();
     }
 
     /**
@@ -91,15 +93,15 @@ public class Hit implements Comparable<Hit> {
      *
      * @param _Layer
      */
-    public void setLayer(int _Layer) {
-        this._Layer = _Layer;
+    public final void setLayer(int _Layer) {
+        this._Descriptor.setLayer(_Layer);
     }
 
     public Strip getStrip() {
         return _Strip;
     }
 
-    public void setStrip(Strip _Strip) {
+    public final void setStrip(Strip _Strip) {
         this._Strip = _Strip;
     }
 
@@ -116,7 +118,7 @@ public class Hit implements Comparable<Hit> {
      *
      * @param _Id
      */
-    public void setId(int _Id) {
+    public final void setId(int _Id) {
         this._Id = _Id;
     }
 
@@ -125,7 +127,7 @@ public class Hit implements Comparable<Hit> {
      * @return region (1...4)
      */
     public int getRegion() {
-        return (int) (this._Layer + 1) / 2;
+        return (int) (this.getLayer() + 1) / 2;
     }
 
     /**
@@ -133,7 +135,7 @@ public class Hit implements Comparable<Hit> {
      * @return superlayer 1 or 2 in region (1...4)
      */
     public int getRegionSlayer() {
-        return (this._Layer + 1) % 2 + 1;
+        return (this.getLayer() + 1) % 2 + 1;
     }
 
     /**

--- a/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Track.java
+++ b/reconstruction/cvt/src/main/java/org/jlab/rec/cvt/track/Track.java
@@ -3,7 +3,6 @@ package org.jlab.rec.cvt.track;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +61,6 @@ public class Track extends Trajectory implements Comparable<Track> {
     private int    secondaryNDF;                   // for track with no beamSpot information
     private int _status = 0;
 
-
     public Track(Helix helix) {
         super(helix);
         if (helix != null) {
@@ -97,7 +95,6 @@ public class Track extends Trajectory implements Comparable<Track> {
             this.setStatus(-1);
         }
     }
-    
         
     public Track(Seed seed, KFitter kf, int pid) {
         this(seed, kf);
@@ -162,7 +159,7 @@ public class Track extends Trajectory implements Comparable<Track> {
         return secondaryHelix;
     }
 
-    public void setSecondaryHelix(Helix secondaryHelix) {
+    public final void setSecondaryHelix(Helix secondaryHelix) {
         this.secondaryHelix = secondaryHelix;
     }
 
@@ -170,7 +167,7 @@ public class Track extends Trajectory implements Comparable<Track> {
         return secondaryChi2;
     }
 
-    public void setSecondaryChi2(double secondaryChi2) {
+    public final void setSecondaryChi2(double secondaryChi2) {
         this.secondaryChi2 = secondaryChi2;
     }
 
@@ -178,7 +175,7 @@ public class Track extends Trajectory implements Comparable<Track> {
         return secondaryNDF;
     }
 
-    public void setSecondaryNDF(int secondaryNDF) {
+    public final void setSecondaryNDF(int secondaryNDF) {
         this.secondaryNDF = secondaryNDF;
     }
 
@@ -205,8 +202,7 @@ public class Track extends Trajectory implements Comparable<Track> {
                 calcPt = 100;
                 setQ(1);
             }
-            double calcPz = 0;
-            calcPz = calcPt * helix.getTanDip();
+            double calcPz = calcPt * helix.getTanDip();
             double calcP = Math.sqrt(calcPt * calcPt + calcPz * calcPz);
             setPt(calcPt);
             setPz(calcPz);
@@ -217,6 +213,8 @@ public class Track extends Trajectory implements Comparable<Track> {
     /**
      * Updates the crosses positions based on trajectories or helix
      * @param trackId
+     * @param xb
+     * @param yb
      */
     public void update_Crosses(int trackId, double xb, double yb) {
         for (int i = 0; i < this.size(); i++) {
@@ -288,12 +286,7 @@ public class Track extends Trajectory implements Comparable<Track> {
         if (getClass() != obj.getClass()) {
             return false;
         }
-        Track other = (Track) obj;
-        if (this.getId() != other.getId()) {
-            return false;
-        }
-
-        return true;
+        return this.getId() == ((Track)obj).getId();
     }
 
     @Override
@@ -328,9 +321,9 @@ public class Track extends Trajectory implements Comparable<Track> {
             return false;
         if(this.getNDF() < Constants.NDFCUT) 
             return false;
-        if(this.getHelix().radius() < Constants.getInstance().getRCUT()) 
+        if(this.getHelix().radius() < Constants.getRCUT()) 
             return false;
-        if(Math.abs(Geometry.getInstance().getTargetZOffset()-this.getHelix().getZ0()) > Geometry.getInstance().getTargetHalfLength()+Constants.getInstance().getZRANGE()) 
+        if(Math.abs(Geometry.getInstance().getTargetZOffset()-this.getHelix().getZ0()) > Geometry.getInstance().getTargetHalfLength()+Constants.getZRANGE()) 
             return false;
         else 
             return true;
@@ -396,7 +389,7 @@ public class Track extends Trajectory implements Comparable<Track> {
         return _PID;
     }
 
-    public void setPID(int _PID) {
+    public final void setPID(int _PID) {
         this._PID = _PID;
     }
     
@@ -445,13 +438,14 @@ public class Track extends Trajectory implements Comparable<Track> {
     public int getStatus() {
         return _status;
     }
-    public void setStatus(int passKFFlag) {
+    public final void setStatus(int passKFFlag) {
         //for status word:
         int nSVT  = 0;
         int nBMTZ = 0;
         int nBMTC = 0;
         // fills the list of cross ids for crosses belonging to that reconstructed track
-        for (int j = 0; j < this.size(); j++) {
+        int size = this.size();
+        for (int j = 0; j < size; j++) {
             // counter to get status word    
             if (this.get(j).getDetector() == DetectorType.BST) {
                 nSVT++;
@@ -565,7 +559,8 @@ public class Track extends Trajectory implements Comparable<Track> {
     
     private  static int[]  getTrackKey(Track track) {
         int[] cids  = new int[9];
-        for (int i = 0; i < track.size(); i++) {
+        int size = track.size();
+        for (int i = 0; i < size; i++) {
             Cross c =  track.get(i);
             if(c.getDetector()==DetectorType.BST) {
                 cids[c.getRegion()-1] = c.getId();
@@ -593,12 +588,13 @@ public class Track extends Trajectory implements Comparable<Track> {
                 return;
         Map<Integer, Track>  map = new HashMap<>();    
         Map<Integer, Track>  selectedTracks = new HashMap<>();  
-        for (int i = 0; i < tracks.size(); i++) {
+        final int size = tracks.size();
+        for (int i = 0; i < size; i++) {
             Track t1 = tracks.get(i);
             t1.setTempId(i+1);
             map.put(i+1, t1);
         }
-        for (int i = 0; i < tracks.size(); i++) {
+        for (int i = 0; i < size; i++) {
             Track t1 = tracks.get(i);
             int[] cids = getTrackKey(t1);
             for (int j = 0;j < tracks.size(); j++) {
@@ -606,10 +602,11 @@ public class Track extends Trajectory implements Comparable<Track> {
                 if(i==j) continue;
                 Track t2 = tracks.get(j);
                 int[] cids2 = getTrackKey(t2);
-                for(int k  =  0; k<9; k++) {
+                for(int k = 0; k < 9; k++) {
                     if(cids[k]!=-1) {
                         if(cids[k]==cids2[k]) {
                             ov=true;
+                            break;
                         }
                     }
                 }
@@ -618,7 +615,7 @@ public class Track extends Trajectory implements Comparable<Track> {
                 }
             }
         }
-        for (int i = 0; i < tracks.size(); i++) {
+        for (int i = 0; i < size; i++) {
             List<Track> ovlTracks =  new ArrayList<>();
             Track t1 = tracks.get(i);
             ovlTracks.add(t1); 
@@ -638,9 +635,10 @@ public class Track extends Trajectory implements Comparable<Track> {
     }
     
     public static void checkForOverlaps(List<Track> tracks, String msg) {
-        for (int i = 0; i < tracks.size(); i++) {
+        int size = tracks.size();
+        for (int i = 0; i < size; i++) {
             Track t1 = tracks.get(i);
-            for(int j=0; j<tracks.size(); j++ ) {
+            for(int j=0; j<size; j++ ) {
                 Track t2 = tracks.get(j);
                 if(i!=j && t1.overlapWith(t2)) {
                     System.out.println(msg + " " + "overlap");
@@ -648,7 +646,6 @@ public class Track extends Trajectory implements Comparable<Track> {
             }
         }        
     }
-
 
     @Override
     public String toString() {
@@ -660,9 +657,5 @@ public class Track extends Trajectory implements Comparable<Track> {
         for(Cluster c: this.getSeed().getClusters()) str = str + c.toString() + "\n";
         return str;
     }
-
-    
-
-    
 
 }


### PR DESCRIPTION
`org.jlab.rec.cvt.cluster.ClusterFinder.findClusters` is a hot spot.

This also allows to avoid some memory overhead by initializing with a `DetectorDescriptor` reference rather than copying the indices.  Is that safe?  Depends on how this is used ...