### PR TITLE
fix:  avoid listeners and timers and call event action manually

### DIFF
--- a/common-tools/clas-io/src/main/java/org/jlab/io/task/DataSourceProcessorPane.java
+++ b/common-tools/clas-io/src/main/java/org/jlab/io/task/DataSourceProcessorPane.java
@@ -210,13 +210,18 @@ public class DataSourceProcessorPane extends JPanel implements ActionListener {
         DataSource source = filename.endsWith(".hipo") ?
             new HipoDataSource() : new EvioSource();
         source.open(filename);
-        this.dataProcessor.setSource(source);
+        dataProcessor.setSource(source);
         statusLabel.setText(dataProcessor.getStatusString());
         mediaPlay.setEnabled(false);
-        mediaPause.setEnabled(true);
-        mediaNext.setEnabled(true);
-        mediaPrev.setEnabled(true);
-        this.startProcessorTimer();
+        mediaPause.setEnabled(false);
+        mediaNext.setEnabled(false);
+        mediaPrev.setEnabled(false);
+        while (dataProcessor.dataSource.hasEvent()) {
+            DataEvent e = dataProcessor.dataSource.getNextEvent();
+            for(IDataEventListener processor : dataProcessor.eventListeners){
+                processor.dataEventAction(e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Workaround for [https://code.jlab.org/hallb/clas12/calibration/calcode/-/work_items/49](https://code.jlab.org/hallb/clas12/calibration/calcode/-/work_items/49).