### PR TITLE
feat:  remove remaining decoding loop

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -1,7 +1,6 @@
 package org.jlab.detector.decode;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,18 +104,18 @@ public class DetectorEventDecoder {
         keysMicromega= new HashSet<>();
         tableTrans = new HashMap<>();
         tableFitter = new HashMap<>();
+
         keysFilter.add(DetectorType.DC);
 
         tableTrans.put(DetectorType.HTCC, "/daq/tt/clasdev/htcc");
         tableTrans.put(DetectorType.BST, "/daq/tt/clasdev/svt");
         tableTrans.put(DetectorType.RTPC, "/daq/tt/clasdev/rtpc");
-        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
 
         tableFitter.put(DetectorType.HTCC, "/daq/fadc/clasdev/htcc");
+
+        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
         fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
-        
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp",
-                                                      "/runcontrol/helicity","/daq/config/scalers/dsc1"}));
+        scalerManager.init("/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
     }
 
     public final void initDecoder() {
@@ -156,7 +155,6 @@ public class DetectorEventDecoder {
         tableTrans.put(DetectorType.RASTER, "/daq/tt/raster");
         tableTrans.put(DetectorType.ATOF,   "/daq/tt/atof");
         tableTrans.put(DetectorType.AHDC,   "/daq/tt/ahdc");
-        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
 
         tableFitter.put(DetectorType.FTCAL,  "/daq/fadc/ftcal");
         tableFitter.put(DetectorType.FTHODO, "/daq/fadc/fthodo");
@@ -174,10 +172,10 @@ public class DetectorEventDecoder {
         tableFitter.put(DetectorType.BAND,   "/daq/fadc/band");
         tableFitter.put(DetectorType.RASTER, "/daq/fadc/raster");
         tableFitter.put(DetectorType.AHDC,   "/daq/fadc/ahdc");
+        
+        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
         fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
- 
-        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup",
-            "/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1"}));
+        scalerManager.init("/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
 
         if (initializeManagers) {
             translationManager.init(tablesTrans);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -214,61 +214,59 @@ public class DetectorEventDecoder {
 
     public void fitPulses(List<DetectorDataDgtz>  detectorData){
 
+        final long hash0 = IndexedTable.DEFAULT_GENERATOR.hashCode(0,0,0);
+
         for (DetectorDataDgtz data : detectorData) {
 
             if (data.getADCSize() == 0) continue;
-            int crate    = data.getDescriptor().getCrate();
-            int slot     = data.getDescriptor().getSlot();
-            int channel  = data.getDescriptor().getChannel();
-            long hash    = IndexedTable.DEFAULT_GENERATOR.hashCode(crate,slot,channel);
-            long hash0   = IndexedTable.DEFAULT_GENERATOR.hashCode(0,0,0);
-            boolean ismm = keysMicromega.contains(data.getDescriptor().getType());
 
-            for (DetectorType type : tablesFitter.keySet()) {
+            DetectorType type = data.getDescriptor().getType();
 
-                IndexedTable daq = tablesFitter.get(type);
-                //custom MM fitter
-                if (ismm && data.getDescriptor().getType() == type) {
-                    short adcOffset = (short) daq.getDoubleValueByHash("adc_offset", hash0);
-                    double fineTimeStampResolution = (byte) daq.getDoubleValueByHash("dream_clock", hash0);
-                    double samplingTime = (byte) daq.getDoubleValueByHash("sampling_time", hash0);
-                    int sparseSample = daq.getIntValueByHash("sparse", hash0);
-                    ADCData adc = data.getADCData(0);
-                    mvtFitter.fit(adcOffset, fineTimeStampResolution, samplingTime, adc.getPulseArray(), adc.getTimeStamp(), sparseSample);
-                    adc.setHeight((short) (mvtFitter.adcMax));
-                    adc.setTime((int) (mvtFitter.timeMax));
-                    adc.setIntegral((int) (mvtFitter.integral));
-                    adc.setTimeStamp(mvtFitter.timestamp);
-                    // first one wins:
-                    break;
-                }
-                else if(daq.hasEntryByHash(hash)==true){
-                    int nsa = daq.getIntValueByHash("nsa", hash);
-                    int nsb = daq.getIntValueByHash("nsb", hash);
-                    int tet = daq.getIntValueByHash("tet", hash);
+            if (!tablesFitter.containsKey(type)) continue;
+
+            IndexedTable daqTable = tablesFitter.get(type);
+
+            // For Micromegas, assume crate/slot/channel=0/0/0 for table lookup:
+            if (keysMicromega.contains(type)) {
+                short adcOffset = (short) daqTable.getDoubleValueByHash("adc_offset", hash0);
+                double fineTimeStampResolution = (byte) daqTable.getDoubleValueByHash("dream_clock", hash0);
+                double samplingTime = (byte) daqTable.getDoubleValueByHash("sampling_time", hash0);
+                int sparseSample = daqTable.getIntValueByHash("sparse", hash0);
+                ADCData adc = data.getADCData(0);
+                mvtFitter.fit(adcOffset, fineTimeStampResolution, samplingTime, adc.getPulseArray(), adc.getTimeStamp(), sparseSample);
+                adc.setHeight((short) (mvtFitter.adcMax));
+                adc.setTime((int) (mvtFitter.timeMax));
+                adc.setIntegral((int) (mvtFitter.integral));
+                adc.setTimeStamp(mvtFitter.timestamp);
+            }
+
+            // Otherwise, use crate/slot/channel to find the table entry:
+            else {
+                long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(
+                        data.getDescriptor().getCrate(),
+                        data.getDescriptor().getSlot(),
+                        data.getDescriptor().getChannel());
+                if (daqTable.hasEntryByHash(hash)) {
+                    int nsa = daqTable.getIntValueByHash("nsa", hash);
+                    int nsb = daqTable.getIntValueByHash("nsb", hash);
+                    int tet = daqTable.getIntValueByHash("tet", hash);
                     int ped = 0;
-                    if(data.getDescriptor().getType() == DetectorType.RF && type == DetectorType.RF) {
-                        ped = daq.getIntValueByHash("pedestal", hash);
+                    if (data.getDescriptor().getType() == DetectorType.RF && type == DetectorType.RF)  {
+                        ped = daqTable.getIntValueByHash("pedestal", hash);
                     }
-                    for(int i = 0; i < data.getADCSize(); i++){
+                    for (int i = 0; i < data.getADCSize(); i++) {
                         ADCData adc = data.getADCData(i);
                         if(adc.getPulseSize()>0){
                             try {
                                 extendedFitter.fit(nsa, nsb, tet, ped, adc.getPulseArray());
                             } catch (Exception e) {
-                                System.out.println(">>>> error : fitting pulse "
-                                    +  crate + " / " + slot + " / " + channel);
+                                System.err.println(">>>> error : fitting pulse "+data.getDescriptor().getCrate()+
+                                    " / "+data.getDescriptor().getSlot()+" / "+data.getDescriptor().getChannel());
                             }
-                            int adc_corrected = extendedFitter.adc + extendedFitter.ped*(nsa+nsb);
                             adc.setHeight((short) this.extendedFitter.pulsePeakValue);
-                            adc.setIntegral(adc_corrected);
-                            adc.setTimeWord(this.extendedFitter.t0);
-                            adc.setPedestal((short) this.extendedFitter.ped);
                         }
                         data.getADCData(i).setADC(nsa, nsb);
                     }
-                    // first one wins:
-                    break;
                 }
             }
         }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -4,8 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.jlab.detector.banks.RawBank.OrderType;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
@@ -22,13 +24,12 @@ public class DetectorEventDecoder {
     ConstantsManager fitterManager      = new ConstantsManager();
     ConstantsManager scalerManager      = new ConstantsManager();
 
-    List<String> tablesTrans  = null;
-    List<String> tablesFitter = null;
+    HashSet<DetectorType> keysFilter;
+    HashSet<DetectorType> keysMicromega;
 
-    List<DetectorType> keysTrans    = null;
-    List<DetectorType> keysFitter   = null;
-    List<DetectorType> keysFilter   = null;
-    List<DetectorType> keysMicromega= null;
+    HashMap<DetectorType,String> tableTrans;
+    HashMap<DetectorType,String> tableFitter;
+    HashMap<DetectorType,IndexedTable> tablesFitter;
 
     private int runNumber = 10;
 
@@ -71,8 +72,11 @@ public class DetectorEventDecoder {
     public void setRunNumber(int run){
         if (run != this.runNumber) {
             translator = new TranslationTable();
-            for (int i=0; i<keysTrans.size(); i++)
-                translator.add(keysTrans.get(i), translationManager.getConstants(run, tablesTrans.get(i)));
+            tablesFitter = new HashMap<>();
+            for (DetectorType t : tableTrans.keySet())
+                translator.add(t, translationManager.getConstants(run, tableTrans.get(t)));
+            for (DetectorType t: tableFitter.keySet())
+                tablesFitter.put(t, fitterManager.getConstants(run, tableFitter.get(t)));
         }
         this.runNumber = run;
     }
@@ -91,13 +95,26 @@ public class DetectorEventDecoder {
                 getValue()).floatValue();
     }
 
-    public final void initDecoderDev(){
-        keysTrans = Arrays.asList(new DetectorType[]{ DetectorType.HTCC,DetectorType.BST,DetectorType.RTPC} );
-        tablesTrans = Arrays.asList(new String[]{ "/daq/tt/clasdev/htcc","/daq/tt/clasdev/svt","/daq/tt/clasdev/rtpc" });
-        keysFitter   = Arrays.asList(new DetectorType[]{DetectorType.HTCC});
-        tablesFitter = Arrays.asList(new String[]{"/daq/fadc/clasdev/htcc"});
-        translationManager.init(tablesTrans);
-        fitterManager.init(tablesFitter);
+    public DetectorEventDecoder(){
+        this.initDecoder();
+    }
+
+    public final void initDecoderDev() {
+
+        keysFilter = new HashSet<>();
+        keysMicromega= new HashSet<>();
+        tableTrans = new HashMap<>();
+        tableFitter = new HashMap<>();
+        keysFilter.add(DetectorType.DC);
+
+        tableTrans.put(DetectorType.HTCC, "/daq/tt/clasdev/htcc");
+        tableTrans.put(DetectorType.BST, "/daq/tt/clasdev/svt");
+        tableTrans.put(DetectorType.RTPC, "/daq/tt/clasdev/rtpc");
+        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
+
+        tableFitter.put(DetectorType.HTCC, "/daq/fadc/clasdev/htcc");
+        fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
+        
         scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp",
                                                       "/runcontrol/helicity","/daq/config/scalers/dsc1"}));
     }
@@ -108,35 +125,59 @@ public class DetectorEventDecoder {
 
     public final void initDecoder(boolean initializeManagers){
 
-        // Detector translation table
-        keysTrans = Arrays.asList(new DetectorType[]{DetectorType.FTCAL,DetectorType.FTHODO,DetectorType.FTTRK,DetectorType.LTCC,DetectorType.ECAL,DetectorType.FTOF,
-                                               DetectorType.HTCC,DetectorType.DC,DetectorType.CTOF,DetectorType.CND,DetectorType.BST,DetectorType.RF,DetectorType.BMT,DetectorType.FMT,
-                                               DetectorType.RICH,DetectorType.HEL,DetectorType.BAND,DetectorType.RTPC,
-                                               DetectorType.RASTER,DetectorType.ATOF,DetectorType.AHDC
-        });
-        tablesTrans = Arrays.asList(new String[]{
-            "/daq/tt/ftcal","/daq/tt/fthodo","/daq/tt/fttrk","/daq/tt/ltcc",
-            "/daq/tt/ec","/daq/tt/ftof","/daq/tt/htcc","/daq/tt/dc","/daq/tt/ctof","/daq/tt/cnd","/daq/tt/svt",
-            "/daq/tt/rf","/daq/tt/bmt","/daq/tt/fmt","/daq/tt/rich2","/daq/tt/hel","/daq/tt/band","/daq/tt/rtpc",
-            "/daq/tt/raster","/daq/tt/atof","/daq/tt/ahdc"
-        });
-        
-        // ADC waveform fitter translation table
-        keysFitter   = Arrays.asList(new DetectorType[]{DetectorType.FTCAL,DetectorType.FTHODO,DetectorType.FTTRK,DetectorType.FTOF,DetectorType.LTCC,
-                                                  DetectorType.ECAL,DetectorType.HTCC,DetectorType.CTOF,DetectorType.CND,DetectorType.BMT,
-                                                  DetectorType.FMT,DetectorType.HEL,DetectorType.RF,DetectorType.BAND,DetectorType.RASTER,
-                                                  DetectorType.AHDC});
-        tablesFitter = Arrays.asList(new String[]{
-            "/daq/fadc/ftcal","/daq/fadc/fthodo","/daq/config/fttrk","/daq/fadc/ftof","/daq/fadc/ltcc",
-            "/daq/fadc/ec", "/daq/fadc/htcc","/daq/fadc/ctof","/daq/fadc/cnd","/daq/config/bmt",
-            "/daq/config/fmt","/daq/fadc/hel","/daq/fadc/rf","/daq/fadc/band","/daq/fadc/raster",
-            "/daq/config/ahdc"
-        });
+        keysFilter = new HashSet<>();
+        keysMicromega= new HashSet<>();
+        tableTrans = new HashMap<>();
+        tableFitter = new HashMap<>();
+        keysFilter.add(DetectorType.DC); 
 
-        // Data filter list
-        keysFilter   = Arrays.asList(new DetectorType[]{DetectorType.DC});
-        
-        keysMicromega = Arrays.asList(new DetectorType[]{DetectorType.BMT,DetectorType.FMT,DetectorType.FTTRK});
+        keysMicromega.add(DetectorType.BMT);
+        keysMicromega.add(DetectorType.FMT);
+        keysMicromega.add(DetectorType.FTTRK);    
+
+        tableTrans.put(DetectorType.FTCAL,  "/daq/tt/ftcal");
+        tableTrans.put(DetectorType.FTHODO, "/daq/tt/fthodo");
+        tableTrans.put(DetectorType.FTTRK,  "/daq/tt/fttrk");
+        tableTrans.put(DetectorType.LTCC,   "/daq/tt/ltcc");
+        tableTrans.put(DetectorType.ECAL,   "/daq/tt/ec");
+        tableTrans.put(DetectorType.FTOF,   "/daq/tt/ftof");
+        tableTrans.put(DetectorType.HTCC,   "/daq/tt/htcc");
+        tableTrans.put(DetectorType.DC,     "/daq/tt/dc");
+        tableTrans.put(DetectorType.CTOF,   "/daq/tt/ctof");
+        tableTrans.put(DetectorType.CND,    "/daq/tt/cnd");
+        tableTrans.put(DetectorType.BST,    "/daq/tt/svt");
+        tableTrans.put(DetectorType.RF,     "/daq/tt/rf");
+        tableTrans.put(DetectorType.BMT,    "/daq/tt/bmt");
+        tableTrans.put(DetectorType.FMT,    "/daq/tt/fmt");
+        tableTrans.put(DetectorType.RICH,   "/daq/tt/rich2");
+        tableTrans.put(DetectorType.HEL,    "/daq/tt/hel");
+        tableTrans.put(DetectorType.BAND,   "/daq/tt/band");
+        tableTrans.put(DetectorType.RTPC,   "/daq/tt/rtpc");
+        tableTrans.put(DetectorType.RASTER, "/daq/tt/raster");
+        tableTrans.put(DetectorType.ATOF,   "/daq/tt/atof");
+        tableTrans.put(DetectorType.AHDC,   "/daq/tt/ahdc");
+        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
+
+        tableFitter.put(DetectorType.FTCAL,  "/daq/fadc/ftcal");
+        tableFitter.put(DetectorType.FTHODO, "/daq/fadc/fthodo");
+        tableFitter.put(DetectorType.FTTRK,  "/daq/fadc/fttrk");
+        tableFitter.put(DetectorType.FTOF,   "/daq/fadc/ftof");
+        tableFitter.put(DetectorType.LTCC,   "/daq/fadc/ltcc");
+        tableFitter.put(DetectorType.ECAL,   "/daq/fadc/ec");
+        tableFitter.put(DetectorType.HTCC,   "/daq/fadc/htcc");
+        tableFitter.put(DetectorType.CTOF,   "/daq/fadc/ctof");
+        tableFitter.put(DetectorType.CND,    "/daq/fadc/cnd");
+        tableFitter.put(DetectorType.BMT,    "/daq/fadc/bmt");
+        tableFitter.put(DetectorType.FMT,    "/daq/fadc/fmt");
+        tableFitter.put(DetectorType.HEL,    "/daq/fadc/hel");
+        tableFitter.put(DetectorType.RF,     "/daq/fadc/rf");
+        tableFitter.put(DetectorType.BAND,   "/daq/fadc/band");
+        tableFitter.put(DetectorType.RASTER, "/daq/fadc/raster");
+        tableFitter.put(DetectorType.AHDC,   "/daq/fadc/ahdc");
+        fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
+ 
+        scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup",
+            "/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1"}));
 
         if (initializeManagers) {
             translationManager.init(tablesTrans);
@@ -149,10 +190,11 @@ public class DetectorEventDecoder {
     }
 
     public void checkTables() {
-        for (int i=0; i<tablesTrans.size(); i++) {
-            IndexedTable t = translationManager.getConstants(runNumber, tablesTrans.get(i));
+        List<String> tables = (List)tableTrans.values().stream().collect(Collectors.toList());
+        for (int i=0; i<tables.size(); i++) {
+            IndexedTable t = translationManager.getConstants(runNumber, tables.get(i));
             for (int j=0; j<i; j++)
-                t.conflicts(translationManager.getConstants(runNumber, tablesTrans.get(j)));
+                t.conflicts(translationManager.getConstants(runNumber, tables.get(j)));
         }
     }
 
@@ -185,9 +227,9 @@ public class DetectorEventDecoder {
     public void fitPulses(List<DetectorDataDgtz>  detectorData){
 
         // preload CCDB tables once:
-        ArrayList<IndexedTable> tables = new ArrayList<>();
-        for (String name : tablesFitter) {
-            tables.add(fitterManager.getConstants(runNumber, name));
+        HashMap<DetectorType,IndexedTable> tables = new HashMap<>();
+        for (Map.Entry<DetectorType, String> e : tableFitter.entrySet()) {
+            tables.put(e.getKey(), fitterManager.getConstants(runNumber, e.getValue()));
         }
 
         for(DetectorDataDgtz data : detectorData){
@@ -199,9 +241,8 @@ public class DetectorEventDecoder {
             long hash0   = IndexedTable.DEFAULT_GENERATOR.hashCode(0,0,0);
             boolean ismm = keysMicromega.contains(data.getDescriptor().getType());
 
-            for (int j=0; j<keysFitter.size(); ++j) {
-                IndexedTable daq = tables.get(j);
-                DetectorType type = keysFitter.get(j);
+            for (DetectorType type : tableFitter.keySet()) {
+                IndexedTable daq = tables.get(type);
                 //custom MM fitter
                 if (ismm && data.getDescriptor().getType() == type) {
                     short adcOffset = (short) daq.getDoubleValueByHash("adc_offset", hash0);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.jlab.detector.banks.RawBank.OrderType;
+import org.jlab.detector.base.DetectorDescriptor;
 import org.jlab.detector.base.DetectorType;
 import org.jlab.detector.calib.utils.ConstantsManager;
 import org.jlab.detector.decode.DetectorDataDgtz.ADCData;
@@ -220,7 +221,8 @@ public class DetectorEventDecoder {
 
             if (data.getADCSize() == 0) continue;
 
-            DetectorType type = data.getDescriptor().getType();
+            final DetectorDescriptor desc = data.getDescriptor();
+            final DetectorType type = desc.getType();
 
             if (!tablesFitter.containsKey(type)) continue;
 
@@ -228,10 +230,10 @@ public class DetectorEventDecoder {
 
             // For Micromegas, assume crate/slot/channel=0/0/0 for table lookup:
             if (keysMicromega.contains(type)) {
-                short adcOffset = (short) daqTable.getDoubleValueByHash("adc_offset", hash0);
-                double fineTimeStampResolution = (byte) daqTable.getDoubleValueByHash("dream_clock", hash0);
-                double samplingTime = (byte) daqTable.getDoubleValueByHash("sampling_time", hash0);
-                int sparseSample = daqTable.getIntValueByHash("sparse", hash0);
+                final short adcOffset = (short) daqTable.getDoubleValueByHash("adc_offset", hash0);
+                final double fineTimeStampResolution = (byte) daqTable.getDoubleValueByHash("dream_clock", hash0);
+                final double samplingTime = (byte) daqTable.getDoubleValueByHash("sampling_time", hash0);
+                final int sparseSample = daqTable.getIntValueByHash("sparse", hash0);
                 ADCData adc = data.getADCData(0);
                 mvtFitter.fit(adcOffset, fineTimeStampResolution, samplingTime, adc.getPulseArray(), adc.getTimeStamp(), sparseSample);
                 adc.setHeight((short) (mvtFitter.adcMax));
@@ -242,28 +244,32 @@ public class DetectorEventDecoder {
 
             // Otherwise, use crate/slot/channel to find the table entry:
             else {
-                long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(
-                        data.getDescriptor().getCrate(),
-                        data.getDescriptor().getSlot(),
-                        data.getDescriptor().getChannel());
+                
+                final long hash = IndexedTable.DEFAULT_GENERATOR.hashCode(
+                    desc.getCrate(), desc.getSlot(), desc.getChannel());
+                
                 if (daqTable.hasEntryByHash(hash)) {
-                    int nsa = daqTable.getIntValueByHash("nsa", hash);
-                    int nsb = daqTable.getIntValueByHash("nsb", hash);
-                    int tet = daqTable.getIntValueByHash("tet", hash);
+                    final int nsa = daqTable.getIntValueByHash("nsa", hash);
+                    final int nsb = daqTable.getIntValueByHash("nsb", hash);
+                    final int tet = daqTable.getIntValueByHash("tet", hash);
                     int ped = 0;
-                    if (data.getDescriptor().getType() == DetectorType.RF && type == DetectorType.RF)  {
+                    if (type == DetectorType.RF)  {
                         ped = daqTable.getIntValueByHash("pedestal", hash);
                     }
-                    for (int i = 0; i < data.getADCSize(); i++) {
+                    final int nadc = data.getADCSize();
+                    for (int i = 0; i < nadc; i++) {
                         ADCData adc = data.getADCData(i);
                         if(adc.getPulseSize()>0){
                             try {
                                 extendedFitter.fit(nsa, nsb, tet, ped, adc.getPulseArray());
                             } catch (Exception e) {
-                                System.err.println(">>>> error : fitting pulse "+data.getDescriptor().getCrate()+
-                                    " / "+data.getDescriptor().getSlot()+" / "+data.getDescriptor().getChannel());
+                                System.err.println(">>>> error : fitting pulse "+desc.getCrate()+
+                                    " / "+desc.getSlot()+" / "+desc.getChannel());
                             }
+                            adc.setIntegral(extendedFitter.adc + extendedFitter.ped*(nsa+nsb));
                             adc.setHeight((short) this.extendedFitter.pulsePeakValue);
+                            adc.setTimeWord(this.extendedFitter.t0);
+                            adc.setPedestal((short) this.extendedFitter.ped);
                         }
                         data.getADCData(i).setADC(nsa, nsb);
                     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -214,13 +214,8 @@ public class DetectorEventDecoder {
 
     public void fitPulses(List<DetectorDataDgtz>  detectorData){
 
-        // preload CCDB tables once:
-        HashMap<DetectorType,IndexedTable> tables = new HashMap<>();
-        for (Map.Entry<DetectorType, String> e : tableFitter.entrySet()) {
-            tables.put(e.getKey(), fitterManager.getConstants(runNumber, e.getValue()));
-        }
+        for (DetectorDataDgtz data : detectorData) {
 
-        for(DetectorDataDgtz data : detectorData){
             if (data.getADCSize() == 0) continue;
             int crate    = data.getDescriptor().getCrate();
             int slot     = data.getDescriptor().getSlot();
@@ -229,8 +224,9 @@ public class DetectorEventDecoder {
             long hash0   = IndexedTable.DEFAULT_GENERATOR.hashCode(0,0,0);
             boolean ismm = keysMicromega.contains(data.getDescriptor().getType());
 
-            for (DetectorType type : tableFitter.keySet()) {
-                IndexedTable daq = tables.get(type);
+            for (DetectorType type : tablesFitter.keySet()) {
+
+                IndexedTable daq = tablesFitter.get(type);
                 //custom MM fitter
                 if (ismm && data.getDescriptor().getType() == type) {
                     short adcOffset = (short) daq.getDoubleValueByHash("adc_offset", hash0);

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -172,7 +172,7 @@ public class DetectorEventDecoder {
         if (initializeManagers) {
             translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
             fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
-            scalerManager.init("/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
+            scalerManager.init("/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
             checkTables();
         }
     }

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -154,20 +154,20 @@ public class DetectorEventDecoder {
 
         tableFitter.put(DetectorType.FTCAL,  "/daq/fadc/ftcal");
         tableFitter.put(DetectorType.FTHODO, "/daq/fadc/fthodo");
-        tableFitter.put(DetectorType.FTTRK,  "/daq/fadc/fttrk");
+        tableFitter.put(DetectorType.FTTRK,  "/daq/config/fttrk");
         tableFitter.put(DetectorType.FTOF,   "/daq/fadc/ftof");
         tableFitter.put(DetectorType.LTCC,   "/daq/fadc/ltcc");
         tableFitter.put(DetectorType.ECAL,   "/daq/fadc/ec");
         tableFitter.put(DetectorType.HTCC,   "/daq/fadc/htcc");
         tableFitter.put(DetectorType.CTOF,   "/daq/fadc/ctof");
         tableFitter.put(DetectorType.CND,    "/daq/fadc/cnd");
-        tableFitter.put(DetectorType.BMT,    "/daq/fadc/bmt");
-        tableFitter.put(DetectorType.FMT,    "/daq/fadc/fmt");
+        tableFitter.put(DetectorType.BMT,    "/daq/config/bmt");
+        tableFitter.put(DetectorType.FMT,    "/daq/config/fmt");
         tableFitter.put(DetectorType.HEL,    "/daq/fadc/hel");
         tableFitter.put(DetectorType.RF,     "/daq/fadc/rf");
         tableFitter.put(DetectorType.BAND,   "/daq/fadc/band");
         tableFitter.put(DetectorType.RASTER, "/daq/fadc/raster");
-        tableFitter.put(DetectorType.AHDC,   "/daq/fadc/ahdc");
+        tableFitter.put(DetectorType.AHDC,   "/daq/config/ahdc");
         
         if (initializeManagers) {
             translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/decode/DetectorEventDecoder.java
@@ -94,10 +94,6 @@ public class DetectorEventDecoder {
                 getValue()).floatValue();
     }
 
-    public DetectorEventDecoder(){
-        this.initDecoder();
-    }
-
     public final void initDecoderDev() {
 
         keysFilter = new HashSet<>();
@@ -173,18 +169,12 @@ public class DetectorEventDecoder {
         tableFitter.put(DetectorType.RASTER, "/daq/fadc/raster");
         tableFitter.put(DetectorType.AHDC,   "/daq/fadc/ahdc");
         
-        translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
-        fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
-        scalerManager.init("/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
-
         if (initializeManagers) {
-            translationManager.init(tablesTrans);
-            fitterManager.init(tablesFitter);
-            scalerManager.init(Arrays.asList(new String[]{"/runcontrol/fcup","/runcontrol/slm","/runcontrol/hwp",
-                                                          "/runcontrol/helicity","/daq/config/scalers/dsc1"}));
+            translationManager.init(tableTrans.values().stream().collect(Collectors.toList()));
+            fitterManager.init(tableFitter.values().stream().collect(Collectors.toList()));
+            scalerManager.init("/runcontrol/slm","/runcontrol/hwp","/runcontrol/helicity","/daq/config/scalers/dsc1");
             checkTables();
         }
-
     }
 
     public void checkTables() {


### PR DESCRIPTION
Replace hit-level loop over detector types/tables with direct hash map lookup.  Depends on #1273