### PR TITLE
ci: update `needs` for `final` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,6 +421,11 @@ jobs:
       - test_coatjava
       - test_run-groovy
       - generate_documentation
+      - spotbugs
+      - test_decoder
+      - test_clara
+      - test_coatjava_macos
+      - unit_tests
     runs-on: ubuntu-latest
     steps:
       - name: pass


### PR DESCRIPTION
with this, we could set `final` to be a required job to pass for CI pipelines