### PR TITLE
feat:  add parallell clara output

### DIFF
--- a/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Writer.java
+++ b/common-tools/clara-io/src/main/java/org/jlab/io/clara/Clas12Writer.java
@@ -28,7 +28,7 @@ import org.json.JSONObject;
  * 3. Writes HEL::flip, RUN/HEL::scaler, and RUN::unix to new tag-1 events
  * 4. Runs post-processing, writing tag-1 information to all events 
  * 5. Adds .hipo to the output filename, if necessary
- *
+ * 6. Outputs a parallel file of select trigger bits with a raw schema
  * @author baltzell
  */
 public class Clas12Writer extends HipoToHipoWriter {
@@ -44,6 +44,8 @@ public class Clas12Writer extends HipoToHipoWriter {
     DaqScalersSequence scalers;
     SchemaFactory fullSchema;
     boolean postprocess;
+    HipoWriterSorted rawWriter;
+    long rawTriggerMask;
 
     private void init(JSONObject opts) {
         fullSchema = new SchemaFactory();
@@ -56,6 +58,7 @@ public class Clas12Writer extends HipoToHipoWriter {
         eventUnix = new TreeMap<>();
         conman.init("/runcontrol/hwp","/runcontrol/helicity");
         postprocess = opts.optBoolean("postprocess", false);
+        rawTriggerMask = opts.optLong("rawTriggerMask", -1);
         if (opts.has("variation")) conman.setVariation(opts.getString("variation"));
         if (opts.has("timestamp")) conman.setTimeStamp(opts.getString("timestamp"));
         tag1banks = new Bank[TAG1BANKS.length];
@@ -70,6 +73,11 @@ public class Clas12Writer extends HipoToHipoWriter {
             HipoWriterSorted w = new HipoWriterSorted();
             super.configure(w, opts);
             w.open(file.toString().endsWith(".hipo") ? file.toString() : file.toString()+".hipo");
+            if (rawTriggerMask > 0) {
+                rawWriter = new HipoWriterSorted();
+                rawWriter.getSchemaFactory().copy(fullSchema);
+                rawWriter.open("raw_"+file.toString().substring(file.toString().indexOf("_")));
+            }
             return w;
         } catch (Exception e) {
             throw new EventWriterException(e);
@@ -90,6 +98,14 @@ public class Clas12Writer extends HipoToHipoWriter {
         Event t = CLASDecoder4.createTaggedEvent((Event)event, runConfig, tag1banks);
         if (!t.isEmpty()) writer.addEvent(t, 1);
         super.writeEvent(event);
+        if (rawTriggerMask > 0) {
+            if (runConfig.getRows() > 0) {
+                if ((runConfig.getLong("trigger",0) & rawTriggerMask) != 0) {
+                    rawWriter.addEvent((Event)event);
+                }
+            }
+            if (!t.isEmpty()) rawWriter.addEvent(t, 1);
+        }
     }
 
     @Override
@@ -101,6 +117,7 @@ public class Clas12Writer extends HipoToHipoWriter {
         // keep the latest helicity/scaler reading for the next file:
         while (helicities.size() > 60) helicities.pollFirst();
         scalers.clear(10);
+        if (rawTriggerMask > 0) rawWriter.close();
     }
  
     /**


### PR DESCRIPTION
This enables outputting a parallel HIPO file containing a full bank schema but only the selected trigger bits, controlled by the `rawTriggerMask` YAML variable.