### PR TITLE
Consume jnp-hipo4 4.5 from the hipo-java package registry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,35 @@
   </modules>
 
   <repositories>
+    <!-- `jnp-hipo4` is now built and published from its own repository,
+         https://code.jlab.org/hallb/clas12/hipo-java, rather than being cut from
+         the monolithic `jnp` tree. Project 919's package registry is public, so
+         this needs no credentials.
+
+         LISTED FIRST DELIBERATELY, and it has to stay first. Maven queries
+         repositories in declaration order and takes the first one that answers
+         with the coordinate, so whichever is listed first *decides* what
+         `org.jlab.jnp:jnp-hipo4` means. The clasweb repositories below still
+         carry the old fat-jar `jnp-hipo4`; if either ever serves a 4.5, being
+         ahead of this entry would silently shadow the artifact this project
+         means to consume, with no error to notice.
+
+         The cost is that Maven now asks code.jlab.org first for *every*
+         artifact it has to fetch, and everything except `jnp-hipo4` misses.
+         Verified: resolving `org.json:json` walks clas12-hipo-java →
+         clas12maven → jnp-maven → central and is served by central. A miss is
+         *silent* at default verbosity — no 404 in the log, Maven just moves to
+         the next repository — so the symptom is not errors but latency, one
+         extra round trip per artifact, and a stall on every resolution whenever
+         that host is slow or down rather than cleanly 404ing.
+
+         That is accepted: waiting on a request beats resolving a dependency
+         from a source nobody chose. It goes away if JLab ever runs a real
+         repository manager to proxy these. -->
+    <repository>
+      <id>clas12-hipo-java</id>
+      <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>
+    </repository>
     <repository>
       <id>clas12maven</id>
       <url>https://clasweb.jlab.org/.clas12maven</url>
@@ -26,14 +55,6 @@
     <repository>
       <id>jnp-maven</id>
       <url>https://clasweb.jlab.org/.jhep/maven</url>
-    </repository>
-    <!-- `jnp-hipo4` is now built and published from its own repository,
-         https://code.jlab.org/hallb/clas12/hipo-java, rather than being cut from
-         the monolithic `jnp` tree. Project 919's package registry is public, so
-         this needs no credentials. -->
-    <repository>
-      <id>clas12-hipo-java</id>
-      <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,14 @@
       <id>jnp-maven</id>
       <url>https://clasweb.jlab.org/.jhep/maven</url>
     </repository>
+    <!-- `jnp-hipo4` is now built and published from its own repository,
+         https://code.jlab.org/hallb/clas12/hipo-java, rather than being cut from
+         the monolithic `jnp` tree. Project 919's package registry is public, so
+         this needs no credentials. -->
+    <repository>
+      <id>clas12-hipo-java</id>
+      <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>
+    </repository>
   </repositories>
 
   <profiles>
@@ -168,7 +176,7 @@
       <dependency>
         <groupId>org.jlab.jnp</groupId>
         <artifactId>jnp-hipo4</artifactId>
-        <version>4.3-SNAPSHOT</version> <!-- WARNING: if changed, check the `net.objecthunter:exp4j` version; see `docs/dependency_conflicts.md` -->
+        <version>4.5</version> <!-- from code.jlab.org/hallb/clas12/hipo-java; WARNING: if changed, check the `net.objecthunter:exp4j` version; see `docs/dependency_conflicts.md` -->
       </dependency>
 
       <dependency>
@@ -216,7 +224,7 @@
         - see `docs/dependency_conflicts.md` for more info
       -->
 
-      <!-- resolve conflict between `org.jlab.jnp:jnp-hipo:jar:2.0-SNAPSHOT` and `org.jlab.jnp:jnp-hipo4:jar:4.3-SNAPSHOT`
+      <!-- resolve conflict between `org.jlab.jnp:jnp-hipo:jar:2.0-SNAPSHOT` and `org.jlab.jnp:jnp-hipo4:jar:4.5`
            by choosing the later version of their `net.objecthunter:exp4j` dependency -->
       <dependency>
         <groupId>net.objecthunter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,33 +19,9 @@
   </modules>
 
   <repositories>
-    <!-- `jnp-hipo4` is now built and published from its own repository,
-         https://code.jlab.org/hallb/clas12/hipo-java, rather than being cut from
-         the monolithic `jnp` tree. Project 919's package registry is public, so
-         this needs no credentials.
-
-         LISTED FIRST DELIBERATELY, and it has to stay first. Maven queries
-         repositories in declaration order and takes the first one that answers
-         with the coordinate, so whichever is listed first *decides* what
-         `org.jlab.jnp:jnp-hipo4` means. The clasweb repositories below still
-         carry the old fat-jar `jnp-hipo4`; if either ever serves a 4.5, being
-         ahead of this entry would silently shadow the artifact this project
-         means to consume, with no error to notice.
-
-         The cost is that Maven now asks code.jlab.org first for *every*
-         artifact it has to fetch, and everything except `jnp-hipo4` misses.
-         Verified: resolving `org.json:json` walks clas12-hipo-java →
-         clas12maven → jnp-maven → central and is served by central. A miss is
-         *silent* at default verbosity — no 404 in the log, Maven just moves to
-         the next repository — so the symptom is not errors but latency, one
-         extra round trip per artifact, and a stall on every resolution whenever
-         that host is slow or down rather than cleanly 404ing.
-
-         That is accepted: waiting on a request beats resolving a dependency
-         from a source nobody chose. It goes away if JLab ever runs a real
-         repository manager to proxy these. -->
+    ` -->
     <repository>
-      <id>clas12-hipo-java</id>
+      <id>clas12-hipo-java</id>  <!-- `jnp-hipo4` is now built and published from its own repository, https://code.jlab.org/hallb/clas12/hipo-java. Project 919's package registry is public -->
       <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>
     </repository>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
   </modules>
 
   <repositories>
-    ` -->
     <repository>
       <id>clas12-hipo-java</id>  <!-- `jnp-hipo4` is now built and published from its own repository, https://code.jlab.org/hallb/clas12/hipo-java. Project 919's package registry is public -->
       <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>


### PR DESCRIPTION
`jnp-hipo4` is now built and released from its own repository,
[code.jlab.org/hallb/clas12/hipo-java](https://code.jlab.org/hallb/clas12/hipo-java),
rather than being cut from the monolithic `jnp` tree. This points the dependency
at **4.5** from that project's package registry.

```xml
<repository>
  <id>clas12-hipo-java</id>
  <url>https://code.jlab.org/api/v4/projects/919/packages/maven</url>
</repository>
```

The registry is **public**, so this needs no credentials or `settings.xml`.

## Two things this changes beyond the coordinate

**exp4j is governed by our pin again.** The old clasweb artifact was a *fat jar*
bundling `exp4j`, `lz4` and `xxhash`. The `net.objecthunter:exp4j:0.4.8` pinned in
the root pom — specifically to resolve the `jnp-hipo` / `jnp-hipo4` conflict, per
`docs/dependency_conflicts.md` — was therefore being shadowed by a copy inside the
jar. 4.5 publishes a plain jar and declares its dependencies normally:

```
\- org.jlab.jnp:jnp-hipo4:jar:4.5:compile
   +- net.objecthunter:exp4j:jar:0.4.8:compile
   \- org.lz4:lz4-java:jar:1.8.0:compile
```

`maven-enforcer`'s `DependencyConvergence` passes.

**Fewer duplicate classes on the classpath.** The fat jar also carried
`org.jlab.jnp.{matrix,ascii,readers}` and MigLayout, all of which `jnp-hipo`
already provides — so they were present twice and classpath order decided the
winner. 4.5 drops them. Every one this project actually imports (17
`org.jlab.jnp.matrix`, 17 `org.jlab.jnp.utils.*`) resolves from `jnp-hipo`, which
we already depend on. `net.miginfocom`, `org.jlab.jnp.ascii` and
`org.jlab.jnp.readers` have **zero** imports here.

No `org.jlab.jnp.hipo4` class is missing in 4.5 — the API surface is complete.

## Verification

Compared against an **unmodified `development` baseline**, same commands:

| | baseline `4.3-SNAPSHOT` | this branch (`4.5`) |
|---|---|---|
| build | 49 modules SUCCESS | 49 modules SUCCESS |
| compiled | — | 1620 source files → 2014 classes, 52 jars |
| tests | 14 run, 0 failures, 1 error | 14 run, 0 failures, 1 error |
| the error | `DCReconstructionTest` | `DCReconstructionTest` — same test, same cause |

That error is `FileNotFoundException: TORUS map not found at
../../etc/data/magfield/Symm_torus_r2501_phi16_z251_24Apr2018.dat` (the NPE is its
downstream effect) — a field map absent from a fresh clone. **It reproduces
identically without this change**, which is the only reason it can be set aside.

## Notes for reviewers

- If you fetched `jnp-hipo4:4.5` before 2026-07-25 09:19 UTC you may have a
  cached **fat** jar from a packaging bug in the first upload (the assembly was
  deployed as the main artifact). It has been corrected and re-published. Clear
  `~/.m2/repository/org/jlab/jnp/jnp-hipo4/4.5` if the tree looks wrong; a correct
  main jar is 127 classes with no `net/*` packages.
- **Pre-existing and not addressed here:** 48 classes still overlap between
  `jnp-hipo` and `jnp-hipo4` (`org.jlab.jnp.utils.{json,file,data,…}`), since
  hipo-java ships its own copies. The old jar duplicated them too, so this is not
  a regression — but classpath order still decides which `JsonObject` wins.
  Removing that overlap means hipo-java dropping `org/jlab/jnp/utils` in favour of
  depending on `jnp-hipo`, which is a larger decision than this PR.