### PR TITLE
fix macos CI test, add SQLites to coatjava build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,12 +66,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - name: setup cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
-      - name: cvmfs
-        run: ls /cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/ccdb/ccdb_latest.sqlite
       - name: bump version to tag if tag trigger
         if: ${{ github.ref_type == 'tag' }}
         run: libexec/version-bump.sh ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,12 +96,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - name: setup cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
-      - name: cvmfs
-        run: ls /cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/ccdb/ccdb_latest.sqlite
       - name: bump version to tag if tag trigger
         if: ${{ github.ref_type == 'tag' }}
         run: libexec/version-bump.sh ${{ github.ref_name }}
@@ -148,9 +142,6 @@ jobs:
           java-version: ${{ matrix.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - name: unit tests
         run: ./build-coatjava.sh --lfs --unittests --no-progress -T${{ env.nthreads }}
       - name: collect jacoco report
@@ -175,9 +166,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - uses: actions/download-artifact@v8
         with:
           name: build_ubuntu-latest
@@ -197,9 +185,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - uses: actions/download-artifact@v8
         with:
           name: build_ubuntu-latest
@@ -229,10 +214,6 @@ jobs:
           java-version: ${{ env.JAVA_VERSION }}
           distribution: ${{ env.java_distribution }}
           cache: maven
-      - name: setup cvmfs
-        uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - uses: actions/download-artifact@v8
         with:
           name: build_ubuntu-latest
@@ -286,9 +267,6 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: build_${{ matrix.runner }}
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - name: untar build
         run: |
           tar xzvf coatjava.tar.gz
@@ -317,9 +295,6 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: build_macos
-      - uses: cvmfs-contrib/github-action-cvmfs@v5
-        with:
-          cvmfs_repositories: 'oasis.opensciencegrid.org'
       - name: untar build
         run: |
           tar xzvf coatjava.tar.gz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-# https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
-
 name: Coatjava-CI
 
 on:
@@ -7,10 +5,6 @@ on:
   push:
     branches: [ development ]
     tags: [ '*' ]
-  schedule:
-    # NOTE: From what I read, the email notification for cron can only go
-    #       to the last committer of this file!!!!!
-    - cron: '0 22 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:////home/runner/work/coatjava/coatjava/coatjava/etc/data/sqlite/ccdb.sqlite'
+  CCDB_CONNECTION: 'sqlite:///${{ github.workspace }}/coatjava/etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:////cvmfs/oasis.opensciencegrid.org/jlab/hallb/clas12/sw/noarch/data/ccdb/ccdb_latest.sqlite'
+  CCDB_CONNECTION: 'sqlite:///etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:///etc/data/sqlite/ccdb.sqlite'
+  CCDB_CONNECTION: 'sqlite:///coatjava/etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,6 +225,7 @@ jobs:
       - name: untar build
         run: |
           tar xzvf clara.tar.gz
+          tar xzvf coatjava.tar.gz
       - name: run test
         run: |
           ls -lhtr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:////home/runner/work/coatjava/coatjava/etc/data/sqlite/ccdb.sqlite'
+  CCDB_CONNECTION: 'sqlite:////home/runner/work/coatjava/coatjava/coatjava/etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:///coatjava/etc/data/sqlite/ccdb.sqlite'
+  CCDB_CONNECTION: 'sqlite:///$GITHUB_WORKSPACE/coatjava/etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
   java_distribution: zulu
   javadoc_version: 25 # newer than `JAVA_VERSION` for better javadoc
   groovy_version: 4.x
-  CCDB_CONNECTION: 'sqlite:///$GITHUB_WORKSPACE/coatjava/etc/data/sqlite/ccdb.sqlite'
+  CCDB_CONNECTION: 'sqlite:////home/runner/work/coatjava/coatjava/etc/data/sqlite/ccdb.sqlite'
   nthreads: 1
 
 jobs:

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "etc/nnet"]
 	path = etc/data/nnet
 	url = https://code.jlab.org/hallb/clas12/coatjava/networks.git
+[submodule "etc/data/sqlite"]
+	path = etc/data/sqlite
+	url = https://code.jlab.org/hallb/clas12/ccdbrcdb-sqlite

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -13,6 +13,7 @@ cleanBuild=false
 runSpotBugs=false
 downloadMaps=true
 downloadNets=true
+downloadSqlites=true
 runUnitTests=false
 dataRetrieval=lfs
 installClara=false
@@ -40,6 +41,7 @@ DATA RETRIEVAL OPTIONS
   Additional options
     --nomaps          do not download/overwrite field maps
     --nonets          do not download/overwrite neural networks
+    --nosqlites       do not download/overwrite SQLite files for CCDB/RCDB
     --wipe            remove retrieved data
 
 TESTING OPTIONS
@@ -66,6 +68,7 @@ do
     -n)          runSpotBugs=false  ;;
     --nomaps)    downloadMaps=false ;;
     --nonets)    downloadNets=false ;;
+    --nosqlites) downloadSqlites=false ;;
     --unittests) runUnitTests=true  ;;
     --clean)     cleanBuild=true    ;;
     --depana)
@@ -281,13 +284,25 @@ if $downloadNets; then
   esac
 fi
 
+# download neural networks
+if $downloadSqlites; then
+  case $dataRetrieval in
+    lfs)
+      notify_retrieval 'ccdb/rcdb SQLite files' 'lfs'
+      download_lfs etc/data/sqlite
+      ;;
+    *)
+      echo 'WARNING: sqlites not downloaded; run with `--help` for guidance' >&2
+      ;;
+  esac
+fi
+
 # download validation data
 if $downloadData; then
   case $dataRetrieval in
     lfs)
       notify_retrieval 'validation data' 'lfs'
       download_lfs validation/advanced-tests/data
-      download_lfs etc/data/sqlite
       ;;
     *)
       echo 'ERROR: option `--lfs` must be used when using `--data`' >&2

--- a/build-coatjava.sh
+++ b/build-coatjava.sh
@@ -287,6 +287,7 @@ if $downloadData; then
     lfs)
       notify_retrieval 'validation data' 'lfs'
       download_lfs validation/advanced-tests/data
+      download_lfs etc/data/sqlite
       ;;
     *)
       echo 'ERROR: option `--lfs` must be used when using `--data`' >&2


### PR DESCRIPTION
* Just remove reliance on CVMFS from github CI
* Add https://code.jlab.org/hallb/clas12/ccdbrcdb-sqlite for git-lfs storage of CCDB/RCDB SQLite files
* Add SQLite to the build script defaults (another 500 MB), add `--nosqlite` option 