### PR TITLE
add column index accessors to FilteredBank

### DIFF
--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/banks/FilteredBank.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/banks/FilteredBank.java
@@ -136,6 +136,51 @@ public class FilteredBank {
     }
 
     /**
+     * @param column
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    public int getByte(int column, int index ){
+        return bank.getByte(column, indexList.get(index));
+    }
+
+    /**
+     * @param column
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    public int getShort(int column, int index ){
+        return bank.getShort(column, indexList.get(index));
+    }
+
+    /**
+     * @param column
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    public int getInt(int column, int index ){
+        return bank.getInt(column, indexList.get(index));
+    }
+
+    /**
+     * @param column
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    public long getLong(int column, int index ){
+        return bank.getLong(column, indexList.get(index));
+    }
+
+    /**
+     * @param column
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    public float getFloat(int column , int index ){
+        return bank.getFloat(column, indexList.get(index));
+    }
+
+    /**
      * @param index filtered index to retrieve
      * @return true bank row index corresponding to the filtered index
      */

--- a/common-tools/clas-detector/src/main/java/org/jlab/detector/banks/RawDataBank.java
+++ b/common-tools/clas-detector/src/main/java/org/jlab/detector/banks/RawDataBank.java
@@ -98,6 +98,51 @@ public class RawDataBank extends RawBank {
         return dataBank.getFloat(varName, indexList.get(index));
     }
 
+    /**
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    @Override
+    public int getByte(int column, int index ){
+        return dataBank.getByte(column, indexList.get(index));
+    }
+
+    /**
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    @Override
+    public int getShort(int column, int index ){
+        return dataBank.getShort(column, indexList.get(index));
+    }
+
+    /**
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    @Override
+    public int getInt(int column, int index ){
+        return dataBank.getInt(column, indexList.get(index));
+    }
+
+    /**
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    @Override
+    public long getLong(int column, int index ){
+        return dataBank.getLong(column, indexList.get(index));
+    }
+
+    /**
+     * @param index filtered index to retrieve
+     * @return value for the filtered index
+     */
+    @Override
+    public float getFloat(int column, int index ){
+        return dataBank.getFloat(column, indexList.get(index));
+    }
+
     public static void main(String[] args){
 
         RawDataBank ftof = new RawDataBank("FTOF::adc");


### PR DESCRIPTION
Note, these `org.jlab.detector.banks` classes are filtering, HIPO-bank wrappers, used to support `order`-marking in ADC/TDC banks for denoising.