### PR TITLE
feat:  finalize clara io service names

### DIFF
--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Writer.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Writer.java
@@ -31,7 +31,7 @@ import org.json.JSONObject;
  *
  * @author baltzell
  */
-public class DecoderWriter extends HipoToHipoWriter {
+public class Clas12Writer extends HipoToHipoWriter {
 
     static final String[] TAG1BANKS = {"RUN::scaler","HEL::scaler","RAW::scaler","RAW::epics","HEL::flip","COAT::config"};
 

--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderReader.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/DecoderReader.java
@@ -14,7 +14,7 @@ import org.jlab.jnp.hipo4.data.Event;
 import org.json.JSONObject;
 
 /**
- * Combined with DecoderWriter, a port of the standard "decoder" to CLARA.
+ * Combined with Clas12Writer, a port of the standard "decoder" to CLARA.
  * 
  * 1. Convert EVIO to HIPO
  * 2. CCDB translation tables, c/s/c -> s/l/c/o

--- a/common-tools/clara-io/src/main/resources/org/jlab/io/clara/Clas12Writer.yaml
+++ b/common-tools/clara-io/src/main/resources/org/jlab/io/clara/Clas12Writer.yaml
@@ -1,6 +1,6 @@
 ---
-name: DecoderWriter
-engine: org.jlab.io.clara.DecoderWriter
+name: Clas12Writer
+engine: org.jlab.io.clara.Clas12Writer
 type: java
 
 author: Nathan Baltzell

--- a/etc/services/data-ai-uber.yml
+++ b/etc/services/data-ai-uber.yml
@@ -17,8 +17,8 @@ io-services:
     class: org.jlab.io.clara.DecoderReader
     name: DecoderReader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   - class: org.jlab.service.uber.Uber$First
     name: 1ST

--- a/etc/services/data-aicv-uber.yml
+++ b/etc/services/data-aicv-uber.yml
@@ -17,8 +17,8 @@ io-services:
     class: org.jlab.io.clara.DecoderReader
     name: DecoderReader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   - class: org.jlab.service.uber.Uber$First
     name: 1ST

--- a/etc/services/data-cv-uber.yml
+++ b/etc/services/data-cv-uber.yml
@@ -15,8 +15,8 @@ io-services:
     class: org.jlab.io.clara.DecoderReader
     name: DecoderReader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   - class: org.jlab.service.uber.Uber$First
     name: 1ST

--- a/etc/services/decode.yaml
+++ b/etc/services/decode.yaml
@@ -3,8 +3,8 @@ io-services:
     class: org.jlab.io.clara.DecoderReader
     name: DecoderReader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   # FIXME: replace with dummy/useful service
   - class: org.jlab.service.eb.EBTBEngine

--- a/etc/services/decode.yaml
+++ b/etc/services/decode.yaml
@@ -1,20 +1,12 @@
 io-services:
   reader:
-    class: org.jlab.io.clara.DecoderReader
-    name: DecoderReader
+    class: org.jlab.io.clara.Clas12Reader
+    name: Clas12Reader
   writer:
     class: org.jlab.io.clara.Clas12Writer
     name: Clas12Writer
 services:
-  # FIXME: replace with dummy/useful service
-  - class: org.jlab.service.eb.EBTBEngine
-    name: EBTB
-configuration:
-  io-services:
-    reader:
-      variation: default
-      timestamp: 05/11/2025-00:00:00
-    writer:
-      schema_dir: full
+  - class: org.jlab.clas.reco.DecoderEngine
+    name: DECO
 mime-types:
   - binary/data-hipo

--- a/etc/services/rgd-clarode.yml
+++ b/etc/services/rgd-clarode.yml
@@ -22,8 +22,8 @@ io-services:
     class: org.jlab.io.clara.EvioToEvioReader
     name: EvioReader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   - class: org.jlab.clas.reco.DecoderEngine
     name: DECO

--- a/etc/services/rgl-clarode.yml
+++ b/etc/services/rgl-clarode.yml
@@ -3,8 +3,8 @@ io-services:
     class: org.jlab.io.clara.Clas12Reader
     name: Clas12Reader
   writer:
-    class: org.jlab.io.clara.DecoderWriter
-    name: DecoderWriter
+    class: org.jlab.io.clara.Clas12Writer
+    name: Clas12Writer
 services:
   - class: org.jlab.clas.swimtools.MagFieldsEngine
     name: MAGFIELDS


### PR DESCRIPTION
This just renames `DecoderWriter` → `Clas12Writer`.

So, now the standard will become `Clas12Reader` and `Clas12Writer`, which works for both HIPO and EVIO inputs, assuming the new `DecoderEngine` is the first engine in the chain.

#1280 will followup with larger YAML changes and unification.
