### PR TITLE
replace old hipo with jevio, dependency cleanup

### DIFF
--- a/common-tools/clara-io/pom.xml
+++ b/common-tools/clara-io/pom.xml
@@ -33,11 +33,6 @@
 
     <dependency>
       <groupId>org.jlab.jnp</groupId>
-      <artifactId>jnp-hipo</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.jlab.jnp</groupId>
       <artifactId>jnp-hipo4</artifactId>
     </dependency>
 

--- a/common-tools/clas-io/pom.xml
+++ b/common-tools/clas-io/pom.xml
@@ -33,12 +33,13 @@
 
     <dependency>
       <groupId>org.jlab.jnp</groupId>
-      <artifactId>jnp-hipo</artifactId>
+      <artifactId>jnp-hipo4</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.jlab.jnp</groupId>
-      <artifactId>jnp-hipo4</artifactId>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jevio</artifactId>
+      <classifier>jar-with-dependencies</classifier>
     </dependency>
 
     <dependency>

--- a/common-tools/clas-reco/pom.xml
+++ b/common-tools/clas-reco/pom.xml
@@ -27,12 +27,13 @@
 
     <dependency>
       <groupId>org.jlab.jnp</groupId>
-      <artifactId>jnp-hipo</artifactId>
+      <artifactId>jnp-hipo4</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>org.jlab.jnp</groupId>
-      <artifactId>jnp-hipo4</artifactId>
+      <groupId>org.jlab.coda</groupId>
+      <artifactId>jevio</artifactId>
+      <classifier>jar-with-dependencies</classifier>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
All other jnp-hipo (not jnp-hipo4) dependencies are coming in through groot.  I guess groot also pulls in coda-jevio, which is why this PR works.