### PR TITLE
build: remove `javafx` from modules that don't really need it

### DIFF
--- a/common-tools/clas-reco/pom.xml
+++ b/common-tools/clas-reco/pom.xml
@@ -21,12 +21,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>javafx-base</artifactId>
-      <classifier>linux</classifier>
-    </dependency>
-
-    <dependency>
       <groupId>org.jlab.coda</groupId>
       <artifactId>jclara</artifactId>
     </dependency>

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/matching/AMatch.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/matching/AMatch.java
@@ -1,7 +1,7 @@
 package org.jlab.clas.detector.matching;
 
 import java.util.List;
-import javafx.util.Pair;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import org.jlab.clas.detector.DetectorParticle;
 import org.jlab.clas.detector.DetectorResponse;
 import org.jlab.detector.base.DetectorType;
@@ -123,8 +123,8 @@ public abstract class AMatch implements IMatch {
      * @return 
      */
     @Override
-    public int compare(Pair<DetectorParticle,DetectorResponse> a,
-                       Pair<DetectorParticle,DetectorResponse> b) {
+    public int compare(SimpleImmutableEntry<DetectorParticle,DetectorResponse> a,
+                       SimpleImmutableEntry<DetectorParticle,DetectorResponse> b) {
         if (this.quality(a.getKey(),a.getValue()) <
             this.quality(b.getKey(),b.getValue())) {
             return 1;
@@ -138,9 +138,9 @@ public abstract class AMatch implements IMatch {
     
     /*
     public DetectorResponse findMatch2(DetectorParticle p, List<DetectorResponse> r) {
-        List<Pair<DetectorParticle,DetectorResponse>> l = new ArrayList<>();
+        List<SimpleImmutableEntry<DetectorParticle,DetectorResponse>> l = new ArrayList<>();
         for (DetectorResponse r1 : r) {
-            l.add(new Pair<>(p,r1));
+            l.add(new SimpleImmutableEntry<>(p,r1));
         }
         Collections.sort(l, this);
         return l.get(0).getValue();

--- a/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/matching/IMatch.java
+++ b/common-tools/clas-reco/src/main/java/org/jlab/clas/detector/matching/IMatch.java
@@ -2,7 +2,7 @@ package org.jlab.clas.detector.matching;
 
 import java.util.Comparator;
 import java.util.List;
-import javafx.util.Pair;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import org.jlab.clas.detector.DetectorParticle;
 import org.jlab.clas.detector.DetectorResponse;
 import org.jlab.detector.base.DetectorType;
@@ -11,7 +11,7 @@ import org.jlab.detector.base.DetectorType;
  *
  * @author baltzell
  */
-public interface IMatch extends Comparator<Pair<DetectorParticle,DetectorResponse>> {
+public interface IMatch extends Comparator<SimpleImmutableEntry<DetectorParticle,DetectorResponse>> {
     
     public abstract boolean matches(DetectorParticle p, DetectorResponse r);
 

--- a/reconstruction/ltcc/pom.xml
+++ b/reconstruction/ltcc/pom.xml
@@ -15,11 +15,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.openjfx</groupId>
-      <artifactId>javafx-base</artifactId>
-      <classifier>linux</classifier>
-    </dependency>
-    <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
     </dependency>

--- a/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHistogrammer.java
+++ b/reconstruction/ltcc/src/main/java/org/jlab/service/ltcc/viewer/LTCCHistogrammer.java
@@ -9,7 +9,7 @@ import java.util.LinkedHashMap;
 import java.util.function.Function;
 import java.util.List;
 import java.util.stream.Collectors;
-import javafx.util.Pair;
+import java.util.AbstractMap.SimpleImmutableEntry;
 import org.jlab.groot.data.H1F;
 import org.jlab.groot.data.H2F;
 
@@ -38,7 +38,7 @@ public class LTCCHistogrammer<DataType> {
     }
     
     private final Map<String, SmartHisto<H1F, Double>> histos1D;
-    private final Map<String, SmartHisto<H2F, Pair<Double, Double>>> histos2D;
+    private final Map<String, SmartHisto<H2F, SimpleImmutableEntry<Double, Double>>> histos2D;
     
     LTCCHistogrammer() {
         histos1D = new LinkedHashMap();
@@ -48,7 +48,7 @@ public class LTCCHistogrammer<DataType> {
     public void add(H1F histo, Function<DataType, Double> getter) {
         histos1D.put(histo.getName(), new SmartHisto(histo, getter));
     }
-    public void add(H2F histo, Function<DataType, Pair<Double, Double>> getter) {
+    public void add(H2F histo, Function<DataType, SimpleImmutableEntry<Double, Double>> getter) {
         histos2D.put(histo.getName(), new SmartHisto(histo, getter));
     }
     
@@ -58,7 +58,7 @@ public class LTCCHistogrammer<DataType> {
     public void fill(DataType data, double weight) {      
         histos1D.forEach((k, v) -> v.getHisto().fill(v.getData(data), weight));
         histos2D.forEach((k, v) -> {
-            Pair<Double, Double> args = v.getData(data);
+            SimpleImmutableEntry<Double, Double> args = v.getData(data);
             v.getHisto().fill(args.getKey(), args.getValue(), weight);
         });
     }


### PR DESCRIPTION
Now `javafx` is only consumed by `common-tools` stuff:
```bash
$ rg javafx -gpom.xml -g!/pom.xml -l
```
```
common-tools/clas-geometry/pom.xml
common-tools/clas-jcsg/pom.xml
```