### PR TITLE
feat:  use previous unix time reading in CLARA writer

### DIFF
--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
@@ -2,6 +2,7 @@ package org.jlab.io.clara;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.TreeMap;
 import java.util.TreeSet;
 import org.jlab.analysis.postprocess.Processor;
 import org.jlab.clara.std.services.EventWriterException;
@@ -38,6 +39,7 @@ public class DecoderWriter extends HipoToHipoWriter {
     Bank runConfig;
     Bank helicityAdc;
     ConstantsManager conman;
+    TreeMap<Integer,Integer> unixEventMap;
     TreeSet<HelicityState> helicities;
     DaqScalersSequence scalers;
     SchemaFactory fullSchema;
@@ -49,6 +51,7 @@ public class DecoderWriter extends HipoToHipoWriter {
         runConfig = new Bank(fullSchema.getSchema("RUN::config"));
         helicityAdc = new Bank(fullSchema.getSchema("HEL::adc"));
         helicities = new TreeSet<>();
+        unixEventMap = new TreeMap<>();
         scalers = new DaqScalersSequence(fullSchema);
         conman = new ConstantsManager();
         conman.init("/runcontrol/hwp","/runcontrol/helicity");
@@ -72,7 +75,7 @@ public class DecoderWriter extends HipoToHipoWriter {
             throw new EventWriterException(e);
         }
     }
-
+    
     /**
      * In addition to writing the incoming event, copies all tag-1 banks to new
      * tag-1 events and writes them, and stores helicity/scaler readings for later.
@@ -85,6 +88,8 @@ public class DecoderWriter extends HipoToHipoWriter {
         ((Event)event).read(runConfig);
         ((Event)event).read(helicityAdc);
         helicities.add(HelicityState.createFromFadcBank(helicityAdc, runConfig, conman));
+        if (runConfig.getRows() > 0)
+            unixEventMap.put(runConfig.getInt("event",0),runConfig.getInt("unixTime", 0));
         Event t = CLASDecoder4.createTaggedEvent((Event)event, runConfig, tag1banks);
         if (!t.isEmpty()) writer.addEvent(t, 1);
         super.writeEvent(event);
@@ -100,8 +105,9 @@ public class DecoderWriter extends HipoToHipoWriter {
         super.closeWriter();
         if (postprocess) postprocess();
         // keep the latest helicity/scaler reading for the next file:
-        while (helicities.size() > 60) helicities.pollFirst();
-        scalers.clear(10);
+        while (helicities.size() > 100) helicities.pollFirst();
+        while (unixEventMap.size() > 100) unixEventMap.pollFirstEntry();
+        scalers.clear(100);
     }
   
     private int getRunNumber() {

--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
@@ -88,8 +88,12 @@ public class DecoderWriter extends HipoToHipoWriter {
         ((Event)event).read(runConfig);
         ((Event)event).read(helicityAdc);
         helicities.add(HelicityState.createFromFadcBank(helicityAdc, runConfig, conman));
-        if (runConfig.getRows() > 0)
-            unixEventMap.put(runConfig.getInt("event",0),runConfig.getInt("unixTime", 0));
+        if (runConfig.getRows() > 0) {
+            int unix = runConfig.getInt("unixTime",0);
+            int evno = runConfig.getInt("event",0);
+            if (unix > 0) unixEventMap.put(evno, unix);
+            else runConfig.putInt("unixTime",0, unixEventMap.get(unixEventMap.floorKey(evno)));
+        }
         Event t = CLASDecoder4.createTaggedEvent((Event)event, runConfig, tag1banks);
         if (!t.isEmpty()) writer.addEvent(t, 1);
         super.writeEvent(event);

--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderWriter.java
@@ -91,7 +91,9 @@ public class DecoderWriter extends HipoToHipoWriter {
         if (runConfig.getRows() > 0) {
             int unix = runConfig.getInt("unixTime",0);
             int evno = runConfig.getInt("event",0);
+            // if this event has a good unix time, store it for later:
             if (unix > 0) unixEventMap.put(evno, unix);
+            // otherwise update it with the latest unix time reading:
             else runConfig.putInt("unixTime",0, unixEventMap.get(unixEventMap.floorKey(evno)));
         }
         Event t = CLASDecoder4.createTaggedEvent((Event)event, runConfig, tag1banks);


### PR DESCRIPTION
Prior to #1263, we were caching the unix time across events in decoding.  That was (presumably) very intentional, as the DAQ often writes zero for unix time, but it leads to non-determinism when parallelizing the decoder.

Here we instead write the "correct" unix time to each event in the CLARA writer.