### PR TITLE
update DCClsComboEngine.java to set limit for cluster combos in case of memory explosion

### DIFF
--- a/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
+++ b/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
@@ -57,6 +57,10 @@ public class DCClsComboEngine extends ReconstructionEngine {
             
     final static int SUPERLAYERS = 6;    
     
+    private static final Logger LOGGER = Logger.getLogger(DCClsComboEngine.class.getName());
+    private boolean warned6ClsLimit = false;
+    private boolean warned5ClsLimit = false;
+    
     public DCClsComboEngine() {
         super("DCClsComboEngine","tongtong","1.0");
     }
@@ -94,7 +98,7 @@ public class DCClsComboEngine extends ReconstructionEngine {
             model6Cls = criteria6Cls.loadModel();
             predictors6Cls = new PredictorPool(threads, model6Cls);
         } catch (NullPointerException | MalformedModelException | IOException | ModelNotFoundException ex) {
-            Logger.getLogger(DCClsComboEngine.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
             return false;
         }
         
@@ -117,7 +121,7 @@ public class DCClsComboEngine extends ReconstructionEngine {
             model5Cls = criteria5Cls.loadModel();
             predictors5Cls = new PredictorPool(threads, model5Cls);
         } catch (NullPointerException | MalformedModelException | IOException | ModelNotFoundException ex) {
-            Logger.getLogger(DCClsComboEngine.class.getName()).log(Level.SEVERE, null, ex);
+            LOGGER.log(Level.SEVERE, null, ex);
             return false;
         }  
         
@@ -147,8 +151,9 @@ public class DCClsComboEngine extends ReconstructionEngine {
             allClusterList.add(cls);
             map.computeIfAbsent(sector, s -> new HashMap<>()).computeIfAbsent(superlayer, sl -> new ArrayList<>()).add(cls);
         }
-        
+                        
         // Make 6-cluster combos
+        warned6ClsLimit = false;
         List<DCClusterCombo> all6ClsCombos = new ArrayList();
         for(Map<Integer, List<DCCluster>> map_sl_clsList : map.values()){
             if(map_sl_clsList.size() == 6){
@@ -230,10 +235,12 @@ public class DCClsComboEngine extends ReconstructionEngine {
         }
         
         // Make 5-cluster combos
+        warned5ClsLimit = false;
         List<DCClusterCombo> all5ClsCombos = new ArrayList<>();
         for (Map<Integer, List<DCCluster>> map_sl_clsList : map.values()) {
             if(map_sl_clsList.size() >= 5){
                 Map<Integer, List<DCCluster>> orderedMap = new TreeMap<>(map_sl_clsList); // Sorts entries by superlayer in ascending order
+                
                 List<DCClusterCombo> combos = new ArrayList<>();
                 generate5ClsCombos(orderedMap, combos);
                 all5ClsCombos.addAll(combos);
@@ -346,8 +353,18 @@ public class DCClsComboEngine extends ReconstructionEngine {
     */
     public void generate6ClsCombos(Map<Integer, List<DCCluster>> map, int sl, DCCluster[] current, List<DCClusterCombo> comboList) {
 
-        // Limit for combos
-        if (comboList.size() >= limitClsCombosPerSector) return; 
+        // Limit for combos        
+        if (comboList.size() >= limitClsCombosPerSector) {
+            if (!warned6ClsLimit) {                
+                LOGGER.log(Level.FINE, String.format(
+                    "6-cluster combo generation reached limit: %d combos per sector. "
+                    + "Further combinations are discarded.",
+                    limitClsCombosPerSector
+                ));
+                warned6ClsLimit = true;
+            }
+            return;
+        }
         
         // Base case: if all superlayers have been processed (sl > 6)
         // then we have a complete 6-cluster combination
@@ -415,7 +432,17 @@ public class DCClsComboEngine extends ReconstructionEngine {
                                        List<DCClusterCombo> outputList) {
         
         // Limit for combos
-        if (outputList.size() >= limitClsCombosPerSector) return; 
+        if (outputList.size() >= limitClsCombosPerSector) {
+            if (!warned5ClsLimit) {
+                LOGGER.log(Level.FINE, String.format(
+                    "5-cluster combo generation reached limit: %d combos per sector. "
+                    + "Further combinations are discarded.",
+                    limitClsCombosPerSector
+                ));
+                warned5ClsLimit = true;
+            }
+            return;
+        }
 
         // Base case: all superlayers processed
         if (sl > SUPERLAYERS) {

--- a/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
+++ b/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
@@ -37,7 +37,7 @@ public class DCClsComboEngine extends ReconstructionEngine {
     final static String CONF_THREADS = "threads";
     
     final static String LIMIT_CLSCOMBOS_PERSECTOR = "limitClsCombosPerSector";
-    int limitClsCombosPerSector = (int)1e6;
+    int limitClsCombosPerSector = (int)1e5;
     
     final static String CONF_MODEL_FILE_6CLS = "modelFile6Cls";
     final static String CONF_THRESHOLD_6CLS = "threshold6Cls";  

--- a/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
+++ b/reconstruction/ai/src/main/java/org/jlab/service/ai/DCClsComboEngine.java
@@ -36,6 +36,9 @@ public class DCClsComboEngine extends ReconstructionEngine {
     
     final static String CONF_THREADS = "threads";
     
+    final static String LIMIT_CLSCOMBOS_PERSECTOR = "limitClsCombosPerSector";
+    int limitClsCombosPerSector = (int)1e6;
+    
     final static String CONF_MODEL_FILE_6CLS = "modelFile6Cls";
     final static String CONF_THRESHOLD_6CLS = "threshold6Cls";  
     String modelFile6Cls = "mlp_64h_4l_6cls.pt";
@@ -51,7 +54,7 @@ public class DCClsComboEngine extends ReconstructionEngine {
     Criteria<float[][], float[]> criteria5Cls;
     ZooModel<float[][], float[]> model5Cls;
     PredictorPool predictors5Cls;    
-    
+            
     final static int SUPERLAYERS = 6;    
     
     public DCClsComboEngine() {
@@ -68,6 +71,9 @@ public class DCClsComboEngine extends ReconstructionEngine {
         System.setProperty("ai.djl.pytorch.graph_optimizer", "false");
         
         int threads = Integer.parseInt(getEngineConfigString(CONF_THREADS,"64"));
+        
+        if (getEngineConfigString(LIMIT_CLSCOMBOS_PERSECTOR) != null)
+            limitClsCombosPerSector = Integer.parseInt(getEngineConfigString(LIMIT_CLSCOMBOS_PERSECTOR));
         
         if (getEngineConfigString(CONF_THRESHOLD_6CLS) != null)
             threshold6Cls = Float.parseFloat(getEngineConfigString(CONF_THRESHOLD_6CLS));
@@ -340,6 +346,9 @@ public class DCClsComboEngine extends ReconstructionEngine {
     */
     public void generate6ClsCombos(Map<Integer, List<DCCluster>> map, int sl, DCCluster[] current, List<DCClusterCombo> comboList) {
 
+        // Limit for combos
+        if (comboList.size() >= limitClsCombosPerSector) return; 
+        
         // Base case: if all superlayers have been processed (sl > 6)
         // then we have a complete 6-cluster combination
         if (sl > SUPERLAYERS) {
@@ -368,7 +377,7 @@ public class DCClsComboEngine extends ReconstructionEngine {
      */
     public void generate5ClsCombos(Map<Integer, List<DCCluster>> mapSL,
                                    List<DCClusterCombo> outputList) {
-
+        
         // Iterate over all possible missing superlayers (1 to 6)
         for (int missingSL = 1; missingSL <= SUPERLAYERS; missingSL++) {
 
@@ -404,6 +413,9 @@ public class DCClsComboEngine extends ReconstructionEngine {
                                        DCCluster[] current,
                                        int idx,
                                        List<DCClusterCombo> outputList) {
+        
+        // Limit for combos
+        if (outputList.size() >= limitClsCombosPerSector) return; 
 
         // Base case: all superlayers processed
         if (sl > SUPERLAYERS) {


### PR DESCRIPTION
Response to #1336,  set limit for DC cluster combos. 
By default, limit is 1M for each sector. If combos reach the limit for a sector, then the first 1M combos will be kept.
Totally, the memory usage is estimate to be ~1.8G at most, if all 6 sectors reach the default limit.
Limit of 1M is supposed to be large enough. The plot show distribution for # of combos of a sector using run 6666 for test.
<img width="730" height="360" alt="Plot_07-16-2026_09 43 03_AM" src="https://github.com/user-attachments/assets/36ce4ad4-c572-4de2-a903-c34ef40269b6" />